### PR TITLE
feat: add parsec pr-status (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,33 @@ Opening https://github.com/org/repo/pull/42
 
 ---
 
+### `parsec pr-status [ticket]`
+
+Check the CI and review status of shipped PRs. Shows CI check results, review approvals, and merge state in a color-coded table.
+
+```
+parsec pr-status [ticket]
+```
+
+```bash
+# Check a specific ticket's PR
+$ parsec pr-status PROJ-1234
+┌───────────┬─────┬────────┬──────────┬──────────────┐
+│ Ticket    │ PR  │ State  │ CI       │ Reviews      │
+├───────────┼─────┼────────┼──────────┼──────────────┤
+│ PROJ-1234 │ #42 │ open   │ ✓ passed │ ✓ approved   │
+└───────────┴─────┴────────┴──────────┴──────────────┘
+
+# Check all shipped PRs
+$ parsec pr-status
+
+# JSON output
+$ parsec pr-status PROJ-1234 --json
+```
+
+Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
+---
+
 ### `parsec config`
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1691,6 +1691,18 @@
           </p>
           <div class="feature-code">$ parsec open PROJ-1234</div>
         </div>
+
+        <!-- Feature 12: PR Status -->
+        <div class="feature-card reveal reveal-delay-3">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+          </div>
+          <h3>PR Status Dashboard</h3>
+          <p>
+            <code>parsec pr-status</code> shows CI checks, review approvals, and merge state for all shipped PRs in one color-coded table.
+          </p>
+          <div class="feature-code">$ parsec pr-status PROJ-1234</div>
+        </div>
       </div>
     </div>
   </section>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -349,6 +349,50 @@ pub async fn open(
     Ok(())
 }
 
+pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<()> {
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let oplog = crate::oplog::OpLog::load(&repo_root)?;
+    let remote_url = git::run_output(repo, &["remote", "get-url", "origin"])?;
+
+    // Find shipped entries with PR URLs
+    let entries: Vec<_> = oplog
+        .get_entries(ticket)
+        .into_iter()
+        .filter(|e| matches!(e.op, crate::oplog::OpKind::Ship))
+        .filter_map(|e| {
+            let url = e.detail.split(" -> ").nth(1)?;
+            // Extract PR number from URL (e.g. .../pull/42)
+            let number = url.rsplit('/').next()?.parse::<u64>().ok()?;
+            Some((
+                e.ticket.clone().unwrap_or_default(),
+                number,
+                url.to_string(),
+            ))
+        })
+        .collect();
+
+    if entries.is_empty() {
+        if let Some(t) = ticket {
+            anyhow::bail!("no shipped PR found for {t}. Ship it first with `parsec ship {t}`.");
+        } else {
+            anyhow::bail!("no shipped PRs found. Ship a ticket first with `parsec ship`.");
+        }
+    }
+
+    let mut statuses = Vec::new();
+    for (ticket_id, pr_number, _url) in &entries {
+        match crate::github::get_pr_status(&remote_url, *pr_number).await? {
+            Some(status) => statuses.push((ticket_id.clone(), status)),
+            None => {
+                anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
+            }
+        }
+    }
+
+    output::print_pr_status(&statuses, mode);
+    Ok(())
+}
+
 pub async fn conflicts(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -104,6 +104,15 @@ pub enum Command {
     /// any files that are being edited in more than one workspace.
     Conflicts,
 
+    /// Check PR/MR CI and review status
+    ///
+    /// Shows CI check results, review approvals, and merge status for
+    /// shipped PRs. Requires a GitHub/GitLab token.
+    PrStatus {
+        /// Ticket identifier (shows all shipped if omitted)
+        ticket: Option<String>,
+    },
+
     /// Print workspace path for a ticket (use with cd)
     ///
     /// Outputs the absolute path to the worktree for a given ticket.
@@ -287,6 +296,9 @@ pub async fn run(cli: Cli) -> Result<()> {
             pr,
             ticket_page,
         } => commands::open(&repo_path, &ticket, pr, ticket_page, output_mode).await,
+        Command::PrStatus { ticket } => {
+            commands::pr_status(&repo_path, ticket.as_deref(), output_mode).await
+        }
         Command::Conflicts => commands::conflicts(&repo_path, output_mode).await,
         Command::Switch { ticket } => {
             commands::switch(&repo_path, ticket.as_deref(), output_mode).await

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -89,6 +89,122 @@ fn resolve_github_token() -> Option<String> {
     None
 }
 
+/// PR status information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrStatus {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub mergeable: Option<bool>,
+    pub ci_status: String,
+    pub review_status: String,
+    pub url: String,
+}
+
+/// Fetch the status of a GitHub PR by number.
+pub async fn get_pr_status(remote_url: &str, pr_number: u64) -> Result<Option<PrStatus>> {
+    let token = match resolve_github_token() {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let remote = parse_github_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+    })?;
+
+    let api_base = remote.api_base();
+    let client = Client::new();
+
+    // Fetch PR details
+    let pr_url = format!(
+        "{}/repos/{}/{}/pulls/{}",
+        api_base, remote.owner, remote.repo, pr_number
+    );
+    let pr_resp: serde_json::Value = client
+        .get(&pr_url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let title = pr_resp["title"].as_str().unwrap_or("").to_string();
+    let state = pr_resp["state"].as_str().unwrap_or("unknown").to_string();
+    let mergeable = pr_resp["mergeable"].as_bool();
+    let html_url = pr_resp["html_url"].as_str().unwrap_or("").to_string();
+    let head_sha = pr_resp["head"]["sha"].as_str().unwrap_or("");
+
+    // Fetch combined commit status
+    let ci_status = if !head_sha.is_empty() {
+        let status_url = format!(
+            "{}/repos/{}/{}/commits/{}/status",
+            api_base, remote.owner, remote.repo, head_sha
+        );
+        let status_resp: serde_json::Value = client
+            .get(&status_url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "git-parsec")
+            .bearer_auth(&token)
+            .send()
+            .await?
+            .json()
+            .await?;
+        status_resp["state"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string()
+    } else {
+        "unknown".to_string()
+    };
+
+    // Fetch reviews
+    let reviews_url = format!(
+        "{}/repos/{}/{}/pulls/{}/reviews",
+        api_base, remote.owner, remote.repo, pr_number
+    );
+    let reviews_resp: Vec<serde_json::Value> = client
+        .get(&reviews_url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let review_status = if reviews_resp.iter().any(|r| {
+        r["state"]
+            .as_str()
+            .is_some_and(|s| s == "CHANGES_REQUESTED")
+    }) {
+        "changes_requested".to_string()
+    } else if reviews_resp
+        .iter()
+        .any(|r| r["state"].as_str().is_some_and(|s| s == "APPROVED"))
+    {
+        "approved".to_string()
+    } else if reviews_resp.is_empty() {
+        "no reviews".to_string()
+    } else {
+        "pending".to_string()
+    };
+
+    Ok(Some(PrStatus {
+        number: pr_number,
+        title,
+        state,
+        mergeable,
+        ci_status,
+        review_status,
+        url: html_url,
+    }))
+}
+
 /// Create a GitHub pull request.
 /// Returns None if no GitHub token is available.
 pub async fn create_pr(

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -311,6 +311,65 @@ pub fn print_sync(synced: &[String], failed: &[(String, String)], strategy: &str
     }
 }
 
+pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
+    use tabled::{Table, Tabled};
+
+    #[derive(Tabled)]
+    struct Row {
+        #[tabled(rename = "Ticket")]
+        ticket: String,
+        #[tabled(rename = "PR")]
+        pr: String,
+        #[tabled(rename = "State")]
+        state: String,
+        #[tabled(rename = "CI")]
+        ci: String,
+        #[tabled(rename = "Reviews")]
+        reviews: String,
+    }
+
+    let rows: Vec<Row> = statuses
+        .iter()
+        .map(|(ticket, s)| {
+            let ci = match s.ci_status.as_str() {
+                "success" => "✓ passed".green().to_string(),
+                "failure" | "error" => "✗ failed".red().to_string(),
+                "pending" => "● pending".yellow().to_string(),
+                _ => s.ci_status.clone(),
+            };
+            let reviews = match s.review_status.as_str() {
+                "approved" => "✓ approved".green().to_string(),
+                "changes_requested" => "✗ changes requested".red().to_string(),
+                "pending" => "● pending".yellow().to_string(),
+                _ => s.review_status.clone(),
+            };
+            let state = match s.state.as_str() {
+                "open" => "open".green().to_string(),
+                "closed" => "closed".red().to_string(),
+                "merged" => "merged".cyan().to_string(),
+                _ => s.state.clone(),
+            };
+            Row {
+                ticket: ticket.clone(),
+                pr: format!("#{}", s.number),
+                state,
+                ci,
+                reviews,
+            }
+        })
+        .collect();
+
+    if rows.is_empty() {
+        println!("No shipped PRs found.");
+        return;
+    }
+
+    let table = Table::new(rows)
+        .with(tabled::settings::Style::modern())
+        .to_string();
+    println!("{table}");
+}
+
 pub fn print_config_show(config: &ParsecConfig) {
     println!("{}", "[workspace]".bold());
     println!("  layout          = {}", config.workspace.layout);

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -75,6 +75,25 @@ pub fn print_sync(synced: &[String], failed: &[(String, String)], strategy: &str
     println!("{}", value);
 }
 
+pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
+    let value: Vec<_> = statuses
+        .iter()
+        .map(|(ticket, s)| {
+            json!({
+                "ticket": ticket,
+                "pr_number": s.number,
+                "title": s.title,
+                "state": s.state,
+                "ci_status": s.ci_status,
+                "review_status": s.review_status,
+                "mergeable": s.mergeable,
+                "url": s.url,
+            })
+        })
+        .collect();
+    emit(&value);
+}
+
 pub fn print_undo(entry: &OpEntry) {
     let value = json!({
         "action": "undo",

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -117,6 +117,14 @@ pub fn print_sync(synced: &[String], failed: &[(String, String)], strategy: &str
     }
 }
 
+pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)], mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_pr_status(statuses),
+        Mode::Human => human::print_pr_status(statuses),
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig, mode: Mode) {
     match mode {
         Mode::Quiet => {}


### PR DESCRIPTION
## Summary
- Add `parsec pr-status [ticket]` to check CI and review status of shipped PRs
- Fetches PR state, CI combined status, and review approvals from GitHub API
- Color-coded table: green (passed/approved), yellow (pending), red (failed/changes)
- Supports `--json` for machine-readable output
- Updated README and landing page

Closes #28

## Test plan
- [ ] `parsec pr-status TICKET` shows CI + review status for a shipped PR
- [ ] `parsec pr-status` shows all shipped PRs
- [ ] `parsec pr-status --json` returns valid JSON
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)