### PR TITLE
feat: add parsec open (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,35 @@ $ parsec sync --strategy merge
 
 ---
 
+### `parsec open <ticket>`
+
+Open the associated PR/MR or ticket tracker page in your default browser. If the ticket has been shipped, opens the PR by default; otherwise opens the tracker page.
+
+```
+parsec open <ticket> [--pr] [--ticket-page]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--pr` | Force open the PR/MR page |
+| `--ticket-page` | Force open the ticket tracker page |
+
+```bash
+# Open PR if shipped, otherwise ticket page
+$ parsec open PROJ-1234
+Opening https://github.com/org/repo/pull/42
+
+# Force open the Jira ticket
+$ parsec open PROJ-1234 --ticket-page
+Opening https://yourcompany.atlassian.net/browse/PROJ-1234
+
+# Force open the PR
+$ parsec open PROJ-1234 --pr
+Opening https://github.com/org/repo/pull/42
+```
+
+---
+
 ### `parsec config`
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1679,6 +1679,18 @@
           </p>
           <div class="feature-code">$ parsec undo --dry-run</div>
         </div>
+
+        <!-- Feature 11: Open in Browser -->
+        <div class="feature-card reveal reveal-delay-2">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+          </div>
+          <h3>Open in Browser</h3>
+          <p>
+            <code>parsec open</code> launches the PR or ticket page in your browser. Works with GitHub, GitLab, and Jira.
+          </p>
+          <div class="feature-code">$ parsec open PROJ-1234</div>
+        </div>
       </div>
     </div>
   </section>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -262,6 +262,93 @@ pub async fn clean(repo: &Path, all: bool, dry_run: bool, mode: Mode) -> Result<
     Ok(())
 }
 
+pub async fn open(
+    repo: &Path,
+    ticket: &str,
+    force_pr: bool,
+    force_ticket: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+
+    // Try to find PR URL from oplog
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let oplog = crate::oplog::OpLog::load(&repo_root)?;
+    let pr_url: Option<String> = oplog.get_entries(Some(ticket)).iter().rev().find_map(|e| {
+        if matches!(e.op, crate::oplog::OpKind::Ship) {
+            // PR URL is after " -> " in the detail string
+            e.detail.split(" -> ").nth(1).map(|s| s.to_string())
+        } else {
+            None
+        }
+    });
+
+    // Try to construct ticket tracker URL
+    use crate::config::TrackerProvider;
+    let ticket_url = match config.tracker.provider {
+        TrackerProvider::Jira => config
+            .tracker
+            .jira
+            .as_ref()
+            .map(|j| format!("{}/browse/{}", j.base_url.trim_end_matches('/'), ticket)),
+        TrackerProvider::Github => git::run_output(repo, &["remote", "get-url", "origin"])
+            .ok()
+            .map(|url| {
+                let url = url
+                    .trim_end_matches(".git")
+                    .replace("git@github.com:", "https://github.com/");
+                format!("{}/issues/{}", url, ticket.trim_start_matches('#'))
+            }),
+        TrackerProvider::Gitlab => config.tracker.gitlab.as_ref().map(|g| {
+            let base = g.base_url.trim_end_matches('/');
+            git::run_output(repo, &["remote", "get-url", "origin"])
+                .ok()
+                .and_then(|url| {
+                    let path = url
+                        .trim_end_matches(".git")
+                        .rsplit_once("gitlab.com")
+                        .map(|(_, p)| p.trim_start_matches([':', '/']))?;
+                    Some(format!("{}/{}/-/issues/{}", base, path, ticket))
+                })
+                .unwrap_or_else(|| format!("{}/-/issues/{}", base, ticket))
+        }),
+        TrackerProvider::None => None,
+    };
+
+    // Decide which URL to open
+    let url = if force_pr {
+        pr_url.ok_or_else(|| anyhow::anyhow!("no PR found for ticket {ticket}. Ship it first."))?
+    } else if force_ticket {
+        ticket_url
+            .ok_or_else(|| anyhow::anyhow!("no ticket URL for {ticket}. Configure a tracker."))?
+    } else {
+        // Default: PR if available, otherwise ticket
+        pr_url.or(ticket_url).ok_or_else(|| {
+            anyhow::anyhow!("no URL found for {ticket}. Ship it or configure a tracker.")
+        })?
+    };
+
+    // Open in browser
+    #[cfg(target_os = "macos")]
+    let open_cmd = "open";
+    #[cfg(not(target_os = "macos"))]
+    let open_cmd = "xdg-open";
+
+    std::process::Command::new(open_cmd)
+        .arg(&url)
+        .spawn()
+        .with_context(|| format!("failed to open browser with {open_cmd}"))?;
+
+    if mode == Mode::Json {
+        let value = serde_json::json!({ "action": "open", "ticket": ticket, "url": url });
+        println!("{}", value);
+    } else if mode != Mode::Quiet {
+        println!("Opening {}", url);
+    }
+
+    Ok(())
+}
+
 pub async fn conflicts(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -133,6 +133,24 @@ pub enum Command {
         strategy: String,
     },
 
+    /// Open PR/MR or ticket page in browser
+    ///
+    /// Opens the associated PR/MR URL (if shipped) or the ticket tracker
+    /// page in your default browser. Use --pr to force opening the PR,
+    /// or --ticket to force opening the tracker page.
+    Open {
+        /// Ticket identifier
+        ticket: String,
+
+        /// Force open the PR/MR page
+        #[arg(long)]
+        pr: bool,
+
+        /// Force open the ticket tracker page
+        #[arg(long)]
+        ticket_page: bool,
+    },
+
     /// Import an existing branch into parsec management
     ///
     /// Brings an existing branch under parsec lifecycle management.
@@ -264,6 +282,11 @@ pub async fn run(cli: Cli) -> Result<()> {
             branch,
             title,
         } => commands::adopt(&repo_path, &ticket, branch.as_deref(), title, output_mode).await,
+        Command::Open {
+            ticket,
+            pr,
+            ticket_page,
+        } => commands::open(&repo_path, &ticket, pr, ticket_page, output_mode).await,
         Command::Conflicts => commands::conflicts(&repo_path, output_mode).await,
         Command::Switch { ticket } => {
             commands::switch(&repo_path, ticket.as_deref(), output_mode).await


### PR DESCRIPTION
## Summary
- Add `parsec open <ticket>` to open PR/MR or ticket tracker page in browser
- Looks up PR URL from oplog ship history, falls back to tracker URL
- Supports `--pr` and `--ticket-page` flags to force target
- Works with Jira, GitHub Issues, and GitLab
- Uses `open` (macOS) / `xdg-open` (Linux) for cross-platform support
- Updated README and landing page

Closes #27

## Test plan
- [ ] `parsec open TICKET` opens PR URL after ship
- [ ] `parsec open TICKET --ticket-page` opens Jira/GitHub issue
- [ ] `parsec open TICKET --pr` errors when no PR exists
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)