### PR TITLE
chore: bump version to 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager — ticket to PR in one command. Parallel AI agent workflows with Jira & GitHub Issues integration."

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,7 @@
     "description": "Git worktree lifecycle manager for parallel AI agent workflows. Create isolated workspaces from ticket IDs (Jira, GitHub Issues, GitLab), work in parallel without lock conflicts, ship with one command (push + PR + cleanup). Supports CI monitoring, stacked PRs, conflict detection, and operation history with undo.",
     "url": "https://erishforg.github.io/git-parsec/",
     "downloadUrl": "https://crates.io/crates/git-parsec",
-    "softwareVersion": "0.2.3",
+    "softwareVersion": "0.2.4",
     "author": {
       "@type": "Person",
       "name": "erishforG",


### PR DESCRIPTION
## Summary
- Bump version from 0.2.3 to 0.2.4
- Update softwareVersion in docs/index.html

## What's new in 0.2.4
- `parsec ci` — CI/CD pipeline status with watch mode
- `parsec merge` — merge PRs from terminal with CI wait
- `parsec diff` — view worktree changes vs base branch
- `parsec stack` — stacked PR dependency tracking
- `parsec start --branch` — attach to existing branches
- SEO and AI search discoverability improvements

After merging to develop, a follow-up PR to master will trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)