### PR TITLE
docs: fix inaccurate comparison tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,13 +827,16 @@ Token priority: `PARSEC_*_TOKEN` > platform-specific variables.
 | Feature | parsec | GitButler | worktrunk | git worktree | git-town |
 |---------|--------|-----------|-----------|--------------|----------|
 | Ticket tracker integration | Jira + GitHub Issues | No | No | No | No |
-| Physical isolation | Yes (worktrees) | No (virtual branches) | Yes | Yes | No |
+| Physical isolation | Yes (worktrees) | No (virtual branches) | Yes (worktrees) | Yes | No |
 | Conflict detection | Cross-worktree | N/A | No | No | No |
 | One-step ship (push+PR+clean) | Yes | No | No | No | Yes |
-| GitHub + GitLab | Both | Both | No | No | No |
-| Operation history + undo | Yes | Yes | No | No | No |
-| JSON output | Yes | Yes | Yes | No | No |
-| Auto-cleanup merged | Yes | No | Yes | Manual | No |
+| GitHub + GitLab | Both | Both | GitHub | No | GitHub, GitLab, Gitea, Bitbucket |
+| Operation history + undo | Yes | Yes | No | No | Yes (undo) |
+| JSON output | Yes | Yes | No | No | No |
+| CI monitoring | Yes (--watch) | No | No | No | No |
+| Stacked PRs | Yes | Yes | No | No | Yes |
+| Auto-cleanup merged | Yes | No | No | Manual | No |
+| Post-create hooks | Yes | No | Yes | No | No |
 | GUI | CLI only | Desktop + TUI | CLI | CLI | CLI |
 | Zero config start | Yes | No | Yes | No | No |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1862,11 +1862,19 @@
           <tbody>
             <tr>
               <td>Ticket tracker integration</td>
-              <td class="highlight"><span class="check">Jira + GitHub</span></td>
+              <td class="highlight"><span class="check">Jira + GitHub Issues</span></td>
               <td><span class="cross">--</span></td>
               <td><span class="cross">--</span></td>
               <td><span class="cross">--</span></td>
               <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Physical isolation (worktrees)</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="partial">Virtual branches</span></td>
             </tr>
             <tr>
               <td>Cross-worktree conflict detection</td>
@@ -1881,11 +1889,43 @@
               <td class="highlight"><span class="check">GitHub + GitLab</span></td>
               <td><span class="cross">--</span></td>
               <td><span class="cross">--</span></td>
-              <td><span class="partial">Partial</span></td>
-              <td><span class="partial">PR only</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Operation history &amp; undo</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="check">Yes (undo)</span></td>
+              <td><span class="check">Yes</span></td>
             </tr>
             <tr>
               <td>JSON output for AI agents</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="check">Yes</span></td>
+            </tr>
+            <tr>
+              <td>CI monitoring</td>
+              <td class="highlight"><span class="check">Yes (--watch)</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Stacked PRs</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="check">Yes</span></td>
+            </tr>
+            <tr>
+              <td>Post-create hooks</td>
               <td class="highlight"><span class="check">Yes</span></td>
               <td><span class="check">Yes</span></td>
               <td><span class="cross">--</span></td>
@@ -1895,55 +1935,23 @@
             <tr>
               <td>Auto-cleanup merged worktrees</td>
               <td class="highlight"><span class="check">Yes</span></td>
-              <td><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
               <td><span class="partial">Manual</span></td>
               <td><span class="cross">--</span></td>
-              <td><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
             </tr>
             <tr>
-              <td>Status dashboard</td>
+              <td>Forge support</td>
+              <td class="highlight"><span class="check">GitHub + GitLab</span></td>
+              <td><span class="partial">GitHub</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="check">GH, GL, Gitea, BB</span></td>
+              <td><span class="check">GitHub + GitLab</span></td>
+            </tr>
+            <tr>
+              <td>Zero config start</td>
               <td class="highlight"><span class="check">Yes</span></td>
               <td><span class="check">Yes</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="check">Yes</span></td>
-            </tr>
-            <tr>
-              <td>Post-create hooks</td>
-              <td class="highlight"><span class="check">Yes</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-            </tr>
-            <tr>
-              <td>Shell integration (cd into worktree)</td>
-              <td class="highlight"><span class="check">Yes</span></td>
-              <td><span class="check">Yes</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-            </tr>
-            <tr>
-              <td>Operation history &amp; undo</td>
-              <td class="highlight"><span class="check">Yes</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-            </tr>
-            <tr>
-              <td>Adopt existing branches</td>
-              <td class="highlight"><span class="check">Yes</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-              <td><span class="cross">--</span></td>
-            </tr>
-            <tr>
-              <td>Attach to existing branch</td>
-              <td class="highlight"><span class="check">Yes</span></td>
-              <td><span class="cross">--</span></td>
               <td><span class="cross">--</span></td>
               <td><span class="cross">--</span></td>
               <td><span class="cross">--</span></td>


### PR DESCRIPTION
## Summary
- Corrected competitor feature claims in README.md and docs/index.html comparison tables
- git-town: added ship command, undo, stacked PRs, multi-forge support (GitHub, GitLab, Gitea, Bitbucket)
- worktrunk: removed false JSON output and auto-cleanup claims, correctly added hooks support
- GitButler: corrected to virtual branches (not worktrees), added undo and JSON output
- Added missing rows: physical isolation, CI monitoring, stacked PRs, forge support

## Test plan
- [ ] Verify docs/index.html renders correctly in browser
- [ ] Cross-check all claims against competitor docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)