### PR TITLE
Add GitLab merge request creation in parsec ship (#14)

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -6,6 +6,7 @@ use crate::config::ParsecConfig;
 use crate::conflict;
 use crate::git;
 use crate::github;
+use crate::gitlab;
 use crate::output::{self, Mode};
 use crate::tracker;
 use crate::worktree::WorktreeManager;
@@ -155,9 +156,10 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
         );
 
         let remote_url = git::get_remote_url(manager.repo_root());
-        if let Ok(remote_url) = remote_url {
+        if let Ok(ref remote_url) = remote_url {
+            // Try GitHub first
             match github::create_pr(
-                &remote_url,
+                remote_url,
                 &result.branch,
                 &result.base_branch,
                 &pr_title,
@@ -170,10 +172,30 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
                     result.pr_url = Some(pr.url);
                 }
                 Ok(None) => {
-                    eprintln!(
-                        "note: PR creation skipped — no GitHub token found.\n      \
-                         Set PARSEC_GITHUB_TOKEN, GITHUB_TOKEN, or GH_TOKEN to enable."
-                    );
+                    // GitHub had no token — try GitLab
+                    match gitlab::create_mr(
+                        remote_url,
+                        &result.branch,
+                        &result.base_branch,
+                        &pr_title,
+                        &pr_body,
+                        draft || config.ship.draft,
+                    )
+                    .await
+                    {
+                        Ok(Some(mr)) => {
+                            result.pr_url = Some(mr.url);
+                        }
+                        Ok(None) => {
+                            eprintln!(
+                                "note: PR/MR creation skipped — no token found.\n      \
+                                 Set PARSEC_GITHUB_TOKEN or PARSEC_GITLAB_TOKEN to enable."
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!("warning: GitLab MR creation failed: {e}");
+                        }
+                    }
                 }
                 Err(e) => {
                     eprintln!("warning: PR creation failed: {e}");

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -33,6 +33,7 @@ fn default_true() -> bool {
 pub enum TrackerProvider {
     Jira,
     Github,
+    Gitlab,
     #[default]
     None,
 }
@@ -42,6 +43,7 @@ impl std::fmt::Display for TrackerProvider {
         match self {
             TrackerProvider::Jira => write!(f, "jira"),
             TrackerProvider::Github => write!(f, "github"),
+            TrackerProvider::Gitlab => write!(f, "gitlab"),
             TrackerProvider::None => write!(f, "none"),
         }
     }
@@ -108,6 +110,15 @@ pub struct JiraConfig {
 }
 
 // ---------------------------------------------------------------------------
+// GitlabConfig
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitlabConfig {
+    pub base_url: String,
+}
+
+// ---------------------------------------------------------------------------
 // TrackerConfig
 // ---------------------------------------------------------------------------
 
@@ -117,6 +128,8 @@ pub struct TrackerConfig {
     pub provider: TrackerProvider,
     #[serde(default)]
     pub jira: Option<JiraConfig>,
+    #[serde(default)]
+    pub gitlab: Option<GitlabConfig>,
 }
 
 impl Default for TrackerConfig {
@@ -124,6 +137,7 @@ impl Default for TrackerConfig {
         Self {
             provider: default_provider(),
             jira: None,
+            gitlab: None,
         }
     }
 }
@@ -233,7 +247,7 @@ impl ParsecConfig {
         let mut config = Self::default();
 
         // ---- Tracker provider ------------------------------------------------
-        let provider_options = &["None", "Jira", "GitHub"];
+        let provider_options = &["None", "Jira", "GitHub", "GitLab"];
         let provider_idx = Select::new()
             .with_prompt("Issue tracker provider")
             .items(provider_options)
@@ -244,6 +258,7 @@ impl ParsecConfig {
         config.tracker.provider = match provider_idx {
             1 => TrackerProvider::Jira,
             2 => TrackerProvider::Github,
+            3 => TrackerProvider::Gitlab,
             _ => TrackerProvider::None,
         };
 
@@ -268,6 +283,17 @@ impl ParsecConfig {
                     Some(email_input)
                 },
             });
+        }
+
+        // ---- GitLab-specific options -----------------------------------------
+        if config.tracker.provider == TrackerProvider::Gitlab {
+            let base_url: String = Input::new()
+                .with_prompt("GitLab base URL (e.g. https://gitlab.com)")
+                .default("https://gitlab.com".to_string())
+                .interact_text()
+                .context("Failed to read GitLab base URL")?;
+
+            config.tracker.gitlab = Some(GitlabConfig { base_url });
         }
 
         // ---- Worktree layout -------------------------------------------------

--- a/src/gitlab/mod.rs
+++ b/src/gitlab/mod.rs
@@ -1,0 +1,137 @@
+use anyhow::{bail, Context, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+/// Result of MR creation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MrResult {
+    pub url: String,
+    pub iid: u64,
+}
+
+/// Parsed GitLab remote info
+#[derive(Debug, Clone)]
+pub struct GitLabRemote {
+    pub host: String,
+    pub project_path: String, // "owner/repo" or "group/subgroup/repo"
+}
+
+impl GitLabRemote {
+    pub fn api_base(&self) -> String {
+        format!("https://{}/api/v4", self.host)
+    }
+}
+
+/// Parse a GitLab remote URL into GitLabRemote.
+/// Supports SSH and HTTPS forms, including nested groups.
+pub fn parse_gitlab_remote(url: &str) -> Option<GitLabRemote> {
+    // SSH: git@gitlab.com:group/subgroup/repo.git
+    if url.starts_with("git@") {
+        let rest = url.strip_prefix("git@")?;
+        let (host, path) = rest.split_once(':')?;
+        let path = path.trim_end_matches(".git");
+        return Some(GitLabRemote {
+            host: host.to_owned(),
+            project_path: path.to_owned(),
+        });
+    }
+
+    // HTTPS: https://gitlab.com/group/subgroup/repo.git
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let (host, path) = rest.split_once('/')?;
+    let path = path.trim_end_matches(".git");
+    Some(GitLabRemote {
+        host: host.to_owned(),
+        project_path: path.to_owned(),
+    })
+}
+
+/// Resolve a GitLab token from environment variables.
+/// Checks: PARSEC_GITLAB_TOKEN > GITLAB_TOKEN
+fn resolve_gitlab_token() -> Option<String> {
+    for var in &["PARSEC_GITLAB_TOKEN", "GITLAB_TOKEN"] {
+        if let Ok(token) = std::env::var(var) {
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+    None
+}
+
+/// Create a GitLab merge request.
+/// Returns None if no GitLab token is available.
+pub async fn create_mr(
+    remote_url: &str,
+    branch: &str,
+    base: &str,
+    title: &str,
+    description: &str,
+    draft: bool,
+) -> Result<Option<MrResult>> {
+    let token = match resolve_gitlab_token() {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let remote = parse_gitlab_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!(
+            "could not parse project path from remote URL: {}",
+            remote_url
+        )
+    })?;
+
+    // URL-encode the project path for the API
+    let encoded_path = remote.project_path.replace('/', "%2F");
+    let api_url = format!(
+        "{}/projects/{}/merge_requests",
+        remote.api_base(),
+        encoded_path
+    );
+
+    let mr_title = if draft {
+        format!("Draft: {}", title)
+    } else {
+        title.to_owned()
+    };
+
+    let payload = serde_json::json!({
+        "source_branch": branch,
+        "target_branch": base,
+        "title": mr_title,
+        "description": description,
+    });
+
+    let client = Client::new();
+    let response = client
+        .post(&api_url)
+        .header("Content-Type", "application/json")
+        .header("User-Agent", "git-parsec")
+        .header("PRIVATE-TOKEN", &token)
+        .json(&payload)
+        .send()
+        .await
+        .context("Failed to send MR creation request to GitLab")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        bail!("GitLab API returned {}: {}", status, body);
+    }
+
+    let resp: serde_json::Value = response
+        .json()
+        .await
+        .context("Failed to parse GitLab API response")?;
+
+    let web_url = resp["web_url"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("GitLab response missing web_url"))?
+        .to_owned();
+
+    let iid = resp["iid"].as_u64().unwrap_or(0);
+
+    Ok(Some(MrResult { url: web_url, iid }))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod conflict;
 mod git;
 mod github;
+mod gitlab;
 mod oplog;
 mod output;
 mod tracker;

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -297,6 +297,9 @@ pub fn print_config_show(config: &ParsecConfig) {
             println!("  jira.email     = {}", email);
         }
     }
+    if let Some(gitlab) = &config.tracker.gitlab {
+        println!("  gitlab.base_url = {}", gitlab.base_url);
+    }
     println!();
     println!("{}", "[ship]".bold());
     println!("  auto_pr         = {}", config.ship.auto_pr);

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -62,7 +62,7 @@ pub async fn fetch_ticket(
             let ticket = tracker.fetch_ticket(id).await?;
             Ok(Some(ticket))
         }
-        TrackerProvider::None => {
+        TrackerProvider::Gitlab | TrackerProvider::None => {
             // Auto-detect Jira: try if env vars available, but don't block on failure
             if std::env::var("JIRA_BASE_URL").is_ok()
                 && (std::env::var("JIRA_PAT").is_ok() || std::env::var("PARSEC_JIRA_TOKEN").is_ok())


### PR DESCRIPTION
## Summary
- New `src/gitlab/mod.rs` for GitLab MR creation via REST API
- Ship command tries GitHub first, then GitLab as fallback
- Supports self-hosted instances and nested groups
- Auth via `PARSEC_GITLAB_TOKEN` or `GITLAB_TOKEN` env var
- Added `Gitlab` tracker provider to config

Closes #14