### PR TITLE
Add parsec undo: revert last operation (#13)

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::config::ParsecConfig;
 use crate::conflict;
@@ -85,7 +85,11 @@ pub async fn adopt(
         manager.repo_root(),
         crate::oplog::OpKind::Adopt,
         Some(ticket),
-        &format!("Adopted branch '{}' at {}", workspace.branch, workspace.path.display()),
+        &format!(
+            "Adopted branch '{}' at {}",
+            workspace.branch,
+            workspace.path.display()
+        ),
         Some(crate::oplog::UndoInfo {
             branch: Some(workspace.branch.clone()),
             base_branch: Some(workspace.base_branch.clone()),
@@ -258,14 +262,150 @@ pub async fn switch(repo: &Path, ticket: &str, mode: Mode) -> Result<()> {
 }
 
 pub async fn log(repo: &Path, ticket: Option<&str>, last: usize, mode: Mode) -> Result<()> {
-    let repo_root =
-        git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
     let oplog = crate::oplog::OpLog::load(&repo_root)?;
     let entries = oplog.get_entries(ticket);
     // Take last N entries
     let start = entries.len().saturating_sub(last);
     let entries: Vec<_> = entries[start..].to_vec();
     output::print_log(&entries, mode);
+    Ok(())
+}
+
+pub async fn undo(repo: &Path, dry_run: bool, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+
+    let mut oplog = crate::oplog::OpLog::load(&repo_root)?;
+
+    let last = oplog.last_entry().cloned().ok_or_else(|| {
+        anyhow::anyhow!("nothing to undo. Run `parsec log` to see operation history.")
+    })?;
+
+    let undo_info = last.undo_info.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "last operation ({}) cannot be undone — no undo info recorded.",
+            last.op
+        )
+    })?;
+
+    if dry_run {
+        output::print_undo_preview(&last, mode);
+        return Ok(());
+    }
+
+    match last.op {
+        crate::oplog::OpKind::Start | crate::oplog::OpKind::Adopt => {
+            // Undo start/adopt = remove the worktree + branch + state
+            let ticket = last
+                .ticket
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("no ticket in oplog entry"))?;
+
+            if let Some(path) = &undo_info.path {
+                if path.exists() {
+                    git::worktree_remove(&repo_root, path)
+                        .with_context(|| format!("failed to remove worktree at {:?}", path))?;
+                }
+            }
+            if let Some(branch) = &undo_info.branch {
+                let _ = git::delete_branch(&repo_root, branch);
+            }
+
+            // Remove from state
+            let mut state = crate::worktree::ParsecState::load(&repo_root)?;
+            state.remove_workspace(ticket);
+            state.save(&repo_root)?;
+        }
+        crate::oplog::OpKind::Ship | crate::oplog::OpKind::Clean => {
+            // Undo ship/clean = re-create the worktree
+            let ticket = last
+                .ticket
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("no ticket in oplog entry"))?;
+            let branch = undo_info
+                .branch
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("no branch info to restore"))?;
+            let base_branch = undo_info.base_branch.as_deref().unwrap_or("main");
+
+            // Check if branch exists locally
+            let branch_exists_locally = git::run_output(
+                &repo_root,
+                &["rev-parse", "--verify", &format!("refs/heads/{}", branch)],
+            )
+            .is_ok();
+
+            // If not local, try to restore from remote
+            if !branch_exists_locally {
+                let remote_ref = format!("origin/{}", branch);
+                if git::run_output(&repo_root, &["rev-parse", "--verify", &remote_ref]).is_ok() {
+                    git::run(&repo_root, &["branch", branch, &remote_ref])?;
+                } else {
+                    anyhow::bail!(
+                        "branch '{}' not found locally or on remote. Cannot restore workspace.",
+                        branch
+                    );
+                }
+            }
+
+            // Compute worktree path based on layout
+            let worktree_path = match config.workspace.layout {
+                crate::config::WorktreeLayout::Sibling => {
+                    let repo_name = repo_root
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "repo".to_string());
+                    repo_root
+                        .parent()
+                        .unwrap_or(&repo_root)
+                        .join(format!("{}.{}", repo_name, ticket))
+                }
+                crate::config::WorktreeLayout::Internal => {
+                    repo_root.join(&config.workspace.base_dir).join(ticket)
+                }
+            };
+
+            git::run(
+                &repo_root,
+                &[
+                    "worktree",
+                    "add",
+                    worktree_path.to_str().unwrap_or(""),
+                    branch,
+                ],
+            )?;
+
+            // Restore state
+            let workspace = crate::worktree::Workspace {
+                ticket: ticket.to_owned(),
+                path: worktree_path,
+                branch: branch.to_owned(),
+                base_branch: base_branch.to_owned(),
+                created_at: chrono::Utc::now(),
+                ticket_title: undo_info.ticket_title.clone(),
+                status: crate::worktree::WorkspaceStatus::Active,
+            };
+
+            let mut state = crate::worktree::ParsecState::load(&repo_root)?;
+            state.add_workspace(workspace);
+            state.save(&repo_root)?;
+        }
+        crate::oplog::OpKind::Undo => {
+            anyhow::bail!("cannot undo an undo operation");
+        }
+    }
+
+    // Record undo in oplog
+    oplog.append(
+        crate::oplog::OpKind::Undo,
+        last.ticket.clone(),
+        format!("Undid {} operation", last.op),
+        None,
+    );
+    oplog.save(&repo_root)?;
+
+    output::print_undo(&last, mode);
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,6 +113,13 @@ pub enum Command {
         last: usize,
     },
 
+    /// Undo the last parsec operation
+    Undo {
+        /// Preview what would be undone without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Configure parsec
     Config {
         #[command(subcommand)]
@@ -172,6 +179,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Log { ticket, last } => {
             commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
         }
+        Command::Undo { dry_run } => commands::undo(&repo_path, dry_run, output_mode).await,
         Command::Config { action } => match action {
             ConfigAction::Init => commands::config_init(output_mode).await,
             ConfigAction::Show => commands::config_show(output_mode).await,

--- a/src/oplog/mod.rs
+++ b/src/oplog/mod.rs
@@ -11,6 +11,7 @@ pub enum OpKind {
     Adopt,
     Ship,
     Clean,
+    Undo,
 }
 
 impl std::fmt::Display for OpKind {
@@ -20,6 +21,7 @@ impl std::fmt::Display for OpKind {
             OpKind::Adopt => write!(f, "adopt"),
             OpKind::Ship => write!(f, "ship"),
             OpKind::Clean => write!(f, "clean"),
+            OpKind::Undo => write!(f, "undo"),
         }
     }
 }
@@ -106,8 +108,7 @@ impl OpLog {
             .collect()
     }
 
-    /// Get the last entry (for future undo)
-    #[allow(dead_code)]
+    /// Get the last entry (for undo)
     pub fn last_entry(&self) -> Option<&OpEntry> {
         self.entries.last()
     }

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -217,6 +217,7 @@ pub fn print_log(entries: &[&OpEntry]) {
                 crate::oplog::OpKind::Adopt => "adopt".cyan().to_string(),
                 crate::oplog::OpKind::Ship => "ship".yellow().to_string(),
                 crate::oplog::OpKind::Clean => "clean".red().to_string(),
+                crate::oplog::OpKind::Undo => "undo".magenta().to_string(),
             },
             ticket: e.ticket.clone().unwrap_or_else(|| "-".to_string()),
             detail: e.detail.clone(),
@@ -226,6 +227,60 @@ pub fn print_log(entries: &[&OpEntry]) {
 
     let table = Table::new(rows).with(Style::rounded()).to_string();
     println!("{}", table);
+}
+
+pub fn print_undo(entry: &OpEntry) {
+    let ticket_str = entry.ticket.as_deref().unwrap_or("?");
+    let msg = format!("Undid {} for {}", entry.op, ticket_str);
+    println!("{}", msg.green().bold());
+
+    match &entry.op {
+        crate::oplog::OpKind::Start | crate::oplog::OpKind::Adopt => {
+            println!("  {}", "Worktree removed.".dimmed());
+        }
+        crate::oplog::OpKind::Ship | crate::oplog::OpKind::Clean => {
+            if let Some(info) = &entry.undo_info {
+                if let Some(path) = &info.path {
+                    println!("  {} {}", "Restored at:".bold(), path.display());
+                }
+            }
+            println!("  {}", "Workspace restored.".dimmed());
+        }
+        _ => {}
+    }
+}
+
+pub fn print_undo_preview(entry: &OpEntry) {
+    let ticket_str = entry.ticket.as_deref().unwrap_or("?");
+    println!(
+        "{}",
+        format!("Would undo: {} {}", entry.op, ticket_str)
+            .yellow()
+            .bold()
+    );
+
+    match &entry.op {
+        crate::oplog::OpKind::Start | crate::oplog::OpKind::Adopt => {
+            if let Some(info) = &entry.undo_info {
+                if let Some(path) = &info.path {
+                    println!("  Would remove worktree at {}", path.display());
+                }
+                if let Some(branch) = &info.branch {
+                    println!("  Would delete branch '{}'", branch);
+                }
+            }
+        }
+        crate::oplog::OpKind::Ship | crate::oplog::OpKind::Clean => {
+            if let Some(info) = &entry.undo_info {
+                if let Some(branch) = &info.branch {
+                    println!("  Would restore worktree for branch '{}'", branch);
+                }
+            }
+        }
+        _ => {
+            println!("  {}", "This operation cannot be undone.".red());
+        }
+    }
 }
 
 pub fn print_config_show(config: &ParsecConfig) {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -64,3 +64,22 @@ pub fn print_config_init() {
 pub fn print_config_show(config: &ParsecConfig) {
     emit(config);
 }
+
+pub fn print_undo(entry: &OpEntry) {
+    let value = json!({
+        "action": "undo",
+        "undone_op": format!("{}", entry.op),
+        "ticket": entry.ticket,
+    });
+    println!("{}", value);
+}
+
+pub fn print_undo_preview(entry: &OpEntry) {
+    let value = json!({
+        "action": "undo_preview",
+        "would_undo": format!("{}", entry.op),
+        "ticket": entry.ticket,
+        "undo_info": entry.undo_info,
+    });
+    println!("{}", value);
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -93,6 +93,22 @@ pub fn print_log(entries: &[&OpEntry], mode: Mode) {
     }
 }
 
+pub fn print_undo(entry: &OpEntry, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_undo(entry),
+        Mode::Human => human::print_undo(entry),
+    }
+}
+
+pub fn print_undo_preview(entry: &OpEntry, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_undo_preview(entry),
+        Mode::Human => human::print_undo_preview(entry),
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig, mode: Mode) {
     match mode {
         Mode::Quiet => {}

--- a/src/worktree/mod.rs
+++ b/src/worktree/mod.rs
@@ -1,5 +1,5 @@
 mod lifecycle;
 mod manager;
 
-pub use lifecycle::{ShipResult, Workspace, WorkspaceStatus};
+pub use lifecycle::{ParsecState, ShipResult, Workspace, WorkspaceStatus};
 pub use manager::WorktreeManager;


### PR DESCRIPTION
## Summary
- New `parsec undo` command to revert the last parsec operation
- Undo start/adopt → removes worktree + deletes branch
- Undo ship/clean → restores worktree from local or remote branch
- `--dry-run` flag to preview what would be undone
- Records undo operations in oplog
- Also fixes cargo fmt issues from #12

Closes #13