### PR TITLE
Add parsec adopt, shell hints, better errors, conflicts info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager for parallel AI agent workflows with ticket tracker integration"

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -41,6 +41,32 @@ pub async fn start(
     Ok(())
 }
 
+pub async fn adopt(
+    repo: &Path,
+    ticket: &str,
+    branch: Option<&str>,
+    title: Option<String>,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let repo_root = git::get_repo_root(repo)?;
+
+    let ticket_title = if let Some(t) = title {
+        Some(t)
+    } else {
+        match tracker::fetch_ticket(&config, ticket, Some(&repo_root)).await {
+            Ok(info) => info.map(|t| t.title),
+            Err(_) => None,
+        }
+    };
+
+    let manager = WorktreeManager::new(repo, &config)?;
+    let workspace = manager.adopt(ticket, branch, ticket_title)?;
+
+    output::print_adopt(&workspace, mode);
+    Ok(())
+}
+
 pub async fn list(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,6 +89,20 @@ pub enum Command {
         ticket: String,
     },
 
+    /// Import an existing branch into parsec management
+    Adopt {
+        /// Ticket identifier to associate with the branch
+        ticket: String,
+
+        /// Branch name to adopt (default: current branch)
+        #[arg(long, short)]
+        branch: Option<String>,
+
+        /// Ticket title (optional)
+        #[arg(long)]
+        title: Option<String>,
+    },
+
     /// Configure parsec
     Config {
         #[command(subcommand)]
@@ -138,6 +152,11 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Clean { all, dry_run } => {
             commands::clean(&repo_path, all, dry_run, output_mode).await
         }
+        Command::Adopt {
+            ticket,
+            branch,
+            title,
+        } => commands::adopt(&repo_path, &ticket, branch.as_deref(), title, output_mode).await,
         Command::Conflicts => commands::conflicts(&repo_path, output_mode).await,
         Command::Switch { ticket } => commands::switch(&repo_path, &ticket, output_mode).await,
         Command::Config { action } => match action {

--- a/src/conflict/detector.rs
+++ b/src/conflict/detector.rs
@@ -18,6 +18,7 @@ pub struct FileConflict {
 pub fn detect(workspaces: &[Workspace]) -> Result<Vec<FileConflict>> {
     // Map: filename -> list of ticket IDs that touch it
     let mut file_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut skipped: Vec<String> = Vec::new();
 
     for ws in workspaces {
         // Skip non-active workspaces
@@ -29,18 +30,37 @@ pub fn detect(workspaces: &[Workspace]) -> Result<Vec<FileConflict>> {
         // Run from the workspace path
         let merge_base = match git::get_merge_base(&ws.path, &ws.base_branch, "HEAD") {
             Ok(base) => base,
-            Err(_) => continue, // Skip if can't determine merge base
+            Err(_) => {
+                skipped.push(ws.ticket.clone());
+                continue;
+            }
         };
 
         // Get changed files
         let changed = match git::get_changed_files(&ws.path, &merge_base, "HEAD") {
             Ok(files) => files,
-            Err(_) => continue,
+            Err(_) => {
+                skipped.push(ws.ticket.clone());
+                continue;
+            }
         };
+
+        if changed.is_empty() {
+            skipped.push(ws.ticket.clone());
+        }
 
         for file in changed {
             file_map.entry(file).or_default().push(ws.ticket.clone());
         }
+    }
+
+    // Report skipped worktrees (no changes yet)
+    if !skipped.is_empty() {
+        eprintln!(
+            "note: {} workspace(s) skipped (no changes yet): {}",
+            skipped.len(),
+            skipped.join(", ")
+        );
     }
 
     // Filter to only files touched by 2+ worktrees

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -68,6 +68,31 @@ pub fn print_start(workspace: &Workspace) {
     if let Some(title) = &workspace.ticket_title {
         println!("  {}", title.dimmed());
     }
+    // Shell integration hint
+    eprintln!(
+        "\n  {} cd $(parsec switch {})",
+        "Tip:".bold().cyan(),
+        workspace.ticket
+    );
+}
+
+pub fn print_adopt(workspace: &Workspace) {
+    let msg = format!(
+        "Adopted branch '{}' as {} at {}",
+        workspace.branch,
+        workspace.ticket.bold(),
+        workspace.path.display()
+    );
+    println!("{}", msg.green());
+    if let Some(title) = &workspace.ticket_title {
+        println!("  {}", title.dimmed());
+    }
+    // Shell integration hint
+    eprintln!(
+        "\n  {} cd $(parsec switch {})",
+        "Tip:".bold().cyan(),
+        workspace.ticket
+    );
 }
 
 pub fn print_list(workspaces: &[Workspace]) {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -17,6 +17,10 @@ pub fn print_start(workspace: &Workspace) {
     emit(workspace);
 }
 
+pub fn print_adopt(workspace: &Workspace) {
+    emit(workspace);
+}
+
 pub fn print_list(workspaces: &[Workspace]) {
     emit(&workspaces);
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -20,6 +20,14 @@ pub fn print_start(workspace: &Workspace, mode: Mode) {
     }
 }
 
+pub fn print_adopt(workspace: &Workspace, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_adopt(workspace),
+        Mode::Human => human::print_adopt(workspace),
+    }
+}
+
 pub fn print_list(workspaces: &[Workspace], mode: Mode) {
     match mode {
         Mode::Quiet => {}

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -113,6 +113,164 @@ impl WorktreeManager {
     }
 
     // -----------------------------------------------------------------------
+    // adopt — import an existing branch into parsec state
+    // -----------------------------------------------------------------------
+
+    pub fn adopt(
+        &self,
+        ticket: &str,
+        branch: Option<&str>,
+        ticket_title: Option<String>,
+    ) -> Result<Workspace> {
+        let mut state =
+            ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
+
+        // Check if ticket is already managed
+        if state.get_workspace(ticket).is_some() {
+            anyhow::bail!(
+                "ticket '{}' is already managed by parsec. Use `parsec status {}` to see it.",
+                ticket,
+                ticket
+            );
+        }
+
+        // Resolve the branch name
+        let branch_name = match branch {
+            Some(b) => b.to_owned(),
+            None => {
+                // Default: branch_prefix + ticket
+                let candidate = format!("{}{}", self.config.workspace.branch_prefix, ticket);
+                // Verify the branch exists
+                match git::run_output(
+                    &self.repo_root,
+                    &[
+                        "rev-parse",
+                        "--verify",
+                        &format!("refs/heads/{}", candidate),
+                    ],
+                ) {
+                    Ok(_) => candidate,
+                    Err(_) => {
+                        // Try current branch
+                        let current = git::run_output(
+                            &self.repo_root,
+                            &["rev-parse", "--abbrev-ref", "HEAD"],
+                        )
+                        .context("could not detect branch. Specify one with --branch <name>")?;
+                        if current == "HEAD" || current == "main" || current == "master" {
+                            anyhow::bail!(
+                                "no branch found for ticket '{}'. Specify one with: parsec adopt {} --branch <branch-name>",
+                                ticket, ticket
+                            );
+                        }
+                        current
+                    }
+                }
+            }
+        };
+
+        // Verify branch exists
+        git::run_output(
+            &self.repo_root,
+            &[
+                "rev-parse",
+                "--verify",
+                &format!("refs/heads/{}", branch_name),
+            ],
+        )
+        .with_context(|| {
+            format!(
+                "branch '{}' does not exist. Create it first or check the name.",
+                branch_name
+            )
+        })?;
+
+        // Detect base branch
+        let base_branch =
+            git::get_default_branch(&self.repo_root).unwrap_or_else(|_| "main".to_owned());
+
+        // Check if this branch already has a worktree
+        let worktree_path = self.find_worktree_for_branch(&branch_name);
+
+        let path = match worktree_path {
+            Some(p) => p,
+            None => {
+                // No worktree exists — create one
+                let wt_path = match self.config.workspace.layout {
+                    crate::config::WorktreeLayout::Sibling => {
+                        let repo_name = self
+                            .repo_root
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_else(|| "repo".to_string());
+                        self.repo_root
+                            .parent()
+                            .unwrap_or(&self.repo_root)
+                            .join(format!("{}.{}", repo_name, ticket))
+                    }
+                    crate::config::WorktreeLayout::Internal => self
+                        .repo_root
+                        .join(&self.config.workspace.base_dir)
+                        .join(ticket),
+                };
+                git::run(
+                    &self.repo_root,
+                    &[
+                        "worktree",
+                        "add",
+                        wt_path.to_str().unwrap_or(""),
+                        &branch_name,
+                    ],
+                )
+                .with_context(|| {
+                    format!(
+                        "failed to create worktree for branch '{}' at {:?}",
+                        branch_name, wt_path
+                    )
+                })?;
+                wt_path
+            }
+        };
+
+        let workspace = Workspace {
+            ticket: ticket.to_owned(),
+            path,
+            branch: branch_name,
+            base_branch,
+            created_at: Utc::now(),
+            ticket_title,
+            status: WorkspaceStatus::Active,
+        };
+
+        state.add_workspace(workspace.clone());
+        state
+            .save(&self.repo_root)
+            .context("failed to save parsec state after adopt")?;
+
+        Ok(workspace)
+    }
+
+    /// Find existing worktree path for a given branch name.
+    fn find_worktree_for_branch(&self, branch: &str) -> Option<PathBuf> {
+        let output = git::run_output(&self.repo_root, &["worktree", "list", "--porcelain"]).ok()?;
+
+        let mut current_path: Option<String> = None;
+        for line in output.lines() {
+            if let Some(val) = line.strip_prefix("worktree ") {
+                current_path = Some(val.to_owned());
+            } else if let Some(val) = line.strip_prefix("branch ") {
+                let wt_branch = val.strip_prefix("refs/heads/").unwrap_or(val);
+                if wt_branch == branch {
+                    return current_path.map(PathBuf::from);
+                }
+            } else if line.is_empty() {
+                current_path = None;
+            }
+        }
+        None
+    }
+
+    // -----------------------------------------------------------------------
     // list
     // -----------------------------------------------------------------------
 
@@ -134,7 +292,12 @@ impl WorktreeManager {
         state
             .get_workspace(ticket)
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("no workspace found for ticket '{}'", ticket))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no workspace found for ticket '{}'. Run `parsec list` to see active workspaces, or `parsec adopt {}` to import an existing branch.",
+                    ticket, ticket
+                )
+            })
     }
 
     // -----------------------------------------------------------------------
@@ -148,7 +311,12 @@ impl WorktreeManager {
         let workspace = state
             .get_workspace(ticket)
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("no workspace found for ticket '{}'", ticket))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no workspace found for ticket '{}'. Run `parsec list` to see active workspaces, or `parsec adopt {}` to import an existing branch.",
+                    ticket, ticket
+                )
+            })?;
 
         // Push the branch from the worktree itself so HEAD is correct.
         git::push_branch(&workspace.path, &workspace.branch)


### PR DESCRIPTION
## Summary
- `parsec adopt`: import existing branches into parsec management (#3)
- Shell integration hint after `parsec start`/`parsec adopt` (#5)
- Actionable error messages with suggested commands (#4)
- Conflicts detection reports skipped empty worktrees (#6)

Closes #3, #4, #5, #6