### PR TITLE
feat: add parsec stack for stacked PR dependency tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Removed 1 worktree(s):
 - **Status dashboard** -- See all parallel work at a glance
 - **Auto-cleanup** -- Remove worktrees for merged branches automatically
 - **GitHub and GitLab** -- PR and MR creation for both platforms
+- **Stacked PRs** -- Create dependent PR chains with `--on` and sync the entire stack
 
 ## Installation
 
@@ -125,13 +126,14 @@ $ parsec log
 Create an isolated worktree for a ticket. Fetches the ticket title from your configured tracker (Jira, GitHub Issues) or accepts a manual title.
 
 ```
-parsec start <ticket> [--base <branch>] [--title "text"]
+parsec start <ticket> [--base <branch>] [--title "text"] [--on <parent-ticket>]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `-b, --base <branch>` | Base branch to create from (default: main/master) |
 | `--title "text"` | Set ticket title manually, skip tracker lookup |
+| `--on <ticket>` | Stack on another ticket's branch (for dependent PRs) |
 
 ```bash
 # With Jira integration (title auto-fetched)
@@ -600,6 +602,42 @@ $ parsec diff --name-only
 
 # JSON output (changed files list)
 $ parsec diff PROJ-1234 --json
+```
+
+---
+
+### `parsec stack [--sync]`
+
+View and manage stacked PR dependencies. Worktrees created with `--on` form a dependency chain.
+
+```
+parsec stack [--sync]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--sync` | Rebase the entire stack chain |
+
+```bash
+# Create a stack
+$ parsec start PROJ-1 --title "Add models"
+$ parsec start PROJ-2 --on PROJ-1 --title "Add API endpoints"
+$ parsec start PROJ-3 --on PROJ-2 --title "Add frontend"
+
+# View the dependency graph
+$ parsec stack
+Stack dependency graph:
+└── PROJ-1 Add models
+    └── PROJ-2 Add API endpoints
+        └── PROJ-3 Add frontend
+
+# Sync the entire stack
+$ parsec stack --sync
+
+# Ship creates PRs with correct base branches
+$ parsec ship PROJ-1   # PR to main
+$ parsec ship PROJ-2   # PR to feature/PROJ-1
+$ parsec ship PROJ-3   # PR to feature/PROJ-2
 ```
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1704,6 +1704,18 @@
           <div class="feature-code">$ parsec pr-status PROJ-1234</div>
         </div>
 
+        <!-- Feature: Stacked PRs -->
+        <div class="feature-card featured reveal reveal-delay-1">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/></svg>
+          </div>
+          <h3>Stacked PRs</h3>
+          <p>
+            Create dependent PR chains with <code>--on</code>. <code>parsec stack</code> shows the dependency graph and <code>--sync</code> rebases the entire chain.
+          </p>
+          <div class="feature-code">$ parsec start PROJ-2 --on PROJ-1</div>
+        </div>
+
         <!-- Feature 13: CI Dashboard -->
         <div class="feature-card reveal reveal-delay-1">
           <div class="feature-icon">

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -17,6 +17,7 @@ pub async fn start(
     ticket: &str,
     base: Option<&str>,
     title: Option<String>,
+    on: Option<&str>,
     mode: Mode,
 ) -> Result<()> {
     let config = ParsecConfig::load()?;
@@ -37,7 +38,7 @@ pub async fn start(
     };
 
     let manager = WorktreeManager::new(repo, &config)?;
-    let workspace = manager.create(ticket, base, ticket_title)?;
+    let workspace = manager.create(ticket, base, ticket_title, on)?;
 
     output::print_start(&workspace, mode);
 
@@ -947,7 +948,7 @@ pub async fn undo(repo: &Path, dry_run: bool, mode: Mode) -> Result<()> {
                 ],
             )?;
 
-            // Restore state
+            // Restore state (parent_ticket is lost on undo — acceptable)
             let workspace = crate::worktree::Workspace {
                 ticket: ticket.to_owned(),
                 path: worktree_path,
@@ -956,6 +957,7 @@ pub async fn undo(repo: &Path, dry_run: bool, mode: Mode) -> Result<()> {
                 created_at: chrono::Utc::now(),
                 ticket_title: undo_info.ticket_title.clone(),
                 status: crate::worktree::WorkspaceStatus::Active,
+                parent_ticket: None,
             };
 
             let mut state = crate::worktree::ParsecState::load(&repo_root)?;
@@ -977,6 +979,110 @@ pub async fn undo(repo: &Path, dry_run: bool, mode: Mode) -> Result<()> {
     oplog.save(&repo_root)?;
 
     output::print_undo(&last, mode);
+    Ok(())
+}
+
+pub async fn stack(repo: &Path, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config)?;
+    let workspaces = manager.list()?;
+
+    // Build the set of workspaces that are part of any stack:
+    // either they have a parent, or they ARE a parent of something.
+    let stacked: Vec<_> = workspaces
+        .iter()
+        .filter(|w| {
+            w.parent_ticket.is_some()
+                || workspaces
+                    .iter()
+                    .any(|other| other.parent_ticket.as_deref() == Some(&w.ticket))
+        })
+        .cloned()
+        .collect();
+
+    if stacked.is_empty() {
+        if mode == Mode::Human {
+            println!(
+                "No stacked worktrees. Use `parsec start <ticket> --on <parent>` to create a stack."
+            );
+        }
+        return Ok(());
+    }
+
+    output::print_stack(&stacked, mode);
+    Ok(())
+}
+
+pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config)?;
+    let workspaces = manager.list()?;
+
+    let mut synced = Vec::new();
+    let mut failed = Vec::new();
+
+    // Find roots: workspaces that have children but no parent themselves
+    let roots: Vec<_> = workspaces
+        .iter()
+        .filter(|w| {
+            w.parent_ticket.is_none()
+                && workspaces
+                    .iter()
+                    .any(|other| other.parent_ticket.as_deref() == Some(&w.ticket))
+        })
+        .collect();
+
+    if roots.is_empty() {
+        if mode == Mode::Human {
+            println!(
+                "No stacked worktrees to sync. Use `parsec start <ticket> --on <parent>` to create a stack."
+            );
+        }
+        return Ok(());
+    }
+
+    for root in &roots {
+        // First sync root with its base branch
+        if let Err(e) = git::run(&root.path, &["fetch", "origin", &root.base_branch]) {
+            failed.push((root.ticket.clone(), format!("fetch failed: {e}")));
+            continue;
+        }
+        let remote_base = format!("origin/{}", root.base_branch);
+        if let Err(e) = git::run(&root.path, &["rebase", &remote_base]) {
+            let _ = git::run(&root.path, &["rebase", "--abort"]);
+            failed.push((root.ticket.clone(), format!("rebase failed: {e}")));
+            continue;
+        }
+        synced.push(root.ticket.clone());
+
+        // Then rebase children onto their parent, in topological order
+        let mut queue: Vec<&str> = vec![&root.ticket];
+        while let Some(parent_ticket) = queue.first().copied() {
+            queue.remove(0);
+            let children: Vec<_> = workspaces
+                .iter()
+                .filter(|w| w.parent_ticket.as_deref() == Some(parent_ticket))
+                .collect();
+            for child in &children {
+                let parent_ws = workspaces
+                    .iter()
+                    .find(|w| w.ticket == parent_ticket)
+                    .unwrap();
+                if let Err(e) = git::run(&child.path, &["rebase", &parent_ws.branch]) {
+                    let _ = git::run(&child.path, &["rebase", "--abort"]);
+                    failed.push((
+                        child.ticket.clone(),
+                        format!("rebase onto {} failed: {e}", parent_ticket),
+                    ));
+                } else {
+                    synced.push(child.ticket.clone());
+                    queue.push(&child.ticket);
+                }
+            }
+        }
+    }
+
+    output::print_sync(&synced, &failed, "rebase (stack)", mode);
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,6 +49,10 @@ pub enum Command {
         /// Manually set the ticket title (skips tracker lookup)
         #[arg(long)]
         title: Option<String>,
+
+        /// Create stacked on another ticket's branch
+        #[arg(long)]
+        on: Option<String>,
     },
 
     /// List all active worktrees
@@ -254,6 +258,16 @@ pub enum Command {
         dry_run: bool,
     },
 
+    /// Show or manage stacked PR dependencies
+    ///
+    /// Displays the dependency graph of worktrees created with --on.
+    /// Use `parsec stack --sync` to rebase the entire chain.
+    Stack {
+        /// Sync the entire stack (rebase chain)
+        #[arg(long)]
+        sync: bool,
+    },
+
     /// Configure parsec
     ///
     /// Manage parsec configuration: run interactive setup, view current
@@ -318,7 +332,18 @@ pub async fn run(cli: Cli) -> Result<()> {
             ticket,
             base,
             title,
-        } => commands::start(&repo_path, &ticket, base.as_deref(), title, output_mode).await,
+            on,
+        } => {
+            commands::start(
+                &repo_path,
+                &ticket,
+                base.as_deref(),
+                title,
+                on.as_deref(),
+                output_mode,
+            )
+            .await
+        }
         Command::List => commands::list(&repo_path, output_mode).await,
         Command::Status { ticket } => {
             commands::status(&repo_path, ticket.as_deref(), output_mode).await
@@ -381,6 +406,13 @@ pub async fn run(cli: Cli) -> Result<()> {
             commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
         }
         Command::Undo { dry_run } => commands::undo(&repo_path, dry_run, output_mode).await,
+        Command::Stack { sync } => {
+            if sync {
+                commands::stack_sync(&repo_path, output_mode).await
+            } else {
+                commands::stack(&repo_path, output_mode).await
+            }
+        }
         Command::Config { action } => match action {
             ConfigAction::Init => commands::config_init(output_mode).await,
             ConfigAction::Show => commands::config_show(output_mode).await,

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -528,6 +528,72 @@ pub fn print_diff_stat(stat: &str, ticket: &str) {
     print!("{}", stat);
 }
 
+pub fn print_stack(workspaces: &[Workspace]) {
+    use std::collections::HashMap;
+
+    // Build parent -> children map
+    let mut children_map: HashMap<&str, Vec<&Workspace>> = HashMap::new();
+    let mut roots = Vec::new();
+
+    for ws in workspaces {
+        if let Some(parent) = &ws.parent_ticket {
+            children_map.entry(parent.as_str()).or_default().push(ws);
+        } else if workspaces
+            .iter()
+            .any(|other| other.parent_ticket.as_deref() == Some(&ws.ticket))
+        {
+            roots.push(ws);
+        }
+    }
+
+    println!("{}", "Stack dependency graph:".bold());
+
+    fn print_tree(
+        ws: &Workspace,
+        children_map: &HashMap<&str, Vec<&Workspace>>,
+        prefix: &str,
+        is_last: bool,
+    ) {
+        use colored::Colorize;
+        let connector = if prefix.is_empty() {
+            ""
+        } else if is_last {
+            "└── "
+        } else {
+            "├── "
+        };
+        let title = ws.ticket_title.as_deref().unwrap_or("");
+        println!(
+            "{}{}{}  {}",
+            prefix,
+            connector,
+            ws.ticket.bold().cyan(),
+            title.dimmed()
+        );
+
+        let child_prefix = if prefix.is_empty() {
+            String::new()
+        } else if is_last {
+            format!("{}    ", prefix)
+        } else {
+            format!("{}│   ", prefix)
+        };
+
+        if let Some(children) = children_map.get(ws.ticket.as_str()) {
+            for (i, child) in children.iter().enumerate() {
+                print_tree(child, children_map, &child_prefix, i == children.len() - 1);
+            }
+        }
+    }
+
+    for (i, root) in roots.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        print_tree(root, &children_map, "", true);
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig) {
     println!("{}", "[workspace]".bold());
     println!("  layout          = {}", config.workspace.layout);

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -146,6 +146,22 @@ pub fn print_diff_full(files: &[(String, String)], ticket: &str) {
     println!("{}", value);
 }
 
+pub fn print_stack(workspaces: &[Workspace]) {
+    let value: Vec<_> = workspaces
+        .iter()
+        .map(|ws| {
+            json!({
+                "ticket": ws.ticket,
+                "branch": ws.branch,
+                "base_branch": ws.base_branch,
+                "parent_ticket": ws.parent_ticket,
+                "title": ws.ticket_title,
+            })
+        })
+        .collect();
+    emit(&value);
+}
+
 pub fn print_undo(entry: &OpEntry) {
     let value = json!({
         "action": "undo",

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -147,6 +147,14 @@ pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)], mode: Mod
     }
 }
 
+pub fn print_stack(workspaces: &[Workspace], mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_stack(workspaces),
+        Mode::Human => human::print_stack(workspaces),
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig, mode: Mode) {
     match mode {
         Mode::Quiet => {}

--- a/src/worktree/lifecycle.rs
+++ b/src/worktree/lifecycle.rs
@@ -31,6 +31,8 @@ pub struct Workspace {
     pub created_at: DateTime<Utc>,
     pub ticket_title: Option<String>,
     pub status: WorkspaceStatus,
+    #[serde(default)]
+    pub parent_ticket: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -42,11 +42,20 @@ impl WorktreeManager {
         ticket: &str,
         base: Option<&str>,
         ticket_title: Option<String>,
+        parent_ticket: Option<&str>,
     ) -> Result<Workspace> {
         let base_branch = match base {
             Some(b) => b.to_owned(),
-            None => git::get_default_branch(&self.repo_root)
-                .context("failed to detect default branch")?,
+            None => {
+                if let Some(parent) = parent_ticket {
+                    // When stacking, use the parent's branch as base
+                    let parent_ws = self.get(parent)?;
+                    parent_ws.branch.clone()
+                } else {
+                    git::get_default_branch(&self.repo_root)
+                        .context("failed to detect default branch")?
+                }
+            }
         };
 
         let branch = format!("{}{}", self.config.workspace.branch_prefix, ticket);
@@ -89,6 +98,7 @@ impl WorktreeManager {
             created_at: Utc::now(),
             ticket_title,
             status: WorkspaceStatus::Active,
+            parent_ticket: parent_ticket.map(|s| s.to_owned()),
         };
 
         let mut state =
@@ -243,6 +253,7 @@ impl WorktreeManager {
             created_at: Utc::now(),
             ticket_title,
             status: WorkspaceStatus::Active,
+            parent_ticket: None,
         };
 
         state.add_workspace(workspace.clone());


### PR DESCRIPTION
## Summary
- Add `--on <parent-ticket>` flag to `parsec start` for creating dependent worktree chains
- Add `parsec stack` command to display the dependency graph as a tree
- Add `parsec stack --sync` to rebase the entire stack in topological order
- Stacked worktrees automatically use the parent's branch as the PR base when shipped

## Changes
- `src/worktree/lifecycle.rs`: Added `parent_ticket: Option<String>` field to `Workspace` struct (backward-compatible via `#[serde(default)]`)
- `src/worktree/manager.rs`: Modified `create()` to accept `parent_ticket` param; when `--on` is used, the parent's branch becomes the base
- `src/cli/mod.rs`: Added `--on` flag to `Start` variant, added `Stack` command variant with `--sync` flag, updated routing
- `src/cli/commands.rs`: Modified `start()` to pass `on` param, added `stack()` and `stack_sync()` command handlers
- `src/output/mod.rs`: Added `print_stack()` dispatcher
- `src/output/human.rs`: Added `print_stack()` with tree visualization (connectors, colors)
- `src/output/json.rs`: Added `print_stack()` JSON output
- `README.md`: Added `parsec stack` documentation section, updated `parsec start` with `--on` option, added stacked PRs to features list
- `docs/index.html`: Added Stacked PRs feature card

## Test plan
- [ ] `cargo build` passes with no errors
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo fmt --check` passes
- [ ] Create a stack: `parsec start T1`, `parsec start T2 --on T1`, `parsec start T3 --on T2`
- [ ] `parsec stack` shows correct tree graph
- [ ] `parsec stack --json` outputs structured JSON
- [ ] `parsec stack --sync` rebases children onto parents in order
- [ ] `parsec ship T2` creates PR with `feature/T1` as base branch (not main)
- [ ] Existing state files without `parent_ticket` deserialize correctly (serde default)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)