### PR TITLE
Add parsec log: operation history tracking (#12)

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -38,6 +38,22 @@ pub async fn start(
     let workspace = manager.create(ticket, base, ticket_title)?;
 
     output::print_start(&workspace, mode);
+
+    if let Err(e) = crate::oplog::record(
+        manager.repo_root(),
+        crate::oplog::OpKind::Start,
+        Some(ticket),
+        &format!("Created workspace at {}", workspace.path.display()),
+        Some(crate::oplog::UndoInfo {
+            branch: Some(workspace.branch.clone()),
+            base_branch: Some(workspace.base_branch.clone()),
+            path: Some(workspace.path.clone()),
+            ticket_title: workspace.ticket_title.clone(),
+        }),
+    ) {
+        eprintln!("warning: failed to write oplog: {e}");
+    }
+
     Ok(())
 }
 
@@ -64,6 +80,22 @@ pub async fn adopt(
     let workspace = manager.adopt(ticket, branch, ticket_title)?;
 
     output::print_adopt(&workspace, mode);
+
+    if let Err(e) = crate::oplog::record(
+        manager.repo_root(),
+        crate::oplog::OpKind::Adopt,
+        Some(ticket),
+        &format!("Adopted branch '{}' at {}", workspace.branch, workspace.path.display()),
+        Some(crate::oplog::UndoInfo {
+            branch: Some(workspace.branch.clone()),
+            base_branch: Some(workspace.base_branch.clone()),
+            path: Some(workspace.path.clone()),
+            ticket_title: workspace.ticket_title.clone(),
+        }),
+    ) {
+        eprintln!("warning: failed to write oplog: {e}");
+    }
+
     Ok(())
 }
 
@@ -147,6 +179,30 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
     }
 
     output::print_ship(&result, mode);
+
+    if let Err(e) = crate::oplog::record(
+        manager.repo_root(),
+        crate::oplog::OpKind::Ship,
+        Some(ticket),
+        &format!(
+            "Shipped branch '{}'{}",
+            result.branch,
+            result
+                .pr_url
+                .as_ref()
+                .map(|u| format!(" -> {}", u))
+                .unwrap_or_default()
+        ),
+        Some(crate::oplog::UndoInfo {
+            branch: Some(result.branch.clone()),
+            base_branch: Some(result.base_branch.clone()),
+            path: None,
+            ticket_title: result.ticket_title.clone(),
+        }),
+    ) {
+        eprintln!("warning: failed to write oplog: {e}");
+    }
+
     Ok(())
 }
 
@@ -157,6 +213,26 @@ pub async fn clean(repo: &Path, all: bool, dry_run: bool, mode: Mode) -> Result<
     let removed = manager.clean(all, dry_run)?;
 
     output::print_clean(&removed, dry_run, mode);
+
+    if !dry_run && !removed.is_empty() {
+        for ws in &removed {
+            if let Err(e) = crate::oplog::record(
+                manager.repo_root(),
+                crate::oplog::OpKind::Clean,
+                Some(&ws.ticket),
+                &format!("Cleaned workspace for branch '{}'", ws.branch),
+                Some(crate::oplog::UndoInfo {
+                    branch: Some(ws.branch.clone()),
+                    base_branch: Some(ws.base_branch.clone()),
+                    path: Some(ws.path.clone()),
+                    ticket_title: ws.ticket_title.clone(),
+                }),
+            ) {
+                eprintln!("warning: failed to write oplog: {e}");
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -178,6 +254,18 @@ pub async fn switch(repo: &Path, ticket: &str, mode: Mode) -> Result<()> {
     let workspace = manager.get(ticket)?;
 
     output::print_switch(&workspace, mode);
+    Ok(())
+}
+
+pub async fn log(repo: &Path, ticket: Option<&str>, last: usize, mode: Mode) -> Result<()> {
+    let repo_root =
+        git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let oplog = crate::oplog::OpLog::load(&repo_root)?;
+    let entries = oplog.get_entries(ticket);
+    // Take last N entries
+    let start = entries.len().saturating_sub(last);
+    let entries: Vec<_> = entries[start..].to_vec();
+    output::print_log(&entries, mode);
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -103,6 +103,16 @@ pub enum Command {
         title: Option<String>,
     },
 
+    /// Show operation history
+    Log {
+        /// Filter by ticket identifier
+        ticket: Option<String>,
+
+        /// Show last N entries (default: 20)
+        #[arg(long, short = 'n', default_value = "20")]
+        last: usize,
+    },
+
     /// Configure parsec
     Config {
         #[command(subcommand)]
@@ -159,6 +169,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         } => commands::adopt(&repo_path, &ticket, branch.as_deref(), title, output_mode).await,
         Command::Conflicts => commands::conflicts(&repo_path, output_mode).await,
         Command::Switch { ticket } => commands::switch(&repo_path, &ticket, output_mode).await,
+        Command::Log { ticket, last } => {
+            commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
+        }
         Command::Config { action } => match action {
             ConfigAction::Init => commands::config_init(output_mode).await,
             ConfigAction::Show => commands::config_show(output_mode).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod conflict;
 mod git;
 mod github;
+mod oplog;
 mod output;
 mod tracker;
 mod worktree;

--- a/src/oplog/mod.rs
+++ b/src/oplog/mod.rs
@@ -1,0 +1,133 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpKind {
+    Start,
+    Adopt,
+    Ship,
+    Clean,
+}
+
+impl std::fmt::Display for OpKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OpKind::Start => write!(f, "start"),
+            OpKind::Adopt => write!(f, "adopt"),
+            OpKind::Ship => write!(f, "ship"),
+            OpKind::Clean => write!(f, "clean"),
+        }
+    }
+}
+
+/// Information needed to undo an operation (for future parsec undo)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UndoInfo {
+    pub branch: Option<String>,
+    pub base_branch: Option<String>,
+    pub path: Option<PathBuf>,
+    pub ticket_title: Option<String>,
+}
+
+/// A single operation log entry
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpEntry {
+    pub id: u64,
+    pub op: OpKind,
+    pub ticket: Option<String>,
+    pub detail: String,
+    pub timestamp: DateTime<Utc>,
+    pub undo_info: Option<UndoInfo>,
+}
+
+/// The full operation log
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OpLog {
+    pub entries: Vec<OpEntry>,
+}
+
+impl OpLog {
+    fn log_path(repo_root: &Path) -> PathBuf {
+        repo_root.join(".parsec").join("oplog.json")
+    }
+
+    pub fn load(repo_root: &Path) -> Result<Self> {
+        let path = Self::log_path(repo_root);
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let contents = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read oplog: {}", path.display()))?;
+        let log: Self = serde_json::from_str(&contents)
+            .with_context(|| format!("failed to parse oplog: {}", path.display()))?;
+        Ok(log)
+    }
+
+    pub fn save(&self, repo_root: &Path) -> Result<()> {
+        let path = Self::log_path(repo_root);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let contents = serde_json::to_string_pretty(self)?;
+        fs::write(&path, contents)?;
+        Ok(())
+    }
+
+    pub fn append(
+        &mut self,
+        op: OpKind,
+        ticket: Option<String>,
+        detail: String,
+        undo_info: Option<UndoInfo>,
+    ) {
+        let id = self.entries.last().map(|e| e.id + 1).unwrap_or(1);
+        self.entries.push(OpEntry {
+            id,
+            op,
+            ticket,
+            detail,
+            timestamp: Utc::now(),
+            undo_info,
+        });
+    }
+
+    /// Get entries, optionally filtered by ticket
+    pub fn get_entries(&self, ticket: Option<&str>) -> Vec<&OpEntry> {
+        self.entries
+            .iter()
+            .filter(|e| match ticket {
+                Some(t) => e.ticket.as_deref() == Some(t),
+                None => true,
+            })
+            .collect()
+    }
+
+    /// Get the last entry (for future undo)
+    #[allow(dead_code)]
+    pub fn last_entry(&self) -> Option<&OpEntry> {
+        self.entries.last()
+    }
+}
+
+/// Helper to record an operation. Call from commands.rs after each mutating operation.
+pub fn record(
+    repo_root: &Path,
+    op: OpKind,
+    ticket: Option<&str>,
+    detail: &str,
+    undo_info: Option<UndoInfo>,
+) -> Result<()> {
+    let mut log = OpLog::load(repo_root)?;
+    log.append(
+        op,
+        ticket.map(|s| s.to_owned()),
+        detail.to_owned(),
+        undo_info,
+    );
+    log.save(repo_root)?;
+    Ok(())
+}

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -4,6 +4,7 @@ use tabled::{Table, Tabled};
 
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
+use crate::oplog::OpEntry;
 use crate::worktree::{ShipResult, Workspace, WorkspaceStatus};
 
 // ---------------------------------------------------------------------------
@@ -184,6 +185,47 @@ pub fn print_switch(workspace: &Workspace) {
 
 pub fn print_config_init() {
     println!("{}", "Configuration saved!".green().bold());
+}
+
+pub fn print_log(entries: &[&OpEntry]) {
+    if entries.is_empty() {
+        println!("{}", "No operations recorded.".dimmed());
+        return;
+    }
+
+    #[derive(Tabled)]
+    struct LogRow {
+        #[tabled(rename = "#")]
+        id: u64,
+        #[tabled(rename = "Op")]
+        op: String,
+        #[tabled(rename = "Ticket")]
+        ticket: String,
+        #[tabled(rename = "Detail")]
+        detail: String,
+        #[tabled(rename = "Time")]
+        time: String,
+    }
+
+    let rows: Vec<LogRow> = entries
+        .iter()
+        .rev()
+        .map(|e| LogRow {
+            id: e.id,
+            op: match &e.op {
+                crate::oplog::OpKind::Start => "start".green().to_string(),
+                crate::oplog::OpKind::Adopt => "adopt".cyan().to_string(),
+                crate::oplog::OpKind::Ship => "ship".yellow().to_string(),
+                crate::oplog::OpKind::Clean => "clean".red().to_string(),
+            },
+            ticket: e.ticket.clone().unwrap_or_else(|| "-".to_string()),
+            detail: e.detail.clone(),
+            time: e.timestamp.format("%Y-%m-%d %H:%M").to_string(),
+        })
+        .collect();
+
+    let table = Table::new(rows).with(Style::rounded()).to_string();
+    println!("{}", table);
 }
 
 pub fn print_config_show(config: &ParsecConfig) {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -3,6 +3,7 @@ use serde_json::json;
 
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
+use crate::oplog::OpEntry;
 use crate::worktree::{ShipResult, Workspace};
 
 fn emit<T: Serialize>(value: &T) {
@@ -49,6 +50,10 @@ pub fn print_conflicts(conflicts: &[FileConflict]) {
 pub fn print_switch(workspace: &Workspace) {
     let value = json!({ "path": workspace.path });
     println!("{}", value);
+}
+
+pub fn print_log(entries: &[&OpEntry]) {
+    emit(&entries);
 }
 
 pub fn print_config_init() {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -3,6 +3,7 @@ mod json;
 
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
+use crate::oplog::OpEntry;
 use crate::worktree::{ShipResult, Workspace};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -81,6 +82,14 @@ pub fn print_config_init(mode: Mode) {
         Mode::Quiet => {}
         Mode::Json => json::print_config_init(),
         Mode::Human => human::print_config_init(),
+    }
+}
+
+pub fn print_log(entries: &[&OpEntry], mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_log(entries),
+        Mode::Human => human::print_log(entries),
     }
 }
 


### PR DESCRIPTION
## Summary
- New `parsec log` command to view operation history
- Records all mutating ops (start, adopt, ship, clean) to `.parsec/oplog.json`
- Each entry includes timestamp, ticket, detail, and undo metadata (for future `parsec undo`)
- Supports `--json`, `--last N`, and ticket filtering

Closes #12