### PR TITLE
feat: add parsec merge to merge PRs from terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,44 @@ $ parsec ci PROJ-1234 --json
 ```
 
 Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
+
+---
+
+### `parsec merge [ticket] [--rebase] [--no-wait] [--no-delete-branch]`
+
+Merge a ticket's PR directly from the terminal. Waits for CI to pass before merging, then cleans up the local worktree.
+
+```
+parsec merge [ticket] [--rebase] [--no-wait] [--no-delete-branch]
+```
+
+| Option | Description |
+|--------|-------------|
+| `ticket` | Ticket identifier (auto-detects current worktree if omitted) |
+| `--rebase` | Use rebase merge instead of squash (default: squash) |
+| `--no-wait` | Skip CI check before merging |
+| `--no-delete-branch` | Keep remote branch after merge |
+
+```bash
+# Squash merge (default)
+$ parsec merge PROJ-1234
+Waiting for CI to pass... ✓
+Merged PR #42 for PROJ-1234!
+  Method: squash
+  SHA:    a1b2c3d
+
+# Rebase merge
+$ parsec merge PROJ-1234 --rebase
+
+# Skip CI wait
+$ parsec merge PROJ-1234 --no-wait
+
+# JSON output
+$ parsec merge PROJ-1234 --json
+```
+
+Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
+
 ---
 
 ### `parsec config`

--- a/docs/index.html
+++ b/docs/index.html
@@ -1715,6 +1715,18 @@
           </p>
           <div class="feature-code">$ parsec ci --watch</div>
         </div>
+
+        <!-- Feature 14: Merge from Terminal -->
+        <div class="feature-card reveal reveal-delay-2">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/><path d="M9 18l6-6-6-6" transform="translate(6,0)"/></svg>
+          </div>
+          <h3>Merge from Terminal</h3>
+          <p>
+            <code>parsec merge</code> merges PRs directly from your terminal. Waits for CI to pass, supports squash and rebase, and cleans up automatically.
+          </p>
+          <div class="feature-code">$ parsec merge PROJ-1234</div>
+        </div>
       </div>
     </div>
   </section>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use colored::Colorize;
 
 use crate::config::ParsecConfig;
 use crate::conflict;
@@ -390,6 +391,148 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
     }
 
     output::print_pr_status(&statuses, mode);
+    Ok(())
+}
+
+pub async fn merge(
+    repo: &Path,
+    ticket: Option<&str>,
+    rebase: bool,
+    no_wait: bool,
+    no_delete_branch: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let remote_url = git::run_output(repo, &["remote", "get-url", "origin"])?;
+    let oplog = crate::oplog::OpLog::load(&repo_root)?;
+    let manager = WorktreeManager::new(repo, &config)?;
+
+    // Resolve ticket
+    let ticket_id = if let Some(t) = ticket {
+        t.to_string()
+    } else {
+        let cwd = std::env::current_dir()?;
+        let all_ws = manager.list()?;
+        let found = all_ws
+            .into_iter()
+            .find(|w| cwd.starts_with(&w.path))
+            .ok_or_else(|| anyhow::anyhow!("not inside a parsec worktree. Specify a ticket."))?;
+        found.ticket
+    };
+
+    // Find PR number: check oplog first, then try open PR by branch
+    let pr_number = {
+        let shipped_pr = oplog
+            .get_entries(Some(&ticket_id))
+            .into_iter()
+            .rev()
+            .filter(|e| matches!(e.op, crate::oplog::OpKind::Ship))
+            .find_map(|e| {
+                let url = e.detail.split(" -> ").nth(1)?;
+                url.rsplit('/').next()?.parse::<u64>().ok()
+            });
+
+        if let Some(pr) = shipped_pr {
+            pr
+        } else {
+            let ws = manager.get(&ticket_id).with_context(|| {
+                format!("ticket {ticket_id} not found in active workspaces or oplog")
+            })?;
+            github::find_pr_by_branch(&remote_url, &ws.branch)
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "no PR found for {ticket_id}. Ship it first with `parsec ship {ticket_id}`."
+                    )
+                })?
+        }
+    };
+
+    // Wait for CI to pass (unless --no-wait)
+    if !no_wait {
+        if mode == Mode::Human {
+            eprint!("Waiting for CI to pass...");
+        }
+        loop {
+            match github::get_check_runs(&remote_url, pr_number).await? {
+                Some(ci) => {
+                    if ci.overall == "passing" {
+                        if mode == Mode::Human {
+                            eprintln!(" {}", "✓".green());
+                        }
+                        break;
+                    } else if ci.overall == "failing" {
+                        if mode == Mode::Human {
+                            eprintln!(" {}", "✗".red());
+                        }
+                        anyhow::bail!(
+                            "CI is failing for PR #{}. Fix CI or use --no-wait to merge anyway.",
+                            pr_number
+                        );
+                    }
+                    // Still pending — wait and retry
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                }
+                None => {
+                    anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
+                }
+            }
+        }
+    }
+
+    // Determine merge method
+    let method = if rebase { "rebase" } else { "squash" };
+    let delete_branch = !no_delete_branch;
+
+    // Merge the PR
+    match github::merge_pr(&remote_url, pr_number, method, delete_branch).await? {
+        Some(result) => {
+            output::print_merge(&ticket_id, pr_number, &result, method, mode);
+
+            // Clean up local worktree if it exists
+            if let Ok(ws) = manager.get(&ticket_id) {
+                if ws.path.exists() {
+                    if let Err(e) = git::worktree_remove(&repo_root, &ws.path) {
+                        eprintln!("warning: failed to remove worktree: {e}");
+                    }
+                }
+                // Update state
+                let mut state = crate::worktree::ParsecState::load(&repo_root)?;
+                state.remove_workspace(&ticket_id);
+                state.save(&repo_root)?;
+
+                // Delete local branch
+                if let Some(branch) = &oplog
+                    .get_entries(Some(&ticket_id))
+                    .last()
+                    .and_then(|e| e.undo_info.as_ref())
+                    .and_then(|u| u.branch.clone())
+                {
+                    let _ = git::delete_branch(&repo_root, branch);
+                }
+
+                if mode == Mode::Human {
+                    println!("  {}", "Local worktree cleaned up.".dimmed());
+                }
+            }
+
+            // Record in oplog
+            if let Err(e) = crate::oplog::record(
+                &repo_root,
+                crate::oplog::OpKind::Clean,
+                Some(&ticket_id),
+                &format!("Merged PR #{} ({})", pr_number, method),
+                None,
+            ) {
+                eprintln!("warning: failed to write oplog: {e}");
+            }
+        }
+        None => {
+            anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
+        }
+    }
+
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,6 +113,25 @@ pub enum Command {
         ticket: Option<String>,
     },
 
+    /// Merge a ticket's PR on GitHub and clean up
+    ///
+    /// Merges the PR via the GitHub API. By default uses squash merge
+    /// and waits for CI to pass before merging. Cleans up the local
+    /// worktree after a successful merge.
+    Merge {
+        /// Ticket identifier (auto-detects current worktree if omitted)
+        ticket: Option<String>,
+        /// Use rebase merge instead of squash
+        #[arg(long)]
+        rebase: bool,
+        /// Skip waiting for CI to pass
+        #[arg(long)]
+        no_wait: bool,
+        /// Keep remote branch after merge (default: delete)
+        #[arg(long)]
+        no_delete_branch: bool,
+    },
+
     /// Check CI/CD pipeline status for a ticket's PR
     ///
     /// Shows individual check runs with status, duration, and overall
@@ -314,6 +333,22 @@ pub async fn run(cli: Cli) -> Result<()> {
         } => commands::open(&repo_path, &ticket, pr, ticket_page, output_mode).await,
         Command::PrStatus { ticket } => {
             commands::pr_status(&repo_path, ticket.as_deref(), output_mode).await
+        }
+        Command::Merge {
+            ticket,
+            rebase,
+            no_wait,
+            no_delete_branch,
+        } => {
+            commands::merge(
+                &repo_path,
+                ticket.as_deref(),
+                rebase,
+                no_wait,
+                no_delete_branch,
+                output_mode,
+            )
+            .await
         }
         Command::Ci { ticket, watch, all } => {
             commands::ci(&repo_path, ticket.as_deref(), watch, all, output_mode).await

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -349,6 +349,105 @@ pub async fn find_pr_by_branch(remote_url: &str, branch: &str) -> Result<Option<
     Ok(resp.first().and_then(|pr| pr["number"].as_u64()))
 }
 
+/// Result of merging a PR
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeResult {
+    pub sha: String,
+    pub message: String,
+    pub merged: bool,
+}
+
+/// Merge a GitHub PR.
+/// `method` should be "squash", "rebase", or "merge".
+/// Returns None if no token, Some(MergeResult) on success.
+pub async fn merge_pr(
+    remote_url: &str,
+    pr_number: u64,
+    method: &str,
+    delete_branch: bool,
+) -> Result<Option<MergeResult>> {
+    let token = match resolve_github_token() {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let remote = parse_github_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+    })?;
+
+    let api_base = remote.api_base();
+    let client = Client::new();
+
+    // Merge the PR
+    let url = format!(
+        "{}/repos/{}/{}/pulls/{}/merge",
+        api_base, remote.owner, remote.repo, pr_number
+    );
+    let payload = serde_json::json!({
+        "merge_method": method,
+    });
+
+    let response = client
+        .put(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .json(&payload)
+        .send()
+        .await
+        .context("Failed to send merge request to GitHub")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        bail!("GitHub merge API returned {}: {}", status, body);
+    }
+
+    let resp: serde_json::Value = response.json().await?;
+    let sha = resp["sha"].as_str().unwrap_or("").to_string();
+    let message = resp["message"].as_str().unwrap_or("").to_string();
+
+    // Delete remote branch if requested
+    if delete_branch {
+        let branch_url = format!(
+            "{}/repos/{}/{}/pulls/{}",
+            api_base, remote.owner, remote.repo, pr_number
+        );
+        let pr_resp: serde_json::Value = client
+            .get(&branch_url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "git-parsec")
+            .bearer_auth(&token)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if let Some(branch_name) = pr_resp["head"]["ref"].as_str() {
+            let del_url = format!(
+                "{}/repos/{}/{}/git/refs/heads/{}",
+                api_base, remote.owner, remote.repo, branch_name
+            );
+            let _ = client
+                .delete(&del_url)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .header("User-Agent", "git-parsec")
+                .bearer_auth(&token)
+                .send()
+                .await;
+        }
+    }
+
+    Ok(Some(MergeResult {
+        sha,
+        message,
+        merged: true,
+    }))
+}
+
 /// Create a GitHub pull request.
 /// Returns None if no GitHub token is available.
 pub async fn create_pr(

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -370,6 +370,25 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
     println!("{table}");
 }
 
+pub fn print_merge(
+    ticket: &str,
+    pr_number: u64,
+    result: &crate::github::MergeResult,
+    method: &str,
+) {
+    println!(
+        "{}",
+        format!("Merged PR #{} for {}!", pr_number, ticket)
+            .green()
+            .bold()
+    );
+    println!("  {} {}", "Method:".bold(), method);
+    println!("  {} {}", "SHA:".bold(), result.sha.dimmed());
+    if !result.message.is_empty() {
+        println!("  {} {}", "Message:".bold(), result.message);
+    }
+}
+
 pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
     use tabled::{Table, Tabled};
 

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -94,6 +94,24 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
     emit(&value);
 }
 
+pub fn print_merge(
+    ticket: &str,
+    pr_number: u64,
+    result: &crate::github::MergeResult,
+    method: &str,
+) {
+    let value = json!({
+        "action": "merge",
+        "ticket": ticket,
+        "pr_number": pr_number,
+        "method": method,
+        "sha": result.sha,
+        "message": result.message,
+        "merged": result.merged,
+    });
+    println!("{}", value);
+}
+
 pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
     let value: Vec<_> = statuses
         .iter()

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -125,6 +125,20 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)], mode: Mod
     }
 }
 
+pub fn print_merge(
+    ticket: &str,
+    pr_number: u64,
+    result: &crate::github::MergeResult,
+    method: &str,
+    mode: Mode,
+) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_merge(ticket, pr_number, result, method),
+        Mode::Human => human::print_merge(ticket, pr_number, result, method),
+    }
+}
+
 pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)], mode: Mode) {
     match mode {
         Mode::Quiet => {}


### PR DESCRIPTION
## Summary
- Add `parsec merge` command to merge PRs directly from the terminal via GitHub API
- Waits for CI to pass before merging (with `--no-wait` to skip)
- Supports squash (default) and rebase merge methods
- Auto-cleans local worktree and branch after successful merge
- Auto-detects current worktree ticket if no argument given

## Changes
| File | Change |
|------|--------|
| `src/github/mod.rs` | `MergeResult` struct + `merge_pr()` function (PUT merge API + branch deletion) |
| `src/output/{mod,human,json}.rs` | `print_merge()` dispatcher, colored human output, JSON output |
| `src/cli/mod.rs` | `Merge` command variant with `--rebase`, `--no-wait`, `--no-delete-branch` |
| `src/cli/commands.rs` | `merge()` handler with CI wait loop, worktree cleanup, oplog recording |
| `README.md` | Command reference section |
| `docs/index.html` | "Merge from Terminal" feature card |

## Test plan
- [ ] `parsec merge <ticket>` — squash merges PR, waits for CI
- [ ] `parsec merge <ticket> --rebase` — rebase merge
- [ ] `parsec merge <ticket> --no-wait` — skips CI check
- [ ] `parsec merge <ticket> --no-delete-branch` — keeps remote branch
- [ ] `parsec merge <ticket> --json` — JSON output
- [ ] Auto-detect from worktree (no ticket arg)
- [ ] `cargo build && cargo clippy && cargo fmt --check` — all pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)