### PR TITLE
feat: add confirmation prompt before post_create hook execution

### DIFF
--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -122,16 +122,40 @@ impl WorktreeManager {
             .context("failed to save parsec state")?;
 
         // Run post-create hooks
-        for hook_cmd in &self.config.hooks.post_create {
-            eprintln!("Running post-create hook: {}", hook_cmd);
-            let status = std::process::Command::new("sh")
-                .args(["-c", hook_cmd])
-                .current_dir(&worktree_path)
-                .status();
-            match status {
-                Ok(s) if s.success() => {}
-                Ok(s) => eprintln!("warning: hook '{}' exited with {}", hook_cmd, s),
-                Err(e) => eprintln!("warning: failed to run hook '{}': {}", hook_cmd, e),
+        if !self.config.hooks.post_create.is_empty() {
+            let skip_prompt = std::env::var("PARSEC_YES").map(|v| v == "1").unwrap_or(false);
+
+            let confirmed = if skip_prompt {
+                true
+            } else {
+                eprintln!("The following post-create hooks will be executed:");
+                for hook_cmd in &self.config.hooks.post_create {
+                    eprintln!("  - {}", hook_cmd);
+                }
+                eprint!("Run these hooks? [y/N] ");
+
+                let mut input = String::new();
+                match std::io::stdin().read_line(&mut input) {
+                    Ok(_) => input.trim().eq_ignore_ascii_case("y"),
+                    Err(_) => false,
+                }
+            };
+
+            if confirmed {
+                for hook_cmd in &self.config.hooks.post_create {
+                    eprintln!("Running post-create hook: {}", hook_cmd);
+                    let status = std::process::Command::new("sh")
+                        .args(["-c", hook_cmd])
+                        .current_dir(&worktree_path)
+                        .status();
+                    match status {
+                        Ok(s) if s.success() => {}
+                        Ok(s) => eprintln!("warning: hook '{}' exited with {}", hook_cmd, s),
+                        Err(e) => eprintln!("warning: failed to run hook '{}': {}", hook_cmd, e),
+                    }
+                }
+            } else {
+                eprintln!("Skipping post-create hooks.");
             }
         }
 

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -123,7 +123,9 @@ impl WorktreeManager {
 
         // Run post-create hooks
         if !self.config.hooks.post_create.is_empty() {
-            let skip_prompt = std::env::var("PARSEC_YES").map(|v| v == "1").unwrap_or(false);
+            let skip_prompt = std::env::var("PARSEC_YES")
+                .map(|v| v == "1")
+                .unwrap_or(false);
 
             let confirmed = if skip_prompt {
                 true


### PR DESCRIPTION
## Summary
- post_create 훅 실행 전 사용자 확인 프롬프트 추가
- `PARSEC_YES=1` 환경변수로 CI에서 프롬프트 스킵 가능
- 기본값 No로 안전성 확보

## Related Issue
Closes #55

## Type of Change
- [x] Bug fix
- [x] New feature

## Pre-submit Checklist
- [x] `cargo check` passes
- [ ] `cargo test` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)