### PR TITLE
Add branch policy: only develop can merge into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  branch-policy:
+    name: Branch Policy
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only develop can merge into main
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "::error::Only the 'develop' branch can be merged into 'main'. Got '${{ github.head_ref }}'."
+            exit 1
+          fi
+
   check:
     name: Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add CI job `Branch Policy` that fails if a PR to `main` comes from any branch other than `develop`
- Enforces the workflow: feature → develop → main

## Test plan
- [x] PRs to develop from feature branches: Branch Policy skips (only runs on main PRs)
- [x] PRs to main from develop: passes
- [x] PRs to main from other branches: fails with error message