### PR TITLE
feat: add parsec ci to check CI/CD pipeline status

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,49 @@ $ parsec pr-status PROJ-1234 --json
 Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
 ---
 
+### `parsec ci [ticket] [--watch] [--all]`
+
+Check CI/CD pipeline status for a ticket's PR. Shows individual check runs with status, duration, and an overall summary.
+
+```
+parsec ci [ticket] [--watch] [--all]
+```
+
+| Option | Description |
+|--------|-------------|
+| `ticket` | Ticket identifier (auto-detects current worktree if omitted) |
+| `--watch` | Poll CI every 5s until all checks complete |
+| `--all` | Show CI for all shipped PRs |
+
+```bash
+# Auto-detect from current worktree
+$ parsec ci
+CI for PROJ-1234 (PR #42, a1b2c3d)
+┌────────────┬───────────┬──────────┐
+│ Check      │ Status    │ Duration │
+├────────────┼───────────┼──────────┤
+│ Tests      │ ✓ passed  │ 2m 15s   │
+│ Build      │ ✓ passed  │ 1m 42s   │
+│ Lint       │ ● running │ running… │
+└────────────┴───────────┴──────────┘
+✓ CI: 2/3 — 2 passed, 1 running
+
+# Check a specific ticket
+$ parsec ci PROJ-1234
+
+# Watch mode — refreshes every 5s until done
+$ parsec ci PROJ-1234 --watch
+
+# All shipped PRs
+$ parsec ci --all
+
+# JSON output
+$ parsec ci PROJ-1234 --json
+```
+
+Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
+---
+
 ### `parsec config`
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1703,6 +1703,18 @@
           </p>
           <div class="feature-code">$ parsec pr-status PROJ-1234</div>
         </div>
+
+        <!-- Feature 13: CI Dashboard -->
+        <div class="feature-card reveal reveal-delay-1">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+          </div>
+          <h3>CI Pipeline Dashboard</h3>
+          <p>
+            <code>parsec ci</code> shows individual check runs, durations, and overall status. Use <code>--watch</code> to poll until completion.
+          </p>
+          <div class="feature-code">$ parsec ci --watch</div>
+        </div>
       </div>
     </div>
   </section>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -393,6 +393,130 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
     Ok(())
 }
 
+pub async fn ci(
+    repo: &Path,
+    ticket: Option<&str>,
+    watch: bool,
+    all: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let remote_url = git::run_output(repo, &["remote", "get-url", "origin"])?;
+    let oplog = crate::oplog::OpLog::load(&repo_root)?;
+    let manager = WorktreeManager::new(repo, &config)?;
+
+    // Collect (ticket_id, pr_number) pairs to check
+    let mut targets: Vec<(String, u64)> = Vec::new();
+
+    if all {
+        // All shipped entries with PR numbers from oplog
+        let entries: Vec<_> = oplog
+            .get_entries(None)
+            .into_iter()
+            .filter(|e| matches!(e.op, crate::oplog::OpKind::Ship))
+            .filter_map(|e| {
+                let url = e.detail.split(" -> ").nth(1)?;
+                let number = url.rsplit('/').next()?.parse::<u64>().ok()?;
+                Some((e.ticket.clone().unwrap_or_default(), number))
+            })
+            .collect();
+        if entries.is_empty() {
+            anyhow::bail!("no shipped PRs found. Ship a ticket first with `parsec ship`.");
+        }
+        targets = entries;
+    } else {
+        // Resolve which ticket to look up
+        let ticket_id = if let Some(t) = ticket {
+            t.to_string()
+        } else {
+            // Auto-detect from current worktree
+            let cwd = std::env::current_dir()?;
+            let all_ws = manager.list()?;
+            let found = all_ws
+                .into_iter()
+                .find(|w| cwd.starts_with(&w.path))
+                .ok_or_else(|| {
+                    anyhow::anyhow!("not inside a parsec worktree. Specify a ticket or use --all.")
+                })?;
+            found.ticket
+        };
+
+        // First check if there's a shipped PR in the oplog
+        let shipped_pr = oplog
+            .get_entries(Some(&ticket_id))
+            .into_iter()
+            .rev()
+            .filter(|e| matches!(e.op, crate::oplog::OpKind::Ship))
+            .find_map(|e| {
+                let url = e.detail.split(" -> ").nth(1)?;
+                url.rsplit('/').next()?.parse::<u64>().ok()
+            });
+
+        if let Some(pr_number) = shipped_pr {
+            targets.push((ticket_id, pr_number));
+        } else {
+            // Not shipped yet — try to find an open PR by branch name
+            let ws = manager.get(&ticket_id).with_context(|| {
+                format!("ticket {ticket_id} not found in active workspaces or oplog")
+            })?;
+            match github::find_pr_by_branch(&remote_url, &ws.branch).await? {
+                Some(pr_number) => targets.push((ticket_id, pr_number)),
+                None => {
+                    anyhow::bail!(
+                        "no PR found for {ticket_id}. Push and create a PR first, or ship with `parsec ship {ticket_id}`."
+                    );
+                }
+            }
+        }
+    }
+
+    loop {
+        let mut statuses: Vec<(String, crate::github::CiStatus)> = Vec::new();
+
+        for (ticket_id, pr_number) in &targets {
+            match github::get_check_runs(&remote_url, *pr_number).await? {
+                Some(ci) => statuses.push((ticket_id.clone(), ci)),
+                None => {
+                    anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
+                }
+            }
+        }
+
+        // In watch + human mode, clear screen before redraw
+        if watch && mode == Mode::Human {
+            print!("\x1B[2J\x1B[H");
+        }
+
+        output::print_ci_status(&statuses, mode);
+
+        if !watch || mode != Mode::Human {
+            // JSON/quiet mode prints once even with --watch
+            // Determine exit code based on overall status
+            let has_failure = statuses.iter().any(|(_t, ci)| ci.overall == "failing");
+            if has_failure {
+                std::process::exit(1);
+            }
+            return Ok(());
+        }
+
+        // Check if all checks are completed
+        let all_completed = statuses
+            .iter()
+            .all(|(_t, ci)| ci.checks.iter().all(|c| c.status == "completed"));
+
+        if all_completed {
+            let has_failure = statuses.iter().any(|(_t, ci)| ci.overall == "failing");
+            if has_failure {
+                std::process::exit(1);
+            }
+            return Ok(());
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+}
+
 pub async fn conflicts(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,6 +113,22 @@ pub enum Command {
         ticket: Option<String>,
     },
 
+    /// Check CI/CD pipeline status for a ticket's PR
+    ///
+    /// Shows individual check runs with status, duration, and overall
+    /// summary. Auto-detects the current worktree if no ticket is given.
+    /// Use --watch to poll until all checks complete.
+    Ci {
+        /// Ticket identifier (auto-detects current worktree if omitted)
+        ticket: Option<String>,
+        /// Watch CI in real-time until completion (refresh every 5s)
+        #[arg(long)]
+        watch: bool,
+        /// Show CI for all shipped PRs
+        #[arg(long)]
+        all: bool,
+    },
+
     /// Print workspace path for a ticket (use with cd)
     ///
     /// Outputs the absolute path to the worktree for a given ticket.
@@ -298,6 +314,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         } => commands::open(&repo_path, &ticket, pr, ticket_page, output_mode).await,
         Command::PrStatus { ticket } => {
             commands::pr_status(&repo_path, ticket.as_deref(), output_mode).await
+        }
+        Command::Ci { ticket, watch, all } => {
+            commands::ci(&repo_path, ticket.as_deref(), watch, all, output_mode).await
         }
         Command::Conflicts => commands::conflicts(&repo_path, output_mode).await,
         Command::Switch { ticket } => {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -205,6 +205,150 @@ pub async fn get_pr_status(remote_url: &str, pr_number: u64) -> Result<Option<Pr
     }))
 }
 
+/// A single CI check run
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckRun {
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub html_url: Option<String>,
+}
+
+/// Aggregated CI status for a PR
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CiStatus {
+    pub pr_number: u64,
+    pub head_sha: String,
+    pub overall: String,
+    pub checks: Vec<CheckRun>,
+}
+
+/// Fetch check runs for a PR by number.
+/// Returns None if no GitHub token is available.
+pub async fn get_check_runs(remote_url: &str, pr_number: u64) -> Result<Option<CiStatus>> {
+    let token = match resolve_github_token() {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let remote = parse_github_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+    })?;
+
+    let api_base = remote.api_base();
+    let client = Client::new();
+
+    // Fetch PR to get head SHA
+    let pr_url = format!(
+        "{}/repos/{}/{}/pulls/{}",
+        api_base, remote.owner, remote.repo, pr_number
+    );
+    let pr_resp: serde_json::Value = client
+        .get(&pr_url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let head_sha = pr_resp["head"]["sha"].as_str().unwrap_or("").to_string();
+
+    if head_sha.is_empty() {
+        bail!("could not determine head SHA for PR #{}", pr_number);
+    }
+
+    // Fetch check runs for the head SHA
+    let checks_url = format!(
+        "{}/repos/{}/{}/commits/{}/check-runs",
+        api_base, remote.owner, remote.repo, head_sha
+    );
+    let checks_resp: serde_json::Value = client
+        .get(&checks_url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let checks: Vec<CheckRun> = checks_resp["check_runs"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|c| CheckRun {
+            name: c["name"].as_str().unwrap_or("").to_string(),
+            status: c["status"].as_str().unwrap_or("").to_string(),
+            conclusion: c["conclusion"].as_str().map(|s| s.to_string()),
+            started_at: c["started_at"].as_str().map(|s| s.to_string()),
+            completed_at: c["completed_at"].as_str().map(|s| s.to_string()),
+            html_url: c["html_url"].as_str().map(|s| s.to_string()),
+        })
+        .collect();
+
+    // Derive overall status
+    let overall = if checks.is_empty() {
+        "no checks".to_string()
+    } else if checks
+        .iter()
+        .any(|c| c.conclusion.as_deref() == Some("failure"))
+    {
+        "failing".to_string()
+    } else if checks.iter().all(|c| {
+        c.conclusion.as_deref() == Some("success") || c.conclusion.as_deref() == Some("skipped")
+    }) {
+        "passing".to_string()
+    } else {
+        "pending".to_string()
+    };
+
+    Ok(Some(CiStatus {
+        pr_number,
+        head_sha,
+        overall,
+        checks,
+    }))
+}
+
+/// Find an open PR by branch name.
+/// Returns the PR number if found, None if no token or no matching PR.
+pub async fn find_pr_by_branch(remote_url: &str, branch: &str) -> Result<Option<u64>> {
+    let token = match resolve_github_token() {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let remote = parse_github_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+    })?;
+
+    let api_base = remote.api_base();
+    let client = Client::new();
+
+    let url = format!(
+        "{}/repos/{}/{}/pulls?head={}:{}&state=open",
+        api_base, remote.owner, remote.repo, remote.owner, branch
+    );
+    let resp: Vec<serde_json::Value> = client
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    Ok(resp.first().and_then(|pr| pr["number"].as_u64()))
+}
+
 /// Create a GitHub pull request.
 /// Returns None if no GitHub token is available.
 pub async fn create_pr(

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -370,6 +370,128 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
     println!("{table}");
 }
 
+pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
+    use tabled::{Table, Tabled};
+
+    for (ticket, ci) in statuses {
+        println!(
+            "{} {} (PR #{}, {})",
+            "CI for".bold(),
+            ticket.bold().cyan(),
+            ci.pr_number,
+            ci.head_sha[..7].dimmed()
+        );
+
+        if ci.checks.is_empty() {
+            println!("  {}", "No checks found.".dimmed());
+            println!();
+            continue;
+        }
+
+        #[derive(Tabled)]
+        struct CheckRow {
+            #[tabled(rename = "Check")]
+            name: String,
+            #[tabled(rename = "Status")]
+            status: String,
+            #[tabled(rename = "Duration")]
+            duration: String,
+        }
+
+        let rows: Vec<CheckRow> = ci
+            .checks
+            .iter()
+            .map(|c| {
+                let status = match (c.status.as_str(), c.conclusion.as_deref()) {
+                    (_, Some("success")) => "✓ passed".green().to_string(),
+                    (_, Some("failure")) => "✗ failed".red().to_string(),
+                    (_, Some("skipped")) => "- skipped".dimmed().to_string(),
+                    ("in_progress", _) => "● running".yellow().to_string(),
+                    ("queued", _) => "○ queued".dimmed().to_string(),
+                    _ => c.status.clone(),
+                };
+                let duration = match (&c.started_at, &c.completed_at) {
+                    (Some(start), Some(end)) => {
+                        if let (Ok(s), Ok(e)) = (
+                            chrono::DateTime::parse_from_rfc3339(start),
+                            chrono::DateTime::parse_from_rfc3339(end),
+                        ) {
+                            let secs = (e - s).num_seconds();
+                            if secs >= 60 {
+                                format!("{}m {}s", secs / 60, secs % 60)
+                            } else {
+                                format!("{}s", secs)
+                            }
+                        } else {
+                            "-".to_string()
+                        }
+                    }
+                    (Some(_), None) => "running...".to_string(),
+                    _ => "-".to_string(),
+                };
+                CheckRow {
+                    name: c.name.clone(),
+                    status,
+                    duration,
+                }
+            })
+            .collect();
+
+        let table = Table::new(rows)
+            .with(tabled::settings::Style::modern())
+            .to_string();
+        println!("{table}");
+
+        // Summary line
+        let passed = ci
+            .checks
+            .iter()
+            .filter(|c| c.conclusion.as_deref() == Some("success"))
+            .count();
+        let failed = ci
+            .checks
+            .iter()
+            .filter(|c| c.conclusion.as_deref() == Some("failure"))
+            .count();
+        let running = ci
+            .checks
+            .iter()
+            .filter(|c| c.status == "in_progress")
+            .count();
+        let queued = ci.checks.iter().filter(|c| c.status == "queued").count();
+        let total = ci.checks.len();
+
+        let mut parts = Vec::new();
+        if passed > 0 {
+            parts.push(format!("{passed} passed").green().to_string());
+        }
+        if failed > 0 {
+            parts.push(format!("{failed} failed").red().to_string());
+        }
+        if running > 0 {
+            parts.push(format!("{running} running").yellow().to_string());
+        }
+        if queued > 0 {
+            parts.push(format!("{queued} queued"));
+        }
+
+        let overall_icon = match ci.overall.as_str() {
+            "passing" => "✓".green().to_string(),
+            "failing" => "✗".red().to_string(),
+            _ => "●".yellow().to_string(),
+        };
+
+        println!(
+            "{} CI: {}/{} — {}",
+            overall_icon,
+            passed,
+            total,
+            parts.join(", ")
+        );
+        println!();
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig) {
     println!("{}", "[workspace]".bold());
     println!("  layout          = {}", config.workspace.layout);

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -94,6 +94,22 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
     emit(&value);
 }
 
+pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
+    let value: Vec<_> = statuses
+        .iter()
+        .map(|(ticket, ci)| {
+            json!({
+                "ticket": ticket,
+                "pr_number": ci.pr_number,
+                "head_sha": ci.head_sha,
+                "overall": ci.overall,
+                "checks": ci.checks,
+            })
+        })
+        .collect();
+    emit(&value);
+}
+
 pub fn print_undo(entry: &OpEntry) {
     let value = json!({
         "action": "undo",

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -125,6 +125,14 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)], mode: Mod
     }
 }
 
+pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)], mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_ci_status(statuses),
+        Mode::Human => human::print_ci_status(statuses),
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig, mode: Mode) {
     match mode {
         Mode::Quiet => {}


### PR DESCRIPTION
## Summary
- Add `parsec ci` command to check CI/CD pipeline status for a ticket's PR
- Shows individual check runs with status, duration, and overall summary
- Supports auto-detection from current worktree, `--watch` mode (5s polling), and `--all` for shipped PRs
- Finds PRs both from shipped oplog entries and from open PRs by branch name

## Changes
| File | Change |
|------|--------|
| `src/github/mod.rs` | `CheckRun`, `CiStatus` structs + `get_check_runs()`, `find_pr_by_branch()` |
| `src/output/{mod,human,json}.rs` | `print_ci_status()` dispatcher, tabled human output, JSON output |
| `src/cli/mod.rs` | `Ci` command variant + routing |
| `src/cli/commands.rs` | `ci()` handler with auto-detect, watch mode, exit codes |
| `README.md` | Command reference section |
| `docs/index.html` | "CI Pipeline Dashboard" feature card |

## Test plan
- [ ] `parsec ci <ticket-with-open-pr>` — shows check runs table
- [ ] `parsec ci <ticket> --json` — JSON output
- [ ] `parsec ci --all` — all shipped PRs
- [ ] `parsec ci --watch` — polls until completion
- [ ] `cargo build && cargo clippy && cargo fmt --check` — all pass

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)