### PR TITLE
Release v0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager — ticket to PR in one command. Parallel AI agent workflows with Jira & GitHub Issues integration."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ name = "git-parsec"
 version = "0.2.3"
 edition = "2021"
 authors = ["erishforG"]
-description = "Git worktree lifecycle manager for parallel AI agent workflows with ticket tracker integration"
+description = "Git worktree lifecycle manager — ticket to PR in one command. Parallel AI agent workflows with Jira & GitHub Issues integration."
 license = "MIT"
 repository = "https://github.com/erishforG/git-parsec"
 homepage = "https://erishforg.github.io/git-parsec/"
-keywords = ["git", "worktree", "parallel", "ai", "workflow"]
+keywords = ["git", "worktree", "cli", "jira", "github"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 ![demo](demo.gif)
 
+## What is parsec?
+
+**parsec** is a command-line tool (CLI) that automates the full lifecycle of git worktrees: create an isolated workspace from a ticket ID, work in parallel without lock conflicts, then push + create PR + clean up in one command. It integrates with **Jira**, **GitHub Issues**, and **GitLab Issues** for automatic ticket title lookup, and supports **GitHub** and **GitLab** for PR/MR creation.
+
+Unlike plain `git worktree`, parsec tracks workspace state, detects file conflicts across worktrees, provides operation history with undo, supports stacked PRs, and offers CI status monitoring — all from a single CLI.
+
+**Key use cases:**
+- Run multiple AI coding agents on the same repo simultaneously (no `index.lock` conflicts)
+- Work on several tickets in parallel as a developer without stashing or switching branches
+- Ship complete features (push + PR + cleanup) with one command
+- Monitor CI, merge PRs, and manage stacked dependencies from the terminal
+
 ## The Problem
 
 Git uses a single working directory with a single `index.lock`. When multiple AI agents (or developers) try to work on the same repo simultaneously:

--- a/README.md
+++ b/README.md
@@ -534,6 +534,44 @@ $ parsec ci PROJ-1234 --json
 ```
 
 Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
+
+---
+
+### `parsec merge [ticket] [--rebase] [--no-wait] [--no-delete-branch]`
+
+Merge a ticket's PR directly from the terminal. Waits for CI to pass before merging, then cleans up the local worktree.
+
+```
+parsec merge [ticket] [--rebase] [--no-wait] [--no-delete-branch]
+```
+
+| Option | Description |
+|--------|-------------|
+| `ticket` | Ticket identifier (auto-detects current worktree if omitted) |
+| `--rebase` | Use rebase merge instead of squash (default: squash) |
+| `--no-wait` | Skip CI check before merging |
+| `--no-delete-branch` | Keep remote branch after merge |
+
+```bash
+# Squash merge (default)
+$ parsec merge PROJ-1234
+Waiting for CI to pass... ✓
+Merged PR #42 for PROJ-1234!
+  Method: squash
+  SHA:    a1b2c3d
+
+# Rebase merge
+$ parsec merge PROJ-1234 --rebase
+
+# Skip CI wait
+$ parsec merge PROJ-1234 --no-wait
+
+# JSON output
+$ parsec merge PROJ-1234 --json
+```
+
+Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
+
 ---
 
 ### `parsec config`

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Removed 1 worktree(s):
 - **Status dashboard** -- See all parallel work at a glance
 - **Auto-cleanup** -- Remove worktrees for merged branches automatically
 - **GitHub and GitLab** -- PR and MR creation for both platforms
+- **Stacked PRs** -- Create dependent PR chains with `--on` and sync the entire stack
 
 ## Installation
 
@@ -125,13 +126,14 @@ $ parsec log
 Create an isolated worktree for a ticket. Fetches the ticket title from your configured tracker (Jira, GitHub Issues) or accepts a manual title.
 
 ```
-parsec start <ticket> [--base <branch>] [--title "text"]
+parsec start <ticket> [--base <branch>] [--title "text"] [--on <parent-ticket>]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `-b, --base <branch>` | Base branch to create from (default: main/master) |
 | `--title "text"` | Set ticket title manually, skip tracker lookup |
+| `--on <ticket>` | Stack on another ticket's branch (for dependent PRs) |
 
 ```bash
 # With Jira integration (title auto-fetched)
@@ -600,6 +602,42 @@ $ parsec diff --name-only
 
 # JSON output (changed files list)
 $ parsec diff PROJ-1234 --json
+```
+
+---
+
+### `parsec stack [--sync]`
+
+View and manage stacked PR dependencies. Worktrees created with `--on` form a dependency chain.
+
+```
+parsec stack [--sync]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--sync` | Rebase the entire stack chain |
+
+```bash
+# Create a stack
+$ parsec start PROJ-1 --title "Add models"
+$ parsec start PROJ-2 --on PROJ-1 --title "Add API endpoints"
+$ parsec start PROJ-3 --on PROJ-2 --title "Add frontend"
+
+# View the dependency graph
+$ parsec stack
+Stack dependency graph:
+└── PROJ-1 Add models
+    └── PROJ-2 Add API endpoints
+        └── PROJ-3 Add frontend
+
+# Sync the entire stack
+$ parsec stack --sync
+
+# Ship creates PRs with correct base branches
+$ parsec ship PROJ-1   # PR to main
+$ parsec ship PROJ-2   # PR to feature/PROJ-1
+$ parsec ship PROJ-3   # PR to feature/PROJ-2
 ```
 ---
 

--- a/README.md
+++ b/README.md
@@ -574,6 +574,35 @@ Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
 
 ---
 
+### `parsec diff [ticket] [--stat] [--name-only]`
+
+View changes in a worktree compared to its base branch. Uses merge-base for accurate comparison.
+
+```
+parsec diff [ticket] [--stat] [--name-only]
+```
+
+| Option | Description |
+|--------|-------------|
+| `ticket` | Ticket identifier (auto-detects current worktree if omitted) |
+| `--stat` | Show file-level summary only |
+| `--name-only` | List changed file names only |
+
+```bash
+# Full diff for current worktree
+$ parsec diff
+
+# File summary
+$ parsec diff PROJ-1234 --stat
+
+# Just file names
+$ parsec diff --name-only
+
+# JSON output (changed files list)
+$ parsec diff PROJ-1234 --json
+```
+---
+
 ### `parsec config`
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Removed 1 worktree(s):
 - **Conflict detection** -- Warns when multiple workspaces modify the same files
 - **One-step shipping** -- `parsec ship` pushes, creates a GitHub PR or GitLab MR, and cleans up
 - **Adopt existing branches** -- Import branches already in progress with `parsec adopt`
+- **Attach to existing branches** -- Start a workspace from an existing local or remote branch with `--branch`
 - **Operation history and undo** -- `parsec log` shows what happened, `parsec undo` reverts it
 - **Keep branches fresh** -- `parsec sync` rebases or merges the latest base branch into any worktree
 - **Agent-friendly output** -- `--json` flag on every command for machine consumption
@@ -126,7 +127,7 @@ $ parsec log
 Create an isolated worktree for a ticket. Fetches the ticket title from your configured tracker (Jira, GitHub Issues) or accepts a manual title.
 
 ```
-parsec start <ticket> [--base <branch>] [--title "text"] [--on <parent-ticket>]
+parsec start <ticket> [--base <branch>] [--title "text"] [--on <parent-ticket>] [--branch <name>]
 ```
 
 | Option | Description |
@@ -134,6 +135,7 @@ parsec start <ticket> [--base <branch>] [--title "text"] [--on <parent-ticket>]
 | `-b, --base <branch>` | Base branch to create from (default: main/master) |
 | `--title "text"` | Set ticket title manually, skip tracker lookup |
 | `--on <ticket>` | Stack on another ticket's branch (for dependent PRs) |
+| `--branch <name>` | Use an existing branch instead of creating a new one |
 
 ```bash
 # With Jira integration (title auto-fetched)
@@ -152,6 +154,12 @@ Created workspace for 42 at /home/user/myapp.42
 
 # From a specific base branch
 $ parsec start PROJ-99 --base release/2.0
+
+# Attach to an existing branch (local or remote)
+$ parsec start CL-2208 --branch feature/CL-2208
+
+# Attach to a remote-only branch (auto-fetches and tracks)
+$ parsec start CL-2208 --branch origin/feature/CL-2208
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -493,6 +493,49 @@ $ parsec pr-status PROJ-1234 --json
 Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
 ---
 
+### `parsec ci [ticket] [--watch] [--all]`
+
+Check CI/CD pipeline status for a ticket's PR. Shows individual check runs with status, duration, and an overall summary.
+
+```
+parsec ci [ticket] [--watch] [--all]
+```
+
+| Option | Description |
+|--------|-------------|
+| `ticket` | Ticket identifier (auto-detects current worktree if omitted) |
+| `--watch` | Poll CI every 5s until all checks complete |
+| `--all` | Show CI for all shipped PRs |
+
+```bash
+# Auto-detect from current worktree
+$ parsec ci
+CI for PROJ-1234 (PR #42, a1b2c3d)
+┌────────────┬───────────┬──────────┐
+│ Check      │ Status    │ Duration │
+├────────────┼───────────┼──────────┤
+│ Tests      │ ✓ passed  │ 2m 15s   │
+│ Build      │ ✓ passed  │ 1m 42s   │
+│ Lint       │ ● running │ running… │
+└────────────┴───────────┴──────────┘
+✓ CI: 2/3 — 2 passed, 1 running
+
+# Check a specific ticket
+$ parsec ci PROJ-1234
+
+# Watch mode — refreshes every 5s until done
+$ parsec ci PROJ-1234 --watch
+
+# All shipped PRs
+$ parsec ci --all
+
+# JSON output
+$ parsec ci PROJ-1234 --json
+```
+
+Requires: `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`)
+---
+
 ### `parsec config`
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1704,6 +1704,18 @@
           <div class="feature-code">$ parsec pr-status PROJ-1234</div>
         </div>
 
+        <!-- Feature: Stacked PRs -->
+        <div class="feature-card featured reveal reveal-delay-1">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/></svg>
+          </div>
+          <h3>Stacked PRs</h3>
+          <p>
+            Create dependent PR chains with <code>--on</code>. <code>parsec stack</code> shows the dependency graph and <code>--sync</code> rebases the entire chain.
+          </p>
+          <div class="feature-code">$ parsec start PROJ-2 --on PROJ-1</div>
+        </div>
+
         <!-- Feature 13: CI Dashboard -->
         <div class="feature-card reveal reveal-delay-1">
           <div class="feature-icon">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1703,6 +1703,18 @@
           </p>
           <div class="feature-code">$ parsec pr-status PROJ-1234</div>
         </div>
+
+        <!-- Feature 13: CI Dashboard -->
+        <div class="feature-card reveal reveal-delay-1">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+          </div>
+          <h3>CI Pipeline Dashboard</h3>
+          <p>
+            <code>parsec ci</code> shows individual check runs, durations, and overall status. Use <code>--watch</code> to poll until completion.
+          </p>
+          <div class="feature-code">$ parsec ci --watch</div>
+        </div>
       </div>
     </div>
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,75 @@
   <!-- Canonical -->
   <link rel="canonical" href="https://erishforg.github.io/git-parsec/">
   <meta name="theme-color" content="#0a0e1a">
+  <!-- Schema.org Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "git-parsec",
+    "alternateName": "parsec",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "macOS, Linux, Windows",
+    "description": "Git worktree lifecycle manager for parallel AI agent workflows. Create isolated workspaces from ticket IDs (Jira, GitHub Issues, GitLab), work in parallel without lock conflicts, ship with one command (push + PR + cleanup). Supports CI monitoring, stacked PRs, conflict detection, and operation history with undo.",
+    "url": "https://erishforg.github.io/git-parsec/",
+    "downloadUrl": "https://crates.io/crates/git-parsec",
+    "softwareVersion": "0.2.3",
+    "author": {
+      "@type": "Person",
+      "name": "erishforG",
+      "url": "https://github.com/erishforG"
+    },
+    "codeRepository": "https://github.com/erishforG/git-parsec",
+    "programmingLanguage": "Rust",
+    "license": "https://opensource.org/licenses/MIT",
+    "keywords": ["git", "worktree", "CLI", "Jira", "GitHub Issues", "GitLab", "parallel development", "AI agents", "developer tools", "pull request", "CI/CD", "stacked PRs", "git worktree manager"],
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is git-parsec?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "git-parsec (parsec) is a command-line tool that manages the full lifecycle of git worktrees tied to issue tickets. It creates isolated workspaces from ticket IDs, enables parallel development without lock conflicts, and ships features with one command (push + PR/MR + cleanup). It integrates with Jira, GitHub Issues, and GitLab."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does parsec differ from git worktree?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Plain git worktree only creates and removes worktrees. parsec adds full lifecycle management: ticket tracker integration (Jira, GitHub Issues, GitLab), one-step shipping (push + PR + cleanup), cross-worktree conflict detection, operation history with undo, CI status monitoring, stacked PR support, and machine-readable JSON output for AI agents."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can multiple AI agents use parsec on the same repository?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Each parsec workspace is a separate git worktree with its own index, so multiple AI agents (or developers) can run git add, commit, and push simultaneously without index.lock conflicts. parsec also detects when multiple workspaces modify the same files."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I install parsec?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Install via cargo: cargo install git-parsec. Or build from source: git clone https://github.com/erishforG/git-parsec.git && cd git-parsec && cargo build --release. The binary is at ./target/release/parsec."
+        }
+      }
+    ]
+  }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@400;500;600;700;800;900&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,7 @@
     "description": "Git worktree lifecycle manager for parallel AI agent workflows. Create isolated workspaces from ticket IDs (Jira, GitHub Issues, GitLab), work in parallel without lock conflicts, ship with one command (push + PR + cleanup). Supports CI monitoring, stacked PRs, conflict detection, and operation history with undo.",
     "url": "https://erishforg.github.io/git-parsec/",
     "downloadUrl": "https://crates.io/crates/git-parsec",
-    "softwareVersion": "0.2.3",
+    "softwareVersion": "0.2.4",
     "author": {
       "@type": "Person",
       "name": "erishforG",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1656,6 +1656,18 @@
           <div class="feature-code">$ parsec adopt PROJ-99 --branch fix/payment-timeout</div>
         </div>
 
+        <!-- Feature: Attach to Existing Branch -->
+        <div class="feature-card reveal reveal-delay-3">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"/></svg>
+          </div>
+          <h3>Attach to Existing Branch</h3>
+          <p>
+            Need to work on a branch that already exists? <code>parsec start --branch</code> creates a managed worktree from any local or remote branch. Fetches remote-only branches automatically.
+          </p>
+          <div class="feature-code">$ parsec start CL-2208 --branch feature/CL-2208</div>
+        </div>
+
         <!-- Feature 9: Operation History -->
         <div class="feature-card reveal reveal-delay-3">
           <div class="feature-icon">
@@ -1853,6 +1865,14 @@
             </tr>
             <tr>
               <td>Adopt existing branches</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Attach to existing branch</td>
               <td class="highlight"><span class="check">Yes</span></td>
               <td><span class="cross">--</span></td>
               <td><span class="cross">--</span></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1727,6 +1727,18 @@
           </p>
           <div class="feature-code">$ parsec merge PROJ-1234</div>
         </div>
+
+        <!-- Feature 15: Worktree Diff -->
+        <div class="feature-card reveal reveal-delay-3">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M12 20V10"/><path d="M18 20V4"/><path d="M6 20v-4"/></svg>
+          </div>
+          <h3>Worktree Diff</h3>
+          <p>
+            <code>parsec diff</code> shows changes in any worktree compared to its base branch. Supports <code>--stat</code> and <code>--name-only</code> views.
+          </p>
+          <div class="feature-code">$ parsec diff --stat</div>
+        </div>
       </div>
     </div>
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1715,6 +1715,18 @@
           </p>
           <div class="feature-code">$ parsec ci --watch</div>
         </div>
+
+        <!-- Feature 14: Merge from Terminal -->
+        <div class="feature-card reveal reveal-delay-2">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/><path d="M9 18l6-6-6-6" transform="translate(6,0)"/></svg>
+          </div>
+          <h3>Merge from Terminal</h3>
+          <p>
+            <code>parsec merge</code> merges PRs directly from your terminal. Waits for CI to pass, supports squash and rebase, and cleans up automatically.
+          </p>
+          <div class="feature-code">$ parsec merge PROJ-1234</div>
+        </div>
       </div>
     </div>
   </section>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -660,6 +660,67 @@ pub async fn ci(
     }
 }
 
+pub async fn diff(
+    repo: &Path,
+    ticket: Option<&str>,
+    stat: bool,
+    name_only: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config)?;
+
+    // Resolve workspace
+    let ws = if let Some(t) = ticket {
+        manager.get(t)?
+    } else {
+        let cwd = std::env::current_dir()?;
+        let all_ws = manager.list()?;
+        all_ws
+            .into_iter()
+            .find(|w| cwd.starts_with(&w.path))
+            .ok_or_else(|| anyhow::anyhow!("not inside a parsec worktree. Specify a ticket."))?
+    };
+
+    // Find merge base
+    let merge_base = git::run_output(
+        &ws.path,
+        &["merge-base", &format!("origin/{}", ws.base_branch), "HEAD"],
+    )?;
+    let merge_base = merge_base.trim();
+
+    if name_only {
+        let output = git::run_output(&ws.path, &["diff", "--name-only", merge_base])?;
+        let files: Vec<String> = output.lines().map(|l| l.to_string()).collect();
+        output::print_diff_names(&files, &ws.ticket, mode);
+    } else if stat {
+        let output = git::run_output(&ws.path, &["diff", "--stat", merge_base])?;
+        output::print_diff_stat(&output, &ws.ticket, mode);
+    } else {
+        // Full diff — just pass through to terminal in human mode
+        if mode == Mode::Json {
+            let output = git::run_output(&ws.path, &["diff", "--name-status", merge_base])?;
+            let files: Vec<(String, String)> = output
+                .lines()
+                .filter_map(|l| {
+                    let mut parts = l.splitn(2, '\t');
+                    let status = parts.next()?.to_string();
+                    let file = parts.next()?.to_string();
+                    Some((status, file))
+                })
+                .collect();
+            output::print_diff_full_json(&files, &ws.ticket);
+        } else if mode == Mode::Human {
+            // Pass through with color
+            let _ = std::process::Command::new("git")
+                .args(["diff", "--color=always", merge_base])
+                .current_dir(&ws.path)
+                .status();
+        }
+    }
+    Ok(())
+}
+
 pub async fn conflicts(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -393,6 +393,130 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
     Ok(())
 }
 
+pub async fn ci(
+    repo: &Path,
+    ticket: Option<&str>,
+    watch: bool,
+    all: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let remote_url = git::run_output(repo, &["remote", "get-url", "origin"])?;
+    let oplog = crate::oplog::OpLog::load(&repo_root)?;
+    let manager = WorktreeManager::new(repo, &config)?;
+
+    // Collect (ticket_id, pr_number) pairs to check
+    let mut targets: Vec<(String, u64)> = Vec::new();
+
+    if all {
+        // All shipped entries with PR numbers from oplog
+        let entries: Vec<_> = oplog
+            .get_entries(None)
+            .into_iter()
+            .filter(|e| matches!(e.op, crate::oplog::OpKind::Ship))
+            .filter_map(|e| {
+                let url = e.detail.split(" -> ").nth(1)?;
+                let number = url.rsplit('/').next()?.parse::<u64>().ok()?;
+                Some((e.ticket.clone().unwrap_or_default(), number))
+            })
+            .collect();
+        if entries.is_empty() {
+            anyhow::bail!("no shipped PRs found. Ship a ticket first with `parsec ship`.");
+        }
+        targets = entries;
+    } else {
+        // Resolve which ticket to look up
+        let ticket_id = if let Some(t) = ticket {
+            t.to_string()
+        } else {
+            // Auto-detect from current worktree
+            let cwd = std::env::current_dir()?;
+            let all_ws = manager.list()?;
+            let found = all_ws
+                .into_iter()
+                .find(|w| cwd.starts_with(&w.path))
+                .ok_or_else(|| {
+                    anyhow::anyhow!("not inside a parsec worktree. Specify a ticket or use --all.")
+                })?;
+            found.ticket
+        };
+
+        // First check if there's a shipped PR in the oplog
+        let shipped_pr = oplog
+            .get_entries(Some(&ticket_id))
+            .into_iter()
+            .rev()
+            .filter(|e| matches!(e.op, crate::oplog::OpKind::Ship))
+            .find_map(|e| {
+                let url = e.detail.split(" -> ").nth(1)?;
+                url.rsplit('/').next()?.parse::<u64>().ok()
+            });
+
+        if let Some(pr_number) = shipped_pr {
+            targets.push((ticket_id, pr_number));
+        } else {
+            // Not shipped yet — try to find an open PR by branch name
+            let ws = manager.get(&ticket_id).with_context(|| {
+                format!("ticket {ticket_id} not found in active workspaces or oplog")
+            })?;
+            match github::find_pr_by_branch(&remote_url, &ws.branch).await? {
+                Some(pr_number) => targets.push((ticket_id, pr_number)),
+                None => {
+                    anyhow::bail!(
+                        "no PR found for {ticket_id}. Push and create a PR first, or ship with `parsec ship {ticket_id}`."
+                    );
+                }
+            }
+        }
+    }
+
+    loop {
+        let mut statuses: Vec<(String, crate::github::CiStatus)> = Vec::new();
+
+        for (ticket_id, pr_number) in &targets {
+            match github::get_check_runs(&remote_url, *pr_number).await? {
+                Some(ci) => statuses.push((ticket_id.clone(), ci)),
+                None => {
+                    anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
+                }
+            }
+        }
+
+        // In watch + human mode, clear screen before redraw
+        if watch && mode == Mode::Human {
+            print!("\x1B[2J\x1B[H");
+        }
+
+        output::print_ci_status(&statuses, mode);
+
+        if !watch || mode != Mode::Human {
+            // JSON/quiet mode prints once even with --watch
+            // Determine exit code based on overall status
+            let has_failure = statuses.iter().any(|(_t, ci)| ci.overall == "failing");
+            if has_failure {
+                std::process::exit(1);
+            }
+            return Ok(());
+        }
+
+        // Check if all checks are completed
+        let all_completed = statuses
+            .iter()
+            .all(|(_t, ci)| ci.checks.iter().all(|c| c.status == "completed"));
+
+        if all_completed {
+            let has_failure = statuses.iter().any(|(_t, ci)| ci.overall == "failing");
+            if has_failure {
+                std::process::exit(1);
+            }
+            return Ok(());
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+}
+
 pub async fn conflicts(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -17,6 +17,7 @@ pub async fn start(
     ticket: &str,
     base: Option<&str>,
     title: Option<String>,
+    on: Option<&str>,
     mode: Mode,
 ) -> Result<()> {
     let config = ParsecConfig::load()?;
@@ -37,7 +38,7 @@ pub async fn start(
     };
 
     let manager = WorktreeManager::new(repo, &config)?;
-    let workspace = manager.create(ticket, base, ticket_title)?;
+    let workspace = manager.create(ticket, base, ticket_title, on)?;
 
     output::print_start(&workspace, mode);
 
@@ -947,7 +948,7 @@ pub async fn undo(repo: &Path, dry_run: bool, mode: Mode) -> Result<()> {
                 ],
             )?;
 
-            // Restore state
+            // Restore state (parent_ticket is lost on undo — acceptable)
             let workspace = crate::worktree::Workspace {
                 ticket: ticket.to_owned(),
                 path: worktree_path,
@@ -956,6 +957,7 @@ pub async fn undo(repo: &Path, dry_run: bool, mode: Mode) -> Result<()> {
                 created_at: chrono::Utc::now(),
                 ticket_title: undo_info.ticket_title.clone(),
                 status: crate::worktree::WorkspaceStatus::Active,
+                parent_ticket: None,
             };
 
             let mut state = crate::worktree::ParsecState::load(&repo_root)?;
@@ -977,6 +979,110 @@ pub async fn undo(repo: &Path, dry_run: bool, mode: Mode) -> Result<()> {
     oplog.save(&repo_root)?;
 
     output::print_undo(&last, mode);
+    Ok(())
+}
+
+pub async fn stack(repo: &Path, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config)?;
+    let workspaces = manager.list()?;
+
+    // Build the set of workspaces that are part of any stack:
+    // either they have a parent, or they ARE a parent of something.
+    let stacked: Vec<_> = workspaces
+        .iter()
+        .filter(|w| {
+            w.parent_ticket.is_some()
+                || workspaces
+                    .iter()
+                    .any(|other| other.parent_ticket.as_deref() == Some(&w.ticket))
+        })
+        .cloned()
+        .collect();
+
+    if stacked.is_empty() {
+        if mode == Mode::Human {
+            println!(
+                "No stacked worktrees. Use `parsec start <ticket> --on <parent>` to create a stack."
+            );
+        }
+        return Ok(());
+    }
+
+    output::print_stack(&stacked, mode);
+    Ok(())
+}
+
+pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config)?;
+    let workspaces = manager.list()?;
+
+    let mut synced = Vec::new();
+    let mut failed = Vec::new();
+
+    // Find roots: workspaces that have children but no parent themselves
+    let roots: Vec<_> = workspaces
+        .iter()
+        .filter(|w| {
+            w.parent_ticket.is_none()
+                && workspaces
+                    .iter()
+                    .any(|other| other.parent_ticket.as_deref() == Some(&w.ticket))
+        })
+        .collect();
+
+    if roots.is_empty() {
+        if mode == Mode::Human {
+            println!(
+                "No stacked worktrees to sync. Use `parsec start <ticket> --on <parent>` to create a stack."
+            );
+        }
+        return Ok(());
+    }
+
+    for root in &roots {
+        // First sync root with its base branch
+        if let Err(e) = git::run(&root.path, &["fetch", "origin", &root.base_branch]) {
+            failed.push((root.ticket.clone(), format!("fetch failed: {e}")));
+            continue;
+        }
+        let remote_base = format!("origin/{}", root.base_branch);
+        if let Err(e) = git::run(&root.path, &["rebase", &remote_base]) {
+            let _ = git::run(&root.path, &["rebase", "--abort"]);
+            failed.push((root.ticket.clone(), format!("rebase failed: {e}")));
+            continue;
+        }
+        synced.push(root.ticket.clone());
+
+        // Then rebase children onto their parent, in topological order
+        let mut queue: Vec<&str> = vec![&root.ticket];
+        while let Some(parent_ticket) = queue.first().copied() {
+            queue.remove(0);
+            let children: Vec<_> = workspaces
+                .iter()
+                .filter(|w| w.parent_ticket.as_deref() == Some(parent_ticket))
+                .collect();
+            for child in &children {
+                let parent_ws = workspaces
+                    .iter()
+                    .find(|w| w.ticket == parent_ticket)
+                    .unwrap();
+                if let Err(e) = git::run(&child.path, &["rebase", &parent_ws.branch]) {
+                    let _ = git::run(&child.path, &["rebase", "--abort"]);
+                    failed.push((
+                        child.ticket.clone(),
+                        format!("rebase onto {} failed: {e}", parent_ticket),
+                    ));
+                } else {
+                    synced.push(child.ticket.clone());
+                    queue.push(&child.ticket);
+                }
+            }
+        }
+    }
+
+    output::print_sync(&synced, &failed, "rebase (stack)", mode);
     Ok(())
 }
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -18,6 +18,7 @@ pub async fn start(
     base: Option<&str>,
     title: Option<String>,
     on: Option<&str>,
+    existing_branch: Option<&str>,
     mode: Mode,
 ) -> Result<()> {
     let config = ParsecConfig::load()?;
@@ -38,7 +39,7 @@ pub async fn start(
     };
 
     let manager = WorktreeManager::new(repo, &config)?;
-    let workspace = manager.create(ticket, base, ticket_title, on)?;
+    let workspace = manager.create(ticket, base, ticket_title, on, existing_branch)?;
 
     output::print_start(&workspace, mode);
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use colored::Colorize;
 
 use crate::config::ParsecConfig;
 use crate::conflict;
@@ -390,6 +391,148 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
     }
 
     output::print_pr_status(&statuses, mode);
+    Ok(())
+}
+
+pub async fn merge(
+    repo: &Path,
+    ticket: Option<&str>,
+    rebase: bool,
+    no_wait: bool,
+    no_delete_branch: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let remote_url = git::run_output(repo, &["remote", "get-url", "origin"])?;
+    let oplog = crate::oplog::OpLog::load(&repo_root)?;
+    let manager = WorktreeManager::new(repo, &config)?;
+
+    // Resolve ticket
+    let ticket_id = if let Some(t) = ticket {
+        t.to_string()
+    } else {
+        let cwd = std::env::current_dir()?;
+        let all_ws = manager.list()?;
+        let found = all_ws
+            .into_iter()
+            .find(|w| cwd.starts_with(&w.path))
+            .ok_or_else(|| anyhow::anyhow!("not inside a parsec worktree. Specify a ticket."))?;
+        found.ticket
+    };
+
+    // Find PR number: check oplog first, then try open PR by branch
+    let pr_number = {
+        let shipped_pr = oplog
+            .get_entries(Some(&ticket_id))
+            .into_iter()
+            .rev()
+            .filter(|e| matches!(e.op, crate::oplog::OpKind::Ship))
+            .find_map(|e| {
+                let url = e.detail.split(" -> ").nth(1)?;
+                url.rsplit('/').next()?.parse::<u64>().ok()
+            });
+
+        if let Some(pr) = shipped_pr {
+            pr
+        } else {
+            let ws = manager.get(&ticket_id).with_context(|| {
+                format!("ticket {ticket_id} not found in active workspaces or oplog")
+            })?;
+            github::find_pr_by_branch(&remote_url, &ws.branch)
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "no PR found for {ticket_id}. Ship it first with `parsec ship {ticket_id}`."
+                    )
+                })?
+        }
+    };
+
+    // Wait for CI to pass (unless --no-wait)
+    if !no_wait {
+        if mode == Mode::Human {
+            eprint!("Waiting for CI to pass...");
+        }
+        loop {
+            match github::get_check_runs(&remote_url, pr_number).await? {
+                Some(ci) => {
+                    if ci.overall == "passing" {
+                        if mode == Mode::Human {
+                            eprintln!(" {}", "✓".green());
+                        }
+                        break;
+                    } else if ci.overall == "failing" {
+                        if mode == Mode::Human {
+                            eprintln!(" {}", "✗".red());
+                        }
+                        anyhow::bail!(
+                            "CI is failing for PR #{}. Fix CI or use --no-wait to merge anyway.",
+                            pr_number
+                        );
+                    }
+                    // Still pending — wait and retry
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                }
+                None => {
+                    anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
+                }
+            }
+        }
+    }
+
+    // Determine merge method
+    let method = if rebase { "rebase" } else { "squash" };
+    let delete_branch = !no_delete_branch;
+
+    // Merge the PR
+    match github::merge_pr(&remote_url, pr_number, method, delete_branch).await? {
+        Some(result) => {
+            output::print_merge(&ticket_id, pr_number, &result, method, mode);
+
+            // Clean up local worktree if it exists
+            if let Ok(ws) = manager.get(&ticket_id) {
+                if ws.path.exists() {
+                    if let Err(e) = git::worktree_remove(&repo_root, &ws.path) {
+                        eprintln!("warning: failed to remove worktree: {e}");
+                    }
+                }
+                // Update state
+                let mut state = crate::worktree::ParsecState::load(&repo_root)?;
+                state.remove_workspace(&ticket_id);
+                state.save(&repo_root)?;
+
+                // Delete local branch
+                if let Some(branch) = &oplog
+                    .get_entries(Some(&ticket_id))
+                    .last()
+                    .and_then(|e| e.undo_info.as_ref())
+                    .and_then(|u| u.branch.clone())
+                {
+                    let _ = git::delete_branch(&repo_root, branch);
+                }
+
+                if mode == Mode::Human {
+                    println!("  {}", "Local worktree cleaned up.".dimmed());
+                }
+            }
+
+            // Record in oplog
+            if let Err(e) = crate::oplog::record(
+                &repo_root,
+                crate::oplog::OpKind::Clean,
+                Some(&ticket_id),
+                &format!("Merged PR #{} ({})", pr_number, method),
+                None,
+            ) {
+                eprintln!("warning: failed to write oplog: {e}");
+            }
+        }
+        None => {
+            anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
+        }
+    }
+
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -53,6 +53,10 @@ pub enum Command {
         /// Create stacked on another ticket's branch
         #[arg(long)]
         on: Option<String>,
+
+        /// Use an existing branch instead of creating a new one
+        #[arg(long = "branch")]
+        existing_branch: Option<String>,
     },
 
     /// List all active worktrees
@@ -333,6 +337,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             base,
             title,
             on,
+            existing_branch,
         } => {
             commands::start(
                 &repo_path,
@@ -340,6 +345,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 base.as_deref(),
                 title,
                 on.as_deref(),
+                existing_branch.as_deref(),
                 output_mode,
             )
             .await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,6 +113,25 @@ pub enum Command {
         ticket: Option<String>,
     },
 
+    /// Merge a ticket's PR on GitHub and clean up
+    ///
+    /// Merges the PR via the GitHub API. By default uses squash merge
+    /// and waits for CI to pass before merging. Cleans up the local
+    /// worktree after a successful merge.
+    Merge {
+        /// Ticket identifier (auto-detects current worktree if omitted)
+        ticket: Option<String>,
+        /// Use rebase merge instead of squash
+        #[arg(long)]
+        rebase: bool,
+        /// Skip waiting for CI to pass
+        #[arg(long)]
+        no_wait: bool,
+        /// Keep remote branch after merge (default: delete)
+        #[arg(long)]
+        no_delete_branch: bool,
+    },
+
     /// Check CI/CD pipeline status for a ticket's PR
     ///
     /// Shows individual check runs with status, duration, and overall
@@ -314,6 +333,22 @@ pub async fn run(cli: Cli) -> Result<()> {
         } => commands::open(&repo_path, &ticket, pr, ticket_page, output_mode).await,
         Command::PrStatus { ticket } => {
             commands::pr_status(&repo_path, ticket.as_deref(), output_mode).await
+        }
+        Command::Merge {
+            ticket,
+            rebase,
+            no_wait,
+            no_delete_branch,
+        } => {
+            commands::merge(
+                &repo_path,
+                ticket.as_deref(),
+                rebase,
+                no_wait,
+                no_delete_branch,
+                output_mode,
+            )
+            .await
         }
         Command::Ci { ticket, watch, all } => {
             commands::ci(&repo_path, ticket.as_deref(), watch, all, output_mode).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,6 +113,22 @@ pub enum Command {
         ticket: Option<String>,
     },
 
+    /// Check CI/CD pipeline status for a ticket's PR
+    ///
+    /// Shows individual check runs with status, duration, and overall
+    /// summary. Auto-detects the current worktree if no ticket is given.
+    /// Use --watch to poll until all checks complete.
+    Ci {
+        /// Ticket identifier (auto-detects current worktree if omitted)
+        ticket: Option<String>,
+        /// Watch CI in real-time until completion (refresh every 5s)
+        #[arg(long)]
+        watch: bool,
+        /// Show CI for all shipped PRs
+        #[arg(long)]
+        all: bool,
+    },
+
     /// Print workspace path for a ticket (use with cd)
     ///
     /// Outputs the absolute path to the worktree for a given ticket.
@@ -298,6 +314,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         } => commands::open(&repo_path, &ticket, pr, ticket_page, output_mode).await,
         Command::PrStatus { ticket } => {
             commands::pr_status(&repo_path, ticket.as_deref(), output_mode).await
+        }
+        Command::Ci { ticket, watch, all } => {
+            commands::ci(&repo_path, ticket.as_deref(), watch, all, output_mode).await
         }
         Command::Conflicts => commands::conflicts(&repo_path, output_mode).await,
         Command::Switch { ticket } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -148,6 +148,21 @@ pub enum Command {
         all: bool,
     },
 
+    /// View changes in a worktree compared to base branch
+    ///
+    /// Shows the diff between the worktree branch and its base branch
+    /// using the merge-base as the comparison point.
+    Diff {
+        /// Ticket identifier (auto-detects current worktree if omitted)
+        ticket: Option<String>,
+        /// Show file-level summary only
+        #[arg(long)]
+        stat: bool,
+        /// List changed file names only
+        #[arg(long)]
+        name_only: bool,
+    },
+
     /// Print workspace path for a ticket (use with cd)
     ///
     /// Outputs the absolute path to the worktree for a given ticket.
@@ -353,6 +368,11 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Ci { ticket, watch, all } => {
             commands::ci(&repo_path, ticket.as_deref(), watch, all, output_mode).await
         }
+        Command::Diff {
+            ticket,
+            stat,
+            name_only,
+        } => commands::diff(&repo_path, ticket.as_deref(), stat, name_only, output_mode).await,
         Command::Conflicts => commands::conflicts(&repo_path, output_mode).await,
         Command::Switch { ticket } => {
             commands::switch(&repo_path, ticket.as_deref(), output_mode).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,6 +49,10 @@ pub enum Command {
         /// Manually set the ticket title (skips tracker lookup)
         #[arg(long)]
         title: Option<String>,
+
+        /// Create stacked on another ticket's branch
+        #[arg(long)]
+        on: Option<String>,
     },
 
     /// List all active worktrees
@@ -254,6 +258,16 @@ pub enum Command {
         dry_run: bool,
     },
 
+    /// Show or manage stacked PR dependencies
+    ///
+    /// Displays the dependency graph of worktrees created with --on.
+    /// Use `parsec stack --sync` to rebase the entire chain.
+    Stack {
+        /// Sync the entire stack (rebase chain)
+        #[arg(long)]
+        sync: bool,
+    },
+
     /// Configure parsec
     ///
     /// Manage parsec configuration: run interactive setup, view current
@@ -318,7 +332,18 @@ pub async fn run(cli: Cli) -> Result<()> {
             ticket,
             base,
             title,
-        } => commands::start(&repo_path, &ticket, base.as_deref(), title, output_mode).await,
+            on,
+        } => {
+            commands::start(
+                &repo_path,
+                &ticket,
+                base.as_deref(),
+                title,
+                on.as_deref(),
+                output_mode,
+            )
+            .await
+        }
         Command::List => commands::list(&repo_path, output_mode).await,
         Command::Status { ticket } => {
             commands::status(&repo_path, ticket.as_deref(), output_mode).await
@@ -381,6 +406,13 @@ pub async fn run(cli: Cli) -> Result<()> {
             commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
         }
         Command::Undo { dry_run } => commands::undo(&repo_path, dry_run, output_mode).await,
+        Command::Stack { sync } => {
+            if sync {
+                commands::stack_sync(&repo_path, output_mode).await
+            } else {
+                commands::stack(&repo_path, output_mode).await
+            }
+        }
         Command::Config { action } => match action {
             ConfigAction::Init => commands::config_init(output_mode).await,
             ConfigAction::Show => commands::config_show(output_mode).await,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -153,6 +153,58 @@ pub fn worktree_add(repo: &Path, path: &Path, branch: &str, base: &str) -> Resul
     run(repo, &["worktree", "add", "-b", branch, path_str, base])
 }
 
+/// Create a worktree at `path` for an already-existing branch.
+/// If the branch only exists on the remote, it is fetched and tracked locally first.
+pub fn worktree_add_existing(repo: &Path, path: &Path, branch: &str) -> Result<()> {
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| anyhow!("worktree path is not valid UTF-8: {:?}", path))?;
+
+    // Check if branch exists locally
+    let local_exists = run_output(
+        repo,
+        &["rev-parse", "--verify", &format!("refs/heads/{}", branch)],
+    )
+    .is_ok();
+
+    if local_exists {
+        return run(repo, &["worktree", "add", path_str, branch]);
+    }
+
+    // Check if it exists on remote (handle "origin/branch" syntax too)
+    let remote_ref = if branch.starts_with("origin/") {
+        branch.to_owned()
+    } else {
+        format!("origin/{}", branch)
+    };
+
+    let remote_exists = run_output(
+        repo,
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("refs/remotes/{}", remote_ref),
+        ],
+    )
+    .is_ok();
+
+    if remote_exists {
+        // Strip "origin/" prefix for the local branch name
+        let local_name = branch.strip_prefix("origin/").unwrap_or(branch);
+        // Create local tracking branch and worktree in one step
+        run(
+            repo,
+            &["worktree", "add", "-b", local_name, path_str, &remote_ref],
+        )
+    } else {
+        Err(anyhow!(
+            "branch '{}' not found locally or on remote. Use `parsec start {}` without --branch to create a new branch.",
+            branch,
+            branch.strip_prefix("origin/").unwrap_or(branch)
+        ))
+    }
+}
+
 /// Remove the worktree rooted at `path`.
 pub fn worktree_remove(repo: &Path, path: &Path) -> Result<()> {
     let path_str = path

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -349,6 +349,105 @@ pub async fn find_pr_by_branch(remote_url: &str, branch: &str) -> Result<Option<
     Ok(resp.first().and_then(|pr| pr["number"].as_u64()))
 }
 
+/// Result of merging a PR
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeResult {
+    pub sha: String,
+    pub message: String,
+    pub merged: bool,
+}
+
+/// Merge a GitHub PR.
+/// `method` should be "squash", "rebase", or "merge".
+/// Returns None if no token, Some(MergeResult) on success.
+pub async fn merge_pr(
+    remote_url: &str,
+    pr_number: u64,
+    method: &str,
+    delete_branch: bool,
+) -> Result<Option<MergeResult>> {
+    let token = match resolve_github_token() {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let remote = parse_github_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+    })?;
+
+    let api_base = remote.api_base();
+    let client = Client::new();
+
+    // Merge the PR
+    let url = format!(
+        "{}/repos/{}/{}/pulls/{}/merge",
+        api_base, remote.owner, remote.repo, pr_number
+    );
+    let payload = serde_json::json!({
+        "merge_method": method,
+    });
+
+    let response = client
+        .put(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .json(&payload)
+        .send()
+        .await
+        .context("Failed to send merge request to GitHub")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        bail!("GitHub merge API returned {}: {}", status, body);
+    }
+
+    let resp: serde_json::Value = response.json().await?;
+    let sha = resp["sha"].as_str().unwrap_or("").to_string();
+    let message = resp["message"].as_str().unwrap_or("").to_string();
+
+    // Delete remote branch if requested
+    if delete_branch {
+        let branch_url = format!(
+            "{}/repos/{}/{}/pulls/{}",
+            api_base, remote.owner, remote.repo, pr_number
+        );
+        let pr_resp: serde_json::Value = client
+            .get(&branch_url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "git-parsec")
+            .bearer_auth(&token)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if let Some(branch_name) = pr_resp["head"]["ref"].as_str() {
+            let del_url = format!(
+                "{}/repos/{}/{}/git/refs/heads/{}",
+                api_base, remote.owner, remote.repo, branch_name
+            );
+            let _ = client
+                .delete(&del_url)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .header("User-Agent", "git-parsec")
+                .bearer_auth(&token)
+                .send()
+                .await;
+        }
+    }
+
+    Ok(Some(MergeResult {
+        sha,
+        message,
+        merged: true,
+    }))
+}
+
 /// Create a GitHub pull request.
 /// Returns None if no GitHub token is available.
 pub async fn create_pr(

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -205,6 +205,150 @@ pub async fn get_pr_status(remote_url: &str, pr_number: u64) -> Result<Option<Pr
     }))
 }
 
+/// A single CI check run
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckRun {
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub html_url: Option<String>,
+}
+
+/// Aggregated CI status for a PR
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CiStatus {
+    pub pr_number: u64,
+    pub head_sha: String,
+    pub overall: String,
+    pub checks: Vec<CheckRun>,
+}
+
+/// Fetch check runs for a PR by number.
+/// Returns None if no GitHub token is available.
+pub async fn get_check_runs(remote_url: &str, pr_number: u64) -> Result<Option<CiStatus>> {
+    let token = match resolve_github_token() {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let remote = parse_github_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+    })?;
+
+    let api_base = remote.api_base();
+    let client = Client::new();
+
+    // Fetch PR to get head SHA
+    let pr_url = format!(
+        "{}/repos/{}/{}/pulls/{}",
+        api_base, remote.owner, remote.repo, pr_number
+    );
+    let pr_resp: serde_json::Value = client
+        .get(&pr_url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let head_sha = pr_resp["head"]["sha"].as_str().unwrap_or("").to_string();
+
+    if head_sha.is_empty() {
+        bail!("could not determine head SHA for PR #{}", pr_number);
+    }
+
+    // Fetch check runs for the head SHA
+    let checks_url = format!(
+        "{}/repos/{}/{}/commits/{}/check-runs",
+        api_base, remote.owner, remote.repo, head_sha
+    );
+    let checks_resp: serde_json::Value = client
+        .get(&checks_url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let checks: Vec<CheckRun> = checks_resp["check_runs"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|c| CheckRun {
+            name: c["name"].as_str().unwrap_or("").to_string(),
+            status: c["status"].as_str().unwrap_or("").to_string(),
+            conclusion: c["conclusion"].as_str().map(|s| s.to_string()),
+            started_at: c["started_at"].as_str().map(|s| s.to_string()),
+            completed_at: c["completed_at"].as_str().map(|s| s.to_string()),
+            html_url: c["html_url"].as_str().map(|s| s.to_string()),
+        })
+        .collect();
+
+    // Derive overall status
+    let overall = if checks.is_empty() {
+        "no checks".to_string()
+    } else if checks
+        .iter()
+        .any(|c| c.conclusion.as_deref() == Some("failure"))
+    {
+        "failing".to_string()
+    } else if checks.iter().all(|c| {
+        c.conclusion.as_deref() == Some("success") || c.conclusion.as_deref() == Some("skipped")
+    }) {
+        "passing".to_string()
+    } else {
+        "pending".to_string()
+    };
+
+    Ok(Some(CiStatus {
+        pr_number,
+        head_sha,
+        overall,
+        checks,
+    }))
+}
+
+/// Find an open PR by branch name.
+/// Returns the PR number if found, None if no token or no matching PR.
+pub async fn find_pr_by_branch(remote_url: &str, branch: &str) -> Result<Option<u64>> {
+    let token = match resolve_github_token() {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let remote = parse_github_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+    })?;
+
+    let api_base = remote.api_base();
+    let client = Client::new();
+
+    let url = format!(
+        "{}/repos/{}/{}/pulls?head={}:{}&state=open",
+        api_base, remote.owner, remote.repo, remote.owner, branch
+    );
+    let resp: Vec<serde_json::Value> = client
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    Ok(resp.first().and_then(|pr| pr["number"].as_u64()))
+}
+
 /// Create a GitHub pull request.
 /// Returns None if no GitHub token is available.
 pub async fn create_pr(

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -370,6 +370,25 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
     println!("{table}");
 }
 
+pub fn print_merge(
+    ticket: &str,
+    pr_number: u64,
+    result: &crate::github::MergeResult,
+    method: &str,
+) {
+    println!(
+        "{}",
+        format!("Merged PR #{} for {}!", pr_number, ticket)
+            .green()
+            .bold()
+    );
+    println!("  {} {}", "Method:".bold(), method);
+    println!("  {} {}", "SHA:".bold(), result.sha.dimmed());
+    if !result.message.is_empty() {
+        println!("  {} {}", "Message:".bold(), result.message);
+    }
+}
+
 pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
     use tabled::{Table, Tabled};
 

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -528,6 +528,72 @@ pub fn print_diff_stat(stat: &str, ticket: &str) {
     print!("{}", stat);
 }
 
+pub fn print_stack(workspaces: &[Workspace]) {
+    use std::collections::HashMap;
+
+    // Build parent -> children map
+    let mut children_map: HashMap<&str, Vec<&Workspace>> = HashMap::new();
+    let mut roots = Vec::new();
+
+    for ws in workspaces {
+        if let Some(parent) = &ws.parent_ticket {
+            children_map.entry(parent.as_str()).or_default().push(ws);
+        } else if workspaces
+            .iter()
+            .any(|other| other.parent_ticket.as_deref() == Some(&ws.ticket))
+        {
+            roots.push(ws);
+        }
+    }
+
+    println!("{}", "Stack dependency graph:".bold());
+
+    fn print_tree(
+        ws: &Workspace,
+        children_map: &HashMap<&str, Vec<&Workspace>>,
+        prefix: &str,
+        is_last: bool,
+    ) {
+        use colored::Colorize;
+        let connector = if prefix.is_empty() {
+            ""
+        } else if is_last {
+            "└── "
+        } else {
+            "├── "
+        };
+        let title = ws.ticket_title.as_deref().unwrap_or("");
+        println!(
+            "{}{}{}  {}",
+            prefix,
+            connector,
+            ws.ticket.bold().cyan(),
+            title.dimmed()
+        );
+
+        let child_prefix = if prefix.is_empty() {
+            String::new()
+        } else if is_last {
+            format!("{}    ", prefix)
+        } else {
+            format!("{}│   ", prefix)
+        };
+
+        if let Some(children) = children_map.get(ws.ticket.as_str()) {
+            for (i, child) in children.iter().enumerate() {
+                print_tree(child, children_map, &child_prefix, i == children.len() - 1);
+            }
+        }
+    }
+
+    for (i, root) in roots.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        print_tree(root, &children_map, "", true);
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig) {
     println!("{}", "[workspace]".bold());
     println!("  layout          = {}", config.workspace.layout);

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -511,6 +511,23 @@ pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
     }
 }
 
+pub fn print_diff_names(files: &[String], ticket: &str) {
+    println!(
+        "{} {} ({} files):",
+        "Changed files for".bold(),
+        ticket.bold().cyan(),
+        files.len()
+    );
+    for f in files {
+        println!("  {}", f);
+    }
+}
+
+pub fn print_diff_stat(stat: &str, ticket: &str) {
+    println!("{} {}:", "Diff stat for".bold(), ticket.bold().cyan());
+    print!("{}", stat);
+}
+
 pub fn print_config_show(config: &ParsecConfig) {
     println!("{}", "[workspace]".bold());
     println!("  layout          = {}", config.workspace.layout);

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -370,6 +370,128 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
     println!("{table}");
 }
 
+pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
+    use tabled::{Table, Tabled};
+
+    for (ticket, ci) in statuses {
+        println!(
+            "{} {} (PR #{}, {})",
+            "CI for".bold(),
+            ticket.bold().cyan(),
+            ci.pr_number,
+            ci.head_sha[..7].dimmed()
+        );
+
+        if ci.checks.is_empty() {
+            println!("  {}", "No checks found.".dimmed());
+            println!();
+            continue;
+        }
+
+        #[derive(Tabled)]
+        struct CheckRow {
+            #[tabled(rename = "Check")]
+            name: String,
+            #[tabled(rename = "Status")]
+            status: String,
+            #[tabled(rename = "Duration")]
+            duration: String,
+        }
+
+        let rows: Vec<CheckRow> = ci
+            .checks
+            .iter()
+            .map(|c| {
+                let status = match (c.status.as_str(), c.conclusion.as_deref()) {
+                    (_, Some("success")) => "✓ passed".green().to_string(),
+                    (_, Some("failure")) => "✗ failed".red().to_string(),
+                    (_, Some("skipped")) => "- skipped".dimmed().to_string(),
+                    ("in_progress", _) => "● running".yellow().to_string(),
+                    ("queued", _) => "○ queued".dimmed().to_string(),
+                    _ => c.status.clone(),
+                };
+                let duration = match (&c.started_at, &c.completed_at) {
+                    (Some(start), Some(end)) => {
+                        if let (Ok(s), Ok(e)) = (
+                            chrono::DateTime::parse_from_rfc3339(start),
+                            chrono::DateTime::parse_from_rfc3339(end),
+                        ) {
+                            let secs = (e - s).num_seconds();
+                            if secs >= 60 {
+                                format!("{}m {}s", secs / 60, secs % 60)
+                            } else {
+                                format!("{}s", secs)
+                            }
+                        } else {
+                            "-".to_string()
+                        }
+                    }
+                    (Some(_), None) => "running...".to_string(),
+                    _ => "-".to_string(),
+                };
+                CheckRow {
+                    name: c.name.clone(),
+                    status,
+                    duration,
+                }
+            })
+            .collect();
+
+        let table = Table::new(rows)
+            .with(tabled::settings::Style::modern())
+            .to_string();
+        println!("{table}");
+
+        // Summary line
+        let passed = ci
+            .checks
+            .iter()
+            .filter(|c| c.conclusion.as_deref() == Some("success"))
+            .count();
+        let failed = ci
+            .checks
+            .iter()
+            .filter(|c| c.conclusion.as_deref() == Some("failure"))
+            .count();
+        let running = ci
+            .checks
+            .iter()
+            .filter(|c| c.status == "in_progress")
+            .count();
+        let queued = ci.checks.iter().filter(|c| c.status == "queued").count();
+        let total = ci.checks.len();
+
+        let mut parts = Vec::new();
+        if passed > 0 {
+            parts.push(format!("{passed} passed").green().to_string());
+        }
+        if failed > 0 {
+            parts.push(format!("{failed} failed").red().to_string());
+        }
+        if running > 0 {
+            parts.push(format!("{running} running").yellow().to_string());
+        }
+        if queued > 0 {
+            parts.push(format!("{queued} queued"));
+        }
+
+        let overall_icon = match ci.overall.as_str() {
+            "passing" => "✓".green().to_string(),
+            "failing" => "✗".red().to_string(),
+            _ => "●".yellow().to_string(),
+        };
+
+        println!(
+            "{} CI: {}/{} — {}",
+            overall_icon,
+            passed,
+            total,
+            parts.join(", ")
+        );
+        println!();
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig) {
     println!("{}", "[workspace]".bold());
     println!("  layout          = {}", config.workspace.layout);

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -94,6 +94,22 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
     emit(&value);
 }
 
+pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
+    let value: Vec<_> = statuses
+        .iter()
+        .map(|(ticket, ci)| {
+            json!({
+                "ticket": ticket,
+                "pr_number": ci.pr_number,
+                "head_sha": ci.head_sha,
+                "overall": ci.overall,
+                "checks": ci.checks,
+            })
+        })
+        .collect();
+    emit(&value);
+}
+
 pub fn print_undo(entry: &OpEntry) {
     let value = json!({
         "action": "undo",

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -94,6 +94,24 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)]) {
     emit(&value);
 }
 
+pub fn print_merge(
+    ticket: &str,
+    pr_number: u64,
+    result: &crate::github::MergeResult,
+    method: &str,
+) {
+    let value = json!({
+        "action": "merge",
+        "ticket": ticket,
+        "pr_number": pr_number,
+        "method": method,
+        "sha": result.sha,
+        "message": result.message,
+        "merged": result.merged,
+    });
+    println!("{}", value);
+}
+
 pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
     let value: Vec<_> = statuses
         .iter()

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -146,6 +146,22 @@ pub fn print_diff_full(files: &[(String, String)], ticket: &str) {
     println!("{}", value);
 }
 
+pub fn print_stack(workspaces: &[Workspace]) {
+    let value: Vec<_> = workspaces
+        .iter()
+        .map(|ws| {
+            json!({
+                "ticket": ws.ticket,
+                "branch": ws.branch,
+                "base_branch": ws.base_branch,
+                "parent_ticket": ws.parent_ticket,
+                "title": ws.ticket_title,
+            })
+        })
+        .collect();
+    emit(&value);
+}
+
 pub fn print_undo(entry: &OpEntry) {
     let value = json!({
         "action": "undo",

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -128,6 +128,24 @@ pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)]) {
     emit(&value);
 }
 
+pub fn print_diff_names(files: &[String], ticket: &str) {
+    let value = json!({
+        "ticket": ticket,
+        "files": files,
+        "count": files.len(),
+    });
+    println!("{}", value);
+}
+
+pub fn print_diff_full(files: &[(String, String)], ticket: &str) {
+    let value = json!({
+        "ticket": ticket,
+        "changes": files.iter().map(|(status, file)| json!({"status": status, "file": file})).collect::<Vec<_>>(),
+        "count": files.len(),
+    });
+    println!("{}", value);
+}
+
 pub fn print_undo(entry: &OpEntry) {
     let value = json!({
         "action": "undo",

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -147,6 +147,14 @@ pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)], mode: Mod
     }
 }
 
+pub fn print_stack(workspaces: &[Workspace], mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_stack(workspaces),
+        Mode::Human => human::print_stack(workspaces),
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig, mode: Mode) {
     match mode {
         Mode::Quiet => {}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -125,6 +125,14 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)], mode: Mod
     }
 }
 
+pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)], mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_ci_status(statuses),
+        Mode::Human => human::print_ci_status(statuses),
+    }
+}
+
 pub fn print_config_show(config: &ParsecConfig, mode: Mode) {
     match mode {
         Mode::Quiet => {}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -154,3 +154,23 @@ pub fn print_config_show(config: &ParsecConfig, mode: Mode) {
         Mode::Human => human::print_config_show(config),
     }
 }
+
+pub fn print_diff_names(files: &[String], ticket: &str, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_diff_names(files, ticket),
+        Mode::Human => human::print_diff_names(files, ticket),
+    }
+}
+
+pub fn print_diff_stat(stat: &str, ticket: &str, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => {} // stat is human-only
+        Mode::Human => human::print_diff_stat(stat, ticket),
+    }
+}
+
+pub fn print_diff_full_json(files: &[(String, String)], ticket: &str) {
+    json::print_diff_full(files, ticket);
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -125,6 +125,20 @@ pub fn print_pr_status(statuses: &[(String, crate::github::PrStatus)], mode: Mod
     }
 }
 
+pub fn print_merge(
+    ticket: &str,
+    pr_number: u64,
+    result: &crate::github::MergeResult,
+    method: &str,
+    mode: Mode,
+) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_merge(ticket, pr_number, result, method),
+        Mode::Human => human::print_merge(ticket, pr_number, result, method),
+    }
+}
+
 pub fn print_ci_status(statuses: &[(String, crate::github::CiStatus)], mode: Mode) {
     match mode {
         Mode::Quiet => {}

--- a/src/worktree/lifecycle.rs
+++ b/src/worktree/lifecycle.rs
@@ -31,6 +31,8 @@ pub struct Workspace {
     pub created_at: DateTime<Utc>,
     pub ticket_title: Option<String>,
     pub status: WorkspaceStatus,
+    #[serde(default)]
+    pub parent_ticket: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -43,6 +43,7 @@ impl WorktreeManager {
         base: Option<&str>,
         ticket_title: Option<String>,
         parent_ticket: Option<&str>,
+        existing_branch: Option<&str>,
     ) -> Result<Workspace> {
         let base_branch = match base {
             Some(b) => b.to_owned(),
@@ -58,7 +59,6 @@ impl WorktreeManager {
             }
         };
 
-        let branch = format!("{}{}", self.config.workspace.branch_prefix, ticket);
         let worktree_path = match self.config.workspace.layout {
             crate::config::WorktreeLayout::Sibling => {
                 // ../reponame.ticket/
@@ -81,14 +81,27 @@ impl WorktreeManager {
         // Graceful fetch — won't fail if no remote exists
         git::fetch_if_remote(&self.repo_root)?;
 
-        git::worktree_add(&self.repo_root, &worktree_path, &branch, &base_branch).with_context(
-            || {
+        let branch = if let Some(eb) = existing_branch {
+            // Use an existing branch — resolve the local name
+            let local_name = eb.strip_prefix("origin/").unwrap_or(eb).to_owned();
+            git::worktree_add_existing(&self.repo_root, &worktree_path, eb).with_context(|| {
                 format!(
-                    "failed to create worktree for ticket '{}' at {:?}",
-                    ticket, worktree_path
+                    "failed to create worktree from existing branch '{}' for ticket '{}' at {:?}",
+                    eb, ticket, worktree_path
                 )
-            },
-        )?;
+            })?;
+            local_name
+        } else {
+            let branch = format!("{}{}", self.config.workspace.branch_prefix, ticket);
+            git::worktree_add(&self.repo_root, &worktree_path, &branch, &base_branch)
+                .with_context(|| {
+                    format!(
+                        "failed to create worktree for ticket '{}' at {:?}",
+                        ticket, worktree_path
+                    )
+                })?;
+            branch
+        };
 
         let workspace = Workspace {
             ticket: ticket.to_owned(),

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -42,11 +42,20 @@ impl WorktreeManager {
         ticket: &str,
         base: Option<&str>,
         ticket_title: Option<String>,
+        parent_ticket: Option<&str>,
     ) -> Result<Workspace> {
         let base_branch = match base {
             Some(b) => b.to_owned(),
-            None => git::get_default_branch(&self.repo_root)
-                .context("failed to detect default branch")?,
+            None => {
+                if let Some(parent) = parent_ticket {
+                    // When stacking, use the parent's branch as base
+                    let parent_ws = self.get(parent)?;
+                    parent_ws.branch.clone()
+                } else {
+                    git::get_default_branch(&self.repo_root)
+                        .context("failed to detect default branch")?
+                }
+            }
         };
 
         let branch = format!("{}{}", self.config.workspace.branch_prefix, ticket);
@@ -89,6 +98,7 @@ impl WorktreeManager {
             created_at: Utc::now(),
             ticket_title,
             status: WorkspaceStatus::Active,
+            parent_ticket: parent_ticket.map(|s| s.to_owned()),
         };
 
         let mut state =
@@ -243,6 +253,7 @@ impl WorktreeManager {
             created_at: Utc::now(),
             ticket_title,
             status: WorkspaceStatus::Active,
+            parent_ticket: None,
         };
 
         state.add_workspace(workspace.clone());


### PR DESCRIPTION
## Release v0.2.4

### New Features
- **`parsec ci`** — CI/CD pipeline status with `--watch` mode for real-time monitoring
- **`parsec merge`** — Merge PRs from terminal with CI wait, auto-cleanup
- **`parsec diff`** — View worktree changes vs base branch (`--stat`, `--name-only`)
- **`parsec stack`** — Stacked PR dependency tracking with `--sync`
- **`parsec start --branch`** — Attach to existing local or remote branches

### Improvements
- Schema.org structured data for AI search discoverability
- "What is parsec?" section in README for better search engine indexing
- Updated GitHub topics and repo description
- Optimized crates.io keywords and description

### Full Changelog
https://github.com/erishforG/git-parsec/compare/main...develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)