### PR TITLE
feat: parsec start --branch for existing branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Removed 1 worktree(s):
 - **Conflict detection** -- Warns when multiple workspaces modify the same files
 - **One-step shipping** -- `parsec ship` pushes, creates a GitHub PR or GitLab MR, and cleans up
 - **Adopt existing branches** -- Import branches already in progress with `parsec adopt`
+- **Attach to existing branches** -- Start a workspace from an existing local or remote branch with `--branch`
 - **Operation history and undo** -- `parsec log` shows what happened, `parsec undo` reverts it
 - **Keep branches fresh** -- `parsec sync` rebases or merges the latest base branch into any worktree
 - **Agent-friendly output** -- `--json` flag on every command for machine consumption
@@ -126,7 +127,7 @@ $ parsec log
 Create an isolated worktree for a ticket. Fetches the ticket title from your configured tracker (Jira, GitHub Issues) or accepts a manual title.
 
 ```
-parsec start <ticket> [--base <branch>] [--title "text"] [--on <parent-ticket>]
+parsec start <ticket> [--base <branch>] [--title "text"] [--on <parent-ticket>] [--branch <name>]
 ```
 
 | Option | Description |
@@ -134,6 +135,7 @@ parsec start <ticket> [--base <branch>] [--title "text"] [--on <parent-ticket>]
 | `-b, --base <branch>` | Base branch to create from (default: main/master) |
 | `--title "text"` | Set ticket title manually, skip tracker lookup |
 | `--on <ticket>` | Stack on another ticket's branch (for dependent PRs) |
+| `--branch <name>` | Use an existing branch instead of creating a new one |
 
 ```bash
 # With Jira integration (title auto-fetched)
@@ -152,6 +154,12 @@ Created workspace for 42 at /home/user/myapp.42
 
 # From a specific base branch
 $ parsec start PROJ-99 --base release/2.0
+
+# Attach to an existing branch (local or remote)
+$ parsec start CL-2208 --branch feature/CL-2208
+
+# Attach to a remote-only branch (auto-fetches and tracks)
+$ parsec start CL-2208 --branch origin/feature/CL-2208
 ```
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -1656,6 +1656,18 @@
           <div class="feature-code">$ parsec adopt PROJ-99 --branch fix/payment-timeout</div>
         </div>
 
+        <!-- Feature: Attach to Existing Branch -->
+        <div class="feature-card reveal reveal-delay-3">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"/></svg>
+          </div>
+          <h3>Attach to Existing Branch</h3>
+          <p>
+            Need to work on a branch that already exists? <code>parsec start --branch</code> creates a managed worktree from any local or remote branch. Fetches remote-only branches automatically.
+          </p>
+          <div class="feature-code">$ parsec start CL-2208 --branch feature/CL-2208</div>
+        </div>
+
         <!-- Feature 9: Operation History -->
         <div class="feature-card reveal reveal-delay-3">
           <div class="feature-icon">
@@ -1853,6 +1865,14 @@
             </tr>
             <tr>
               <td>Adopt existing branches</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Attach to existing branch</td>
               <td class="highlight"><span class="check">Yes</span></td>
               <td><span class="cross">--</span></td>
               <td><span class="cross">--</span></td>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -18,6 +18,7 @@ pub async fn start(
     base: Option<&str>,
     title: Option<String>,
     on: Option<&str>,
+    existing_branch: Option<&str>,
     mode: Mode,
 ) -> Result<()> {
     let config = ParsecConfig::load()?;
@@ -38,7 +39,7 @@ pub async fn start(
     };
 
     let manager = WorktreeManager::new(repo, &config)?;
-    let workspace = manager.create(ticket, base, ticket_title, on)?;
+    let workspace = manager.create(ticket, base, ticket_title, on, existing_branch)?;
 
     output::print_start(&workspace, mode);
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -53,6 +53,10 @@ pub enum Command {
         /// Create stacked on another ticket's branch
         #[arg(long)]
         on: Option<String>,
+
+        /// Use an existing branch instead of creating a new one
+        #[arg(long = "branch")]
+        existing_branch: Option<String>,
     },
 
     /// List all active worktrees
@@ -333,6 +337,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             base,
             title,
             on,
+            existing_branch,
         } => {
             commands::start(
                 &repo_path,
@@ -340,6 +345,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 base.as_deref(),
                 title,
                 on.as_deref(),
+                existing_branch.as_deref(),
                 output_mode,
             )
             .await

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -153,6 +153,58 @@ pub fn worktree_add(repo: &Path, path: &Path, branch: &str, base: &str) -> Resul
     run(repo, &["worktree", "add", "-b", branch, path_str, base])
 }
 
+/// Create a worktree at `path` for an already-existing branch.
+/// If the branch only exists on the remote, it is fetched and tracked locally first.
+pub fn worktree_add_existing(repo: &Path, path: &Path, branch: &str) -> Result<()> {
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| anyhow!("worktree path is not valid UTF-8: {:?}", path))?;
+
+    // Check if branch exists locally
+    let local_exists = run_output(
+        repo,
+        &["rev-parse", "--verify", &format!("refs/heads/{}", branch)],
+    )
+    .is_ok();
+
+    if local_exists {
+        return run(repo, &["worktree", "add", path_str, branch]);
+    }
+
+    // Check if it exists on remote (handle "origin/branch" syntax too)
+    let remote_ref = if branch.starts_with("origin/") {
+        branch.to_owned()
+    } else {
+        format!("origin/{}", branch)
+    };
+
+    let remote_exists = run_output(
+        repo,
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("refs/remotes/{}", remote_ref),
+        ],
+    )
+    .is_ok();
+
+    if remote_exists {
+        // Strip "origin/" prefix for the local branch name
+        let local_name = branch.strip_prefix("origin/").unwrap_or(branch);
+        // Create local tracking branch and worktree in one step
+        run(
+            repo,
+            &["worktree", "add", "-b", local_name, path_str, &remote_ref],
+        )
+    } else {
+        Err(anyhow!(
+            "branch '{}' not found locally or on remote. Use `parsec start {}` without --branch to create a new branch.",
+            branch,
+            branch.strip_prefix("origin/").unwrap_or(branch)
+        ))
+    }
+}
+
 /// Remove the worktree rooted at `path`.
 pub fn worktree_remove(repo: &Path, path: &Path) -> Result<()> {
     let path_str = path

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -43,6 +43,7 @@ impl WorktreeManager {
         base: Option<&str>,
         ticket_title: Option<String>,
         parent_ticket: Option<&str>,
+        existing_branch: Option<&str>,
     ) -> Result<Workspace> {
         let base_branch = match base {
             Some(b) => b.to_owned(),
@@ -58,7 +59,6 @@ impl WorktreeManager {
             }
         };
 
-        let branch = format!("{}{}", self.config.workspace.branch_prefix, ticket);
         let worktree_path = match self.config.workspace.layout {
             crate::config::WorktreeLayout::Sibling => {
                 // ../reponame.ticket/
@@ -81,14 +81,27 @@ impl WorktreeManager {
         // Graceful fetch — won't fail if no remote exists
         git::fetch_if_remote(&self.repo_root)?;
 
-        git::worktree_add(&self.repo_root, &worktree_path, &branch, &base_branch).with_context(
-            || {
+        let branch = if let Some(eb) = existing_branch {
+            // Use an existing branch — resolve the local name
+            let local_name = eb.strip_prefix("origin/").unwrap_or(eb).to_owned();
+            git::worktree_add_existing(&self.repo_root, &worktree_path, eb).with_context(|| {
                 format!(
-                    "failed to create worktree for ticket '{}' at {:?}",
-                    ticket, worktree_path
+                    "failed to create worktree from existing branch '{}' for ticket '{}' at {:?}",
+                    eb, ticket, worktree_path
                 )
-            },
-        )?;
+            })?;
+            local_name
+        } else {
+            let branch = format!("{}{}", self.config.workspace.branch_prefix, ticket);
+            git::worktree_add(&self.repo_root, &worktree_path, &branch, &base_branch)
+                .with_context(|| {
+                    format!(
+                        "failed to create worktree for ticket '{}' at {:?}",
+                        ticket, worktree_path
+                    )
+                })?;
+            branch
+        };
 
         let workspace = Workspace {
             ticket: ticket.to_owned(),


### PR DESCRIPTION
## Summary
- Add `--branch` flag to `parsec start` that creates a worktree from an existing local or remote branch instead of creating a new one
- If the branch exists only on remote, it is automatically fetched and tracked locally
- If the branch doesn't exist anywhere, a clear error is shown

Closes #46

## Changes
- `src/git/mod.rs` — New `worktree_add_existing()` function handling local/remote branch resolution
- `src/worktree/manager.rs` — `create()` accepts `existing_branch` parameter
- `src/cli/mod.rs` — `--branch` flag on `Start` command variant
- `src/cli/commands.rs` — Pass `existing_branch` through to manager
- `README.md` — Updated docs with `--branch` examples
- `docs/index.html` — Added feature card and comparison table row

## Usage
```bash
# Attach to a local branch
parsec start CL-2208 --branch feature/CL-2208

# Attach to a remote-only branch (auto-fetches)
parsec start CL-2208 --branch origin/feature/CL-2208
```

## Test plan
- [ ] `parsec start TEST-1 --branch <existing-local-branch>` creates worktree correctly
- [ ] `parsec start TEST-2 --branch <remote-only-branch>` fetches and creates worktree
- [ ] `parsec start TEST-3 --branch nonexistent` gives clear error
- [ ] `cargo build && cargo clippy && cargo fmt --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)