### PR TITLE
feat: interactive parsec switch picker (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,17 +313,24 @@ $ parsec conflicts
 
 ---
 
-### `parsec switch <ticket>`
+### `parsec switch [ticket]`
 
-Print the absolute path to a ticket's worktree. Designed for `cd $(parsec switch ...)`.
+Print the absolute path to a ticket's worktree. When called without a ticket, shows an interactive picker. Designed for `cd $(parsec switch ...)`.
 
 ```
-parsec switch <ticket>
+parsec switch [ticket]
 ```
 
 ```bash
+# Direct switch
 $ parsec switch PROJ-1234
 /home/user/myapp.PROJ-1234
+
+# Interactive picker (no argument)
+$ parsec switch
+? Switch to workspace ›
+❯ PROJ-1234 — Add user authentication
+  PROJ-5678 — Fix payment timeout
 
 # Use with cd
 $ cd $(parsec switch PROJ-1234)

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -273,12 +273,38 @@ pub async fn conflicts(repo: &Path, mode: Mode) -> Result<()> {
     Ok(())
 }
 
-pub async fn switch(repo: &Path, ticket: &str, mode: Mode) -> Result<()> {
+pub async fn switch(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
 
-    let workspace = manager.get(ticket)?;
+    let ticket = match ticket {
+        Some(t) => t.to_string(),
+        None => {
+            let workspaces = manager.list()?;
+            if workspaces.is_empty() {
+                anyhow::bail!("no active workspaces. Run `parsec start <ticket>` to create one.");
+            }
+            let items: Vec<String> = workspaces
+                .iter()
+                .map(|w| {
+                    let title = w
+                        .ticket_title
+                        .as_deref()
+                        .map(|t| format!(" — {t}"))
+                        .unwrap_or_default();
+                    format!("{}{title}", w.ticket)
+                })
+                .collect();
+            let selection = dialoguer::Select::new()
+                .with_prompt("Switch to workspace")
+                .items(&items)
+                .default(0)
+                .interact()?;
+            workspaces[selection].ticket.clone()
+        }
+    };
 
+    let workspace = manager.get(&ticket)?;
     output::print_switch(&workspace, mode);
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -107,11 +107,12 @@ pub enum Command {
     /// Print workspace path for a ticket (use with cd)
     ///
     /// Outputs the absolute path to the worktree for a given ticket.
+    /// When called without a ticket, shows an interactive picker.
     /// With shell integration (eval "$(parsec config shell zsh)"),
     /// this command changes your directory automatically.
     Switch {
-        /// Ticket identifier
-        ticket: String,
+        /// Ticket identifier (interactive picker if omitted)
+        ticket: Option<String>,
     },
 
     /// Import an existing branch into parsec management
@@ -241,7 +242,9 @@ pub async fn run(cli: Cli) -> Result<()> {
             title,
         } => commands::adopt(&repo_path, &ticket, branch.as_deref(), title, output_mode).await,
         Command::Conflicts => commands::conflicts(&repo_path, output_mode).await,
-        Command::Switch { ticket } => commands::switch(&repo_path, &ticket, output_mode).await,
+        Command::Switch { ticket } => {
+            commands::switch(&repo_path, ticket.as_deref(), output_mode).await
+        }
         Command::Log { ticket, last } => {
             commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
         }


### PR DESCRIPTION
## Summary
- `parsec switch` without arguments now shows an interactive picker of active worktrees
- Uses `dialoguer::Select` for the interactive UI
- Shows ticket ID and title in the picker list
- Errors gracefully when no workspaces exist
- Updated README with interactive switch examples

Closes #25

## Test plan
- [ ] `parsec switch` with no args shows interactive picker when worktrees exist
- [ ] `parsec switch` with no args and no worktrees shows helpful error
- [ ] `parsec switch TICKET` still works as before
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)