### PR TITLE
Bump v0.2.2: add man page support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager for parallel AI agent workflows with ticket tracker integration"
@@ -30,6 +30,7 @@ indicatif = "0.17"
 dialoguer = "0.11"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tokio = { version = "1", features = ["full"] }
+clap_mangen = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 
@@ -493,7 +493,7 @@ function parsec() {
 }
 "#;
 
-pub async fn config_man(dir: &PathBuf) -> Result<()> {
+pub async fn config_man(dir: &Path) -> Result<()> {
     use clap::CommandFactory;
     let cmd = super::Cli::command();
     let man = clap_mangen::Man::new(cmd);

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
@@ -492,6 +492,26 @@ function parsec() {
     fi
 }
 "#;
+
+pub async fn config_man(dir: &PathBuf) -> Result<()> {
+    use clap::CommandFactory;
+    let cmd = super::Cli::command();
+    let man = clap_mangen::Man::new(cmd);
+    let mut buf = Vec::new();
+    man.render(&mut buf)?;
+
+    let man1_dir = dir.join("man1");
+    std::fs::create_dir_all(&man1_dir)
+        .with_context(|| format!("Failed to create directory {}", man1_dir.display()))?;
+
+    let path = man1_dir.join("parsec.1");
+    std::fs::write(&path, buf)
+        .with_context(|| format!("Failed to write man page to {}", path.display()))?;
+
+    println!("Man page installed to {}", path.display());
+    println!("Try: man parsec");
+    Ok(())
+}
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -188,6 +188,15 @@ pub enum ConfigAction {
         #[arg(default_value = "zsh")]
         shell: String,
     },
+    /// Install man page
+    ///
+    /// Generates and installs the parsec(1) man page so that
+    /// `man parsec` works. Requires write access to the man directory.
+    Man {
+        /// Man page base directory (default: /usr/local/share/man)
+        #[arg(long, default_value = "/usr/local/share/man")]
+        dir: PathBuf,
+    },
 }
 
 pub async fn run(cli: Cli) -> Result<()> {
@@ -233,6 +242,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             ConfigAction::Init => commands::config_init(output_mode).await,
             ConfigAction::Show => commands::config_show(output_mode).await,
             ConfigAction::Shell { shell } => commands::config_shell(&shell, output_mode).await,
+            ConfigAction::Man { dir } => commands::config_man(&dir).await,
         },
     }
 }


### PR DESCRIPTION
## Summary
- Bump version to v0.2.2
- Add `parsec config man` command to generate and install man(1) page via `clap_mangen`
- `man parsec` shows full CLI reference with all subcommands and options

## Usage
```bash
# Install man page (may need sudo)
sudo parsec config man

# Or to a custom directory
parsec config man --dir ~/.local/share/man

# Verify
man parsec
```

## Test plan
- [x] `cargo test` — 17/17 passing
- [x] `parsec config man --dir /tmp/test-man` generates valid man page
- [x] `MANPATH=/tmp/test-man man parsec` displays correctly