### PR TITLE
feat: restrict .atlassian-env loader to allowed prefixes

### DIFF
--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -33,6 +33,12 @@ fn load_atlassian_env() {
             if let Some((key, value)) = line.split_once('=') {
                 let key = key.trim();
                 let value = value.trim();
+                // Only allow specific prefixes for security
+                let allowed_prefixes = ["JIRA_", "PARSEC_", "CONFLUENCE_", "ATLASSIAN_"];
+                if !allowed_prefixes.iter().any(|p| key.starts_with(p)) {
+                    eprintln!("warning: ignoring disallowed env var '{}' in .atlassian-env (allowed prefixes: JIRA_, PARSEC_, CONFLUENCE_, ATLASSIAN_)", key);
+                    continue;
+                }
                 // Only set if not already in environment (env vars take precedence)
                 if std::env::var(key).is_err() {
                     std::env::set_var(key, value);


### PR DESCRIPTION
## Summary
- .atlassian-env 로더에 허용 프리픽스 제한 추가 (JIRA_, PARSEC_, CONFLUENCE_, ATLASSIAN_)
- 허용되지 않은 변수는 경고 출력 후 무시
- PATH 등 시스템 변수 덮어쓰기 방지

## Related Issue
Closes #56

## Type of Change
- [x] Bug fix

## Pre-submit Checklist
- [x] `cargo check` passes
- [ ] `cargo test` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)