### PR TITLE
Warn when PR creation skipped due to missing token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager for parallel AI agent workflows with ticket tracker integration"

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -108,7 +108,10 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
                     result.pr_url = Some(pr.url);
                 }
                 Ok(None) => {
-                    // No GitHub token — skip silently
+                    eprintln!(
+                        "note: PR creation skipped — no GitHub token found.\n      \
+                         Set PARSEC_GITHUB_TOKEN, GITHUB_TOKEN, or GH_TOKEN to enable."
+                    );
                 }
                 Err(e) => {
                     eprintln!("warning: PR creation failed: {e}");


### PR DESCRIPTION
## Summary
- `parsec ship` now prints a helpful note when PR creation is skipped because no GitHub token env var is set
- Tells the user which env vars to configure

Closes #9