### PR TITLE
feat: add parsec diff to view worktree changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,35 @@ Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
 
 ---
 
+### `parsec diff [ticket] [--stat] [--name-only]`
+
+View changes in a worktree compared to its base branch. Uses merge-base for accurate comparison.
+
+```
+parsec diff [ticket] [--stat] [--name-only]
+```
+
+| Option | Description |
+|--------|-------------|
+| `ticket` | Ticket identifier (auto-detects current worktree if omitted) |
+| `--stat` | Show file-level summary only |
+| `--name-only` | List changed file names only |
+
+```bash
+# Full diff for current worktree
+$ parsec diff
+
+# File summary
+$ parsec diff PROJ-1234 --stat
+
+# Just file names
+$ parsec diff --name-only
+
+# JSON output (changed files list)
+$ parsec diff PROJ-1234 --json
+```
+---
+
 ### `parsec config`
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1727,6 +1727,18 @@
           </p>
           <div class="feature-code">$ parsec merge PROJ-1234</div>
         </div>
+
+        <!-- Feature 15: Worktree Diff -->
+        <div class="feature-card reveal reveal-delay-3">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M12 20V10"/><path d="M18 20V4"/><path d="M6 20v-4"/></svg>
+          </div>
+          <h3>Worktree Diff</h3>
+          <p>
+            <code>parsec diff</code> shows changes in any worktree compared to its base branch. Supports <code>--stat</code> and <code>--name-only</code> views.
+          </p>
+          <div class="feature-code">$ parsec diff --stat</div>
+        </div>
       </div>
     </div>
   </section>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -660,6 +660,67 @@ pub async fn ci(
     }
 }
 
+pub async fn diff(
+    repo: &Path,
+    ticket: Option<&str>,
+    stat: bool,
+    name_only: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config)?;
+
+    // Resolve workspace
+    let ws = if let Some(t) = ticket {
+        manager.get(t)?
+    } else {
+        let cwd = std::env::current_dir()?;
+        let all_ws = manager.list()?;
+        all_ws
+            .into_iter()
+            .find(|w| cwd.starts_with(&w.path))
+            .ok_or_else(|| anyhow::anyhow!("not inside a parsec worktree. Specify a ticket."))?
+    };
+
+    // Find merge base
+    let merge_base = git::run_output(
+        &ws.path,
+        &["merge-base", &format!("origin/{}", ws.base_branch), "HEAD"],
+    )?;
+    let merge_base = merge_base.trim();
+
+    if name_only {
+        let output = git::run_output(&ws.path, &["diff", "--name-only", merge_base])?;
+        let files: Vec<String> = output.lines().map(|l| l.to_string()).collect();
+        output::print_diff_names(&files, &ws.ticket, mode);
+    } else if stat {
+        let output = git::run_output(&ws.path, &["diff", "--stat", merge_base])?;
+        output::print_diff_stat(&output, &ws.ticket, mode);
+    } else {
+        // Full diff — just pass through to terminal in human mode
+        if mode == Mode::Json {
+            let output = git::run_output(&ws.path, &["diff", "--name-status", merge_base])?;
+            let files: Vec<(String, String)> = output
+                .lines()
+                .filter_map(|l| {
+                    let mut parts = l.splitn(2, '\t');
+                    let status = parts.next()?.to_string();
+                    let file = parts.next()?.to_string();
+                    Some((status, file))
+                })
+                .collect();
+            output::print_diff_full_json(&files, &ws.ticket);
+        } else if mode == Mode::Human {
+            // Pass through with color
+            let _ = std::process::Command::new("git")
+                .args(["diff", "--color=always", merge_base])
+                .current_dir(&ws.path)
+                .status();
+        }
+    }
+    Ok(())
+}
+
 pub async fn conflicts(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -148,6 +148,21 @@ pub enum Command {
         all: bool,
     },
 
+    /// View changes in a worktree compared to base branch
+    ///
+    /// Shows the diff between the worktree branch and its base branch
+    /// using the merge-base as the comparison point.
+    Diff {
+        /// Ticket identifier (auto-detects current worktree if omitted)
+        ticket: Option<String>,
+        /// Show file-level summary only
+        #[arg(long)]
+        stat: bool,
+        /// List changed file names only
+        #[arg(long)]
+        name_only: bool,
+    },
+
     /// Print workspace path for a ticket (use with cd)
     ///
     /// Outputs the absolute path to the worktree for a given ticket.
@@ -353,6 +368,11 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Ci { ticket, watch, all } => {
             commands::ci(&repo_path, ticket.as_deref(), watch, all, output_mode).await
         }
+        Command::Diff {
+            ticket,
+            stat,
+            name_only,
+        } => commands::diff(&repo_path, ticket.as_deref(), stat, name_only, output_mode).await,
         Command::Conflicts => commands::conflicts(&repo_path, output_mode).await,
         Command::Switch { ticket } => {
             commands::switch(&repo_path, ticket.as_deref(), output_mode).await

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -511,6 +511,23 @@ pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
     }
 }
 
+pub fn print_diff_names(files: &[String], ticket: &str) {
+    println!(
+        "{} {} ({} files):",
+        "Changed files for".bold(),
+        ticket.bold().cyan(),
+        files.len()
+    );
+    for f in files {
+        println!("  {}", f);
+    }
+}
+
+pub fn print_diff_stat(stat: &str, ticket: &str) {
+    println!("{} {}:", "Diff stat for".bold(), ticket.bold().cyan());
+    print!("{}", stat);
+}
+
 pub fn print_config_show(config: &ParsecConfig) {
     println!("{}", "[workspace]".bold());
     println!("  layout          = {}", config.workspace.layout);

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -128,6 +128,24 @@ pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
     emit(&value);
 }
 
+pub fn print_diff_names(files: &[String], ticket: &str) {
+    let value = json!({
+        "ticket": ticket,
+        "files": files,
+        "count": files.len(),
+    });
+    println!("{}", value);
+}
+
+pub fn print_diff_full(files: &[(String, String)], ticket: &str) {
+    let value = json!({
+        "ticket": ticket,
+        "changes": files.iter().map(|(status, file)| json!({"status": status, "file": file})).collect::<Vec<_>>(),
+        "count": files.len(),
+    });
+    println!("{}", value);
+}
+
 pub fn print_undo(entry: &OpEntry) {
     let value = json!({
         "action": "undo",

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -154,3 +154,23 @@ pub fn print_config_show(config: &ParsecConfig, mode: Mode) {
         Mode::Human => human::print_config_show(config),
     }
 }
+
+pub fn print_diff_names(files: &[String], ticket: &str, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_diff_names(files, ticket),
+        Mode::Human => human::print_diff_names(files, ticket),
+    }
+}
+
+pub fn print_diff_stat(stat: &str, ticket: &str, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => {} // stat is human-only
+        Mode::Human => human::print_diff_stat(stat, ticket),
+    }
+}
+
+pub fn print_diff_full_json(files: &[(String, String)], ticket: &str) {
+    json::print_diff_full(files, ticket);
+}


### PR DESCRIPTION
## Summary
- Add `parsec diff` command to view changes in a worktree compared to its base branch using merge-base
- Support `--stat` for file-level summary and `--name-only` for changed file names
- Full `--json` support for machine-readable output of changed files

## Changes

| File | Change |
|------|--------|
| `src/cli/mod.rs` | Add `Diff` variant to `Command` enum + routing in `run()` |
| `src/cli/commands.rs` | Add `diff()` command handler with merge-base comparison |
| `src/output/mod.rs` | Add `print_diff_names`, `print_diff_stat`, `print_diff_full_json` dispatchers |
| `src/output/human.rs` | Add human-readable diff name and stat output |
| `src/output/json.rs` | Add JSON output for diff names and full diff |
| `README.md` | Add `parsec diff` documentation section |
| `docs/index.html` | Add Worktree Diff feature card |

## Test plan
- [ ] `parsec diff` inside a worktree shows full colored diff vs base branch
- [ ] `parsec diff TICKET` shows diff for a specific ticket's worktree
- [ ] `parsec diff --stat` shows file-level summary
- [ ] `parsec diff --name-only` lists changed file names
- [ ] `parsec diff --json` outputs JSON with changed files and statuses
- [ ] `parsec diff` outside a worktree without ticket shows helpful error
- [ ] `cargo fmt && cargo build && cargo clippy` passes clean

Closes #41