### PR TITLE
feat: add shell completions (#24)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ dialoguer = "0.11"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tokio = { version = "1", features = ["full"] }
 clap_mangen = "0.2"
+clap_complete = "4"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -422,6 +422,12 @@ $ parsec config show
 
 # Output shell integration script
 $ parsec config shell zsh
+
+# Generate shell completions
+$ parsec config completions zsh
+
+# Install man page
+$ sudo parsec config man
 ```
 
 ---
@@ -461,6 +467,41 @@ After sourcing, `parsec switch <ticket>` will `cd` into the worktree directly:
 ```bash
 $ parsec switch PROJ-1234
 # Now you're in /home/user/myapp.PROJ-1234
+```
+
+---
+
+## Shell Completions
+
+Generate tab-completion scripts for your shell:
+
+```bash
+# Zsh — add to ~/.zshrc
+eval "$(parsec config completions zsh)"
+
+# Bash — add to ~/.bashrc
+eval "$(parsec config completions bash)"
+
+# Fish — add to ~/.config/fish/config.fish
+parsec config completions fish | source
+
+# Other shells
+parsec config completions elvish
+parsec config completions powershell
+```
+
+---
+
+## Man Page
+
+Install the man page so `man parsec` works:
+
+```bash
+sudo parsec config man
+# Man page installed to /usr/local/share/man/man1/parsec.1
+
+# Custom directory
+parsec config man --dir ~/.local/share/man
 ```
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -1608,14 +1608,14 @@
           </p>
         </div>
 
-        <!-- Feature 5: Shell Integration -->
+        <!-- Feature 5: Shell Integration & Completions -->
         <div class="feature-card reveal reveal-delay-2">
           <div class="feature-icon">
             <svg viewBox="0 0 24 24"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
           </div>
-          <h3>Shell Integration</h3>
+          <h3>Shell Integration & Completions</h3>
           <p>
-            Add <code>eval "$(parsec config shell zsh)"</code> to your shell config and <code>parsec switch</code> teleports you into any worktree.
+            Auto-cd with <code>parsec switch</code>, tab-completions for zsh/bash/fish/powershell, and a man page — all built in.
           </p>
         </div>
 
@@ -1814,8 +1814,8 @@
         <div class="step-card reveal reveal-delay-2">
           <div class="step-number">02</div>
           <h3>Configure</h3>
-          <p>Run interactive setup to connect your Jira or GitHub Issues instance.</p>
-          <div class="step-code">parsec config init</div>
+          <p>Run interactive setup, enable shell integration and tab-completions.</p>
+          <div class="step-code">parsec config init<br>eval "$(parsec config completions zsh)"</div>
         </div>
         <div class="step-card reveal reveal-delay-3">
           <div class="step-number">03</div>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -513,6 +513,13 @@ pub async fn config_man(dir: &Path) -> Result<()> {
     Ok(())
 }
 
+pub async fn config_completions(shell: clap_complete::Shell) -> Result<()> {
+    use clap::CommandFactory;
+    let mut cmd = super::Cli::command();
+    clap_complete::generate(shell, &mut cmd, "parsec", &mut std::io::stdout());
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -197,6 +197,14 @@ pub enum ConfigAction {
         #[arg(long, default_value = "/usr/local/share/man")]
         dir: PathBuf,
     },
+    /// Output shell completions
+    ///
+    /// Generates tab-completion scripts for your shell.
+    /// Add eval "$(parsec config completions zsh)" to your ~/.zshrc.
+    Completions {
+        /// Shell type (zsh, bash, fish, elvish, powershell)
+        shell: clap_complete::Shell,
+    },
 }
 
 pub async fn run(cli: Cli) -> Result<()> {
@@ -243,6 +251,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             ConfigAction::Show => commands::config_show(output_mode).await,
             ConfigAction::Shell { shell } => commands::config_shell(&shell, output_mode).await,
             ConfigAction::Man { dir } => commands::config_man(&dir).await,
+            ConfigAction::Completions { shell } => commands::config_completions(shell).await,
         },
     }
 }


### PR DESCRIPTION
## Summary
- Add `parsec config completions <shell>` command for tab-completion scripts (zsh, bash, fish, elvish, powershell)
- Uses `clap_complete` crate for generation
- Updated README with Shell Completions and Man Page sections
- Updated landing page to mention completions in features and Quick Start

Closes #24

## Test plan
- [ ] `parsec config completions zsh` outputs valid zsh completion script
- [ ] `parsec config completions bash` outputs valid bash completion script
- [ ] CI passes (build, test, clippy, fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)