### PR TITLE
feat(board): vertical layout, config defaults, enhanced JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # git-parsec
 
+[![Crates.io](https://img.shields.io/crates/v/git-parsec.svg)](https://crates.io/crates/git-parsec)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/erishforG/git-parsec/actions/workflows/ci.yml/badge.svg)](https://github.com/erishforG/git-parsec/actions)
+
 > Git worktree lifecycle manager for parallel AI agent workflows
 
 **parsec** manages isolated git worktrees tied to tickets (Jira, GitHub Issues), enabling multiple AI agents or developers to work on the same repository in parallel without lock conflicts.
@@ -79,6 +83,41 @@ Removed 1 worktree(s):
 - **Auto-cleanup** -- Remove worktrees for merged branches automatically
 - **GitHub and GitLab** -- PR and MR creation for both platforms
 - **Stacked PRs** -- Create dependent PR chains with `--on` and sync the entire stack
+- **Sprint board view** -- See the active sprint as a Kanban board with `parsec board`
+
+## Why AI-Native?
+
+Traditional AI agents waste tokens calling raw APIs. Each Jira or GitHub API call costs dozens of tokens for auth setup, pagination, and response parsing. **parsec packages git + tracker operations into single commands with structured output.**
+
+### Before: Raw API Calls
+
+```bash
+# Agent needs: sprint tickets + status + worktree info + PR status
+# Step 1: Authenticate with Jira API
+# Step 2: Find active sprint (GET /rest/agile/1.0/board/{id}/sprint?state=active)
+# Step 3: Fetch sprint issues (GET /rest/agile/1.0/sprint/{id}/issue)
+# Step 4: For each ticket, check local worktrees (git worktree list, parse output)
+# Step 5: For each ticket, check PR status (GitHub API)
+# → 5+ API calls, 100+ tokens, custom parsing logic
+```
+
+### After: One parsec Command
+
+```bash
+parsec board --json
+# → Sprint + status-grouped tickets + worktree/PR flags in one structured JSON
+```
+
+### Key Benefits for AI Agents
+
+| Capability | What it means |
+|------------|---------------|
+| `--json` on every command | Structured output AI can parse instantly |
+| `parsec start` | git worktree + Jira fetch + state management in one call |
+| `parsec board --json` | Sprint + tickets + worktree/PR status in one call |
+| `parsec ship` | Push + PR creation + cleanup in one call |
+| Env var defaults | Zero-arg commands after one-time setup |
+| Conflict detection | AI agents can check before parallel edits |
 
 ## Installation
 
@@ -659,6 +698,49 @@ $ parsec ship PROJ-1   # PR to main
 $ parsec ship PROJ-2   # PR to feature/PROJ-1
 $ parsec ship PROJ-3   # PR to feature/PROJ-2
 ```
+
+---
+
+### `parsec board`
+
+Show the active sprint as a vertical board view. Fetches tickets from Jira grouped by status column, with worktree and PR indicators.
+
+```
+parsec board [--project <KEY>] [--board-id <ID>] [--assignee <name>] [--all]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-p, --project <KEY>` | Jira project key (default from env/config) |
+| `--board-id <ID>` | Jira board ID (auto-detected from project) |
+| `--assignee <name>` | Filter by assignee (default from env/config) |
+| `--all` | Show all tickets (ignore assignee filter) |
+
+```bash
+# Show your tickets (with PARSEC_JIRA_ASSIGNEE configured)
+$ parsec board
+
+26.04.06 ~ 26.04.20
+
+In Progress (3)
+  CL-2283 [wt]  로그 분석 서비스 개발
+  CL-2284 [wt]  FDE 대시보드 관련
+  CL-2291       반품 요청 API 개발
+
+In Review (2)
+  CL-2281 [pr]  ai 커피챗 준비
+  CL-2280       이관 요청할 API 정리
+
+# Show all team tickets
+$ parsec board --all
+
+# JSON output for AI agents
+$ parsec board --json
+{"sprint":{"id":123,"name":"...","start":"...","end":"..."},"total_count":48,"columns":{"In Progress":[...],...}}
+```
+
+Defaults can be set via environment variables or config file (see below).
+
 ---
 
 ### `parsec config`
@@ -788,6 +870,9 @@ provider = "jira"
 [tracker.jira]
 base_url = "https://yourcompany.atlassian.net"
 # Auth: PARSEC_JIRA_TOKEN or JIRA_PAT env var
+# project = "CL"            # Default project for board
+# board_id = 123            # Default board ID
+# assignee = "eric.signal"  # Default assignee filter
 
 [tracker.gitlab]
 base_url = "https://gitlab.com"
@@ -817,6 +902,9 @@ post_create = ["npm install"]
 | `GH_TOKEN` | Fallback GitHub token |
 | `PARSEC_GITLAB_TOKEN` | GitLab token for MR creation |
 | `GITLAB_TOKEN` | Fallback GitLab token |
+| `PARSEC_JIRA_PROJECT` | Default Jira project key for `board` |
+| `PARSEC_JIRA_BOARD_ID` | Default Jira board ID for `board` |
+| `PARSEC_JIRA_ASSIGNEE` | Default assignee filter for `board` |
 
 Token priority: `PARSEC_*_TOKEN` > platform-specific variables.
 
@@ -837,6 +925,7 @@ Token priority: `PARSEC_*_TOKEN` > platform-specific variables.
 | Stacked PRs | Yes | Yes | No | No | Yes |
 | Auto-cleanup merged | Yes | No | No | Manual | No |
 | Post-create hooks | Yes | No | Yes | No | No |
+| AI token efficiency | Single-command ops | N/A | N/A | N/A | N/A |
 | GUI | CLI only | Desktop + TUI | CLI | CLI | CLI |
 | Zero config start | Yes | No | Yes | No | No |
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,15 +1,17 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use colored::Colorize;
 
-use crate::config::ParsecConfig;
+use crate::config::{ParsecConfig, TrackerProvider};
 use crate::conflict;
 use crate::git;
 use crate::github;
 use crate::gitlab;
-use crate::output::{self, Mode};
+use crate::output::{self, BoardTicketDisplay, Mode};
 use crate::tracker;
+use crate::tracker::jira::JiraTracker;
 use crate::worktree::WorktreeManager;
 
 pub async fn start(
@@ -1084,6 +1086,164 @@ pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
     }
 
     output::print_sync(&synced, &failed, "rebase (stack)", mode);
+    Ok(())
+}
+
+pub async fn board(
+    repo: &Path,
+    board_id_override: Option<u64>,
+    project_override: Option<String>,
+    assignee_override: Option<String>,
+    show_all: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+
+    // Board view currently supports Jira only
+    if !matches!(
+        config.tracker.provider,
+        TrackerProvider::Jira | TrackerProvider::None
+    ) {
+        anyhow::bail!("Board view currently supports Jira only.");
+    }
+
+    // Load atlassian env for auto-detection
+    tracker::load_atlassian_env();
+
+    // Resolve Jira base URL and email
+    let base_url = config
+        .tracker
+        .jira
+        .as_ref()
+        .map(|j| j.base_url.clone())
+        .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Jira not configured. Run `parsec config init` or set {}.",
+                crate::env::JIRA_BASE_URL,
+            )
+        })?;
+    let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());
+    let jira = JiraTracker::new(&base_url, email.as_deref());
+
+    // Resolve project key: --project CLI > PARSEC_JIRA_PROJECT env > config > worktree inference
+    let project = if let Some(p) = project_override {
+        p
+    } else if let Ok(p) = std::env::var(crate::env::PARSEC_JIRA_PROJECT) {
+        p
+    } else if let Some(p) = config.tracker.jira.as_ref().and_then(|j| j.project.clone()) {
+        p
+    } else {
+        let config2 = ParsecConfig::load()?;
+        let manager = WorktreeManager::new(repo, &config2)?;
+        let workspaces = manager.list()?;
+        workspaces
+            .iter()
+            .find_map(|ws| ws.ticket.split('-').next().map(String::from))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Could not infer project key. Use --project <KEY>, set {}, or start a worktree first.",
+                    crate::env::PARSEC_JIRA_PROJECT,
+                )
+            })?
+    };
+
+    // Resolve board ID: --board-id CLI > PARSEC_JIRA_BOARD_ID env > config > API fetch
+    let board_id = if let Some(id) = board_id_override {
+        id
+    } else if let Ok(id_str) = std::env::var(crate::env::PARSEC_JIRA_BOARD_ID) {
+        id_str.parse::<u64>().map_err(|_| {
+            anyhow::anyhow!(
+                "{} must be a valid number, got: {}",
+                crate::env::PARSEC_JIRA_BOARD_ID,
+                id_str,
+            )
+        })?
+    } else if let Some(id) = config.tracker.jira.as_ref().and_then(|j| j.board_id) {
+        id
+    } else {
+        jira.fetch_board_id(&project).await?
+    };
+
+    // Resolve assignee filter: --assignee CLI > PARSEC_JIRA_ASSIGNEE env > config > none
+    let assignee_filter = if show_all {
+        None
+    } else if let Some(a) = assignee_override {
+        Some(a)
+    } else if let Ok(a) = std::env::var(crate::env::PARSEC_JIRA_ASSIGNEE) {
+        Some(a)
+    } else {
+        config
+            .tracker
+            .jira
+            .as_ref()
+            .and_then(|j| j.assignee.clone())
+    };
+
+    // Fetch active sprint
+    let sprint = jira.fetch_active_sprint(board_id).await?;
+
+    // Fetch sprint issues
+    let tickets = jira.fetch_sprint_issues(sprint.id).await?;
+
+    // Collect active worktree ticket set
+    let config3 = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config3)?;
+    let active_worktree_tickets: HashSet<String> =
+        manager.list()?.iter().map(|ws| ws.ticket.clone()).collect();
+
+    // Collect shipped PR ticket set from oplog
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let oplog = crate::oplog::OpLog::load(&repo_root)?;
+    let shipped_tickets: HashSet<String> = oplog
+        .entries
+        .iter()
+        .filter(|e| matches!(e.op, crate::oplog::OpKind::Ship))
+        .filter_map(|e| e.ticket.clone())
+        .collect();
+
+    // Annotate tickets and group by status
+    let mut column_map: Vec<(String, Vec<BoardTicketDisplay>)> = Vec::new();
+
+    // Preserve unique status order as encountered
+    let mut seen_statuses: Vec<String> = Vec::new();
+    for ticket in &tickets {
+        if !seen_statuses.contains(&ticket.status) {
+            seen_statuses.push(ticket.status.clone());
+        }
+    }
+
+    for status in &seen_statuses {
+        let col_tickets: Vec<BoardTicketDisplay> = tickets
+            .iter()
+            .filter(|t| &t.status == status)
+            .filter(|t| {
+                // Apply assignee filter if set
+                if let Some(ref filter) = assignee_filter {
+                    t.assignee.as_deref() == Some(filter.as_str())
+                } else {
+                    true
+                }
+            })
+            .map(|t| BoardTicketDisplay {
+                key: t.key.clone(),
+                summary: t.summary.clone(),
+                assignee: t.assignee.clone(),
+                has_worktree: active_worktree_tickets.contains(&t.key),
+                has_pr: shipped_tickets.contains(&t.key),
+                url: Some(format!(
+                    "{}/browse/{}",
+                    base_url.trim_end_matches('/'),
+                    t.key
+                )),
+            })
+            .collect();
+        if !col_tickets.is_empty() {
+            column_map.push((status.clone(), col_tickets));
+        }
+    }
+
+    output::print_board(Some(&sprint), &column_map, mode);
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -262,6 +262,29 @@ pub enum Command {
         dry_run: bool,
     },
 
+    /// Show the sprint board as a Kanban view
+    ///
+    /// Fetches the active sprint from Jira and displays tickets grouped
+    /// by status column. Active worktrees are marked with [wt] and
+    /// shipped PRs with [pr]. Currently supports Jira only.
+    Board {
+        /// Jira board ID (auto-detected from project if omitted)
+        #[arg(long)]
+        board_id: Option<u64>,
+
+        /// Jira project key (inferred from active worktrees if omitted)
+        #[arg(long, short)]
+        project: Option<String>,
+
+        /// Filter by assignee (default from config/env)
+        #[arg(long)]
+        assignee: Option<String>,
+
+        /// Show all tickets (ignore assignee filter)
+        #[arg(long)]
+        all: bool,
+    },
+
     /// Show or manage stacked PR dependencies
     ///
     /// Displays the dependency graph of worktrees created with --on.
@@ -412,6 +435,12 @@ pub async fn run(cli: Cli) -> Result<()> {
             commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
         }
         Command::Undo { dry_run } => commands::undo(&repo_path, dry_run, output_mode).await,
+        Command::Board {
+            board_id,
+            project,
+            assignee,
+            all,
+        } => commands::board(&repo_path, board_id, project, assignee, all, output_mode).await,
         Command::Stack { sync } => {
             if sync {
                 commands::stack_sync(&repo_path, output_mode).await

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -107,6 +107,9 @@ impl Default for WorkspaceConfig {
 pub struct JiraConfig {
     pub base_url: String,
     pub email: Option<String>,
+    pub project: Option<String>,
+    pub board_id: Option<u64>,
+    pub assignee: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -282,6 +285,9 @@ impl ParsecConfig {
                 } else {
                     Some(email_input)
                 },
+                project: None,
+                board_id: None,
+                assignee: None,
             });
         }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,70 @@
+//! Centralized environment variable definitions for parsec.
+//!
+//! All env var names and token resolution logic live here so that
+//! adding or renaming a variable only requires touching one file.
+
+// ---------------------------------------------------------------------------
+// Jira
+// ---------------------------------------------------------------------------
+
+pub const PARSEC_JIRA_TOKEN: &str = "PARSEC_JIRA_TOKEN";
+pub const JIRA_PAT: &str = "JIRA_PAT";
+pub const JIRA_BASE_URL: &str = "JIRA_BASE_URL";
+pub const PARSEC_JIRA_PROJECT: &str = "PARSEC_JIRA_PROJECT";
+pub const PARSEC_JIRA_BOARD_ID: &str = "PARSEC_JIRA_BOARD_ID";
+pub const PARSEC_JIRA_ASSIGNEE: &str = "PARSEC_JIRA_ASSIGNEE";
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+pub const PARSEC_GITHUB_TOKEN: &str = "PARSEC_GITHUB_TOKEN";
+pub const GITHUB_TOKEN: &str = "GITHUB_TOKEN";
+pub const GH_TOKEN: &str = "GH_TOKEN";
+
+// ---------------------------------------------------------------------------
+// GitLab
+// ---------------------------------------------------------------------------
+
+pub const PARSEC_GITLAB_TOKEN: &str = "PARSEC_GITLAB_TOKEN";
+pub const GITLAB_TOKEN: &str = "GITLAB_TOKEN";
+
+// ---------------------------------------------------------------------------
+// Token resolvers
+// ---------------------------------------------------------------------------
+
+/// Resolve Jira API token. Priority: PARSEC_JIRA_TOKEN > JIRA_PAT
+pub fn jira_token() -> Option<String> {
+    for var in [PARSEC_JIRA_TOKEN, JIRA_PAT] {
+        if let Ok(token) = std::env::var(var) {
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+    None
+}
+
+/// Resolve GitHub token. Priority: PARSEC_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN
+pub fn github_token() -> Option<String> {
+    for var in [PARSEC_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN] {
+        if let Ok(token) = std::env::var(var) {
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+    None
+}
+
+/// Resolve GitLab token. Priority: PARSEC_GITLAB_TOKEN > GITLAB_TOKEN
+pub fn gitlab_token() -> Option<String> {
+    for var in [PARSEC_GITLAB_TOKEN, GITLAB_TOKEN] {
+        if let Ok(token) = std::env::var(var) {
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+    None
+}

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -79,14 +79,7 @@ pub fn parse_github_remote(url: &str) -> Option<GitHubRemote> {
 /// Resolve a GitHub token from environment variables.
 /// Checks: PARSEC_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN
 fn resolve_github_token() -> Option<String> {
-    for var in &["PARSEC_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] {
-        if let Ok(token) = std::env::var(var) {
-            if !token.is_empty() {
-                return Some(token);
-            }
-        }
-    }
-    None
+    crate::env::github_token()
 }
 
 /// PR status information

--- a/src/gitlab/mod.rs
+++ b/src/gitlab/mod.rs
@@ -51,14 +51,7 @@ pub fn parse_gitlab_remote(url: &str) -> Option<GitLabRemote> {
 /// Resolve a GitLab token from environment variables.
 /// Checks: PARSEC_GITLAB_TOKEN > GITLAB_TOKEN
 fn resolve_gitlab_token() -> Option<String> {
-    for var in &["PARSEC_GITLAB_TOKEN", "GITLAB_TOKEN"] {
-        if let Ok(token) = std::env::var(var) {
-            if !token.is_empty() {
-                return Some(token);
-            }
-        }
-    }
-    None
+    crate::env::gitlab_token()
 }
 
 /// Create a GitLab merge request.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod config;
 mod conflict;
+mod env;
 mod git;
 mod github;
 mod gitlab;

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -2,9 +2,11 @@ use colored::Colorize;
 use tabled::settings::Style;
 use tabled::{Table, Tabled};
 
+use super::BoardTicketDisplay;
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
+use crate::tracker::jira::SprintInfo;
 use crate::worktree::{ShipResult, Workspace, WorkspaceStatus};
 
 // ---------------------------------------------------------------------------
@@ -591,6 +593,66 @@ pub fn print_stack(workspaces: &[Workspace]) {
             println!();
         }
         print_tree(root, &children_map, "", true);
+    }
+}
+
+pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTicketDisplay>)]) {
+    // Sprint header: show dates in compact form
+    if let Some(s) = sprint {
+        let start = s
+            .start_date
+            .as_deref()
+            .and_then(|d| d.get(..10))
+            .unwrap_or("");
+        let end = s
+            .end_date
+            .as_deref()
+            .and_then(|d| d.get(..10))
+            .unwrap_or("");
+        // Use short date format: strip leading "20" → "26.04.06"
+        let fmt_date = |d: &str| -> String {
+            if d.len() >= 10 {
+                let without_century = &d[2..];
+                without_century.replace('-', ".")
+            } else {
+                d.to_string()
+            }
+        };
+        if !start.is_empty() && !end.is_empty() {
+            println!(
+                "{}",
+                format!("{} ~ {}", fmt_date(start), fmt_date(end)).dimmed()
+            );
+        }
+        println!();
+    }
+
+    if columns.is_empty() {
+        println!("{}", "No tickets in sprint.".dimmed());
+        return;
+    }
+
+    for (i, (status, tickets)) in columns.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        // Status header: bold name + dimmed count
+        println!(
+            "{} {}",
+            status.bold(),
+            format!("({})", tickets.len()).dimmed()
+        );
+
+        for ticket in tickets {
+            let indicator = if ticket.has_worktree {
+                format!(" {}", "[wt]".green())
+            } else if ticket.has_pr {
+                format!(" {}", "[pr]".blue())
+            } else {
+                "     ".to_string()
+            };
+            println!("  {}{}  {}", ticket.key, indicator, ticket.summary.dimmed());
+        }
     }
 }
 

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,9 +1,11 @@
 use serde::Serialize;
 use serde_json::json;
 
+use super::BoardTicketDisplay;
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
+use crate::tracker::jira::SprintInfo;
 use crate::worktree::{ShipResult, Workspace};
 
 fn emit<T: Serialize>(value: &T) {
@@ -177,6 +179,56 @@ pub fn print_undo_preview(entry: &OpEntry) {
         "would_undo": format!("{}", entry.op),
         "ticket": entry.ticket,
         "undo_info": entry.undo_info,
+    });
+    println!("{}", value);
+}
+
+pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTicketDisplay>)]) {
+    let sprint_json = sprint.map(|s| {
+        json!({
+            "id": s.id,
+            "name": s.name,
+            "start": s.start_date,
+            "end": s.end_date,
+        })
+    });
+
+    let total_count: usize = columns.iter().map(|(_, tickets)| tickets.len()).sum();
+
+    let columns_json: serde_json::Map<String, serde_json::Value> = columns
+        .iter()
+        .map(|(name, tickets)| {
+            let ticket_list: Vec<serde_json::Value> = tickets
+                .iter()
+                .map(|t| {
+                    let mut obj = json!({
+                        "key": t.key,
+                        "summary": t.summary,
+                        "status": name,
+                    });
+                    if let Some(ref assignee) = t.assignee {
+                        obj["assignee"] = json!(assignee);
+                    }
+                    if let Some(ref url) = t.url {
+                        obj["url"] = json!(url);
+                    }
+                    if t.has_worktree {
+                        obj["worktree"] = json!(true);
+                    }
+                    if t.has_pr {
+                        obj["pr"] = json!(true);
+                    }
+                    obj
+                })
+                .collect();
+            (name.clone(), json!(ticket_list))
+        })
+        .collect();
+
+    let value = json!({
+        "sprint": sprint_json,
+        "total_count": total_count,
+        "columns": columns_json,
     });
     println!("{}", value);
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,7 +4,18 @@ mod json;
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
+use crate::tracker::jira::SprintInfo;
 use crate::worktree::{ShipResult, Workspace};
+
+/// A ticket annotated with parsec-specific indicators for board display.
+pub struct BoardTicketDisplay {
+    pub key: String,
+    pub summary: String,
+    pub assignee: Option<String>,
+    pub has_worktree: bool,
+    pub has_pr: bool,
+    pub url: Option<String>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Mode {
@@ -181,4 +192,16 @@ pub fn print_diff_stat(stat: &str, ticket: &str, mode: Mode) {
 
 pub fn print_diff_full_json(files: &[(String, String)], ticket: &str) {
     json::print_diff_full(files, ticket);
+}
+
+pub fn print_board(
+    sprint: Option<&SprintInfo>,
+    columns: &[(String, Vec<BoardTicketDisplay>)],
+    mode: Mode,
+) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_board(sprint, columns),
+        Mode::Human => human::print_board(sprint, columns),
+    }
 }

--- a/src/tracker/github_issues.rs
+++ b/src/tracker/github_issues.rs
@@ -18,14 +18,7 @@ impl GithubIssueTracker {
     }
 
     fn resolve_token() -> Option<String> {
-        for var in &["PARSEC_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] {
-            if let Ok(token) = std::env::var(var) {
-                if !token.is_empty() {
-                    return Some(token);
-                }
-            }
-        }
-        None
+        crate::env::github_token()
     }
 
     pub async fn fetch_ticket(&self, id: &str) -> Result<Ticket> {

--- a/src/tracker/jira.rs
+++ b/src/tracker/jira.rs
@@ -1,6 +1,23 @@
 use super::Ticket;
 use anyhow::{bail, Context, Result};
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SprintInfo {
+    pub id: u64,
+    pub name: String,
+    pub start_date: Option<String>,
+    pub end_date: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoardTicket {
+    pub key: String,
+    pub summary: String,
+    pub status: String,
+    pub assignee: Option<String>,
+}
 
 pub struct JiraTracker {
     base_url: String,
@@ -20,25 +37,21 @@ impl JiraTracker {
     /// Resolve the Jira API token from environment.
     /// Priority: PARSEC_JIRA_TOKEN > JIRA_PAT
     fn resolve_token() -> Result<String> {
-        if let Ok(token) = std::env::var("PARSEC_JIRA_TOKEN") {
-            if !token.is_empty() {
-                return Ok(token);
-            }
-        }
-        if let Ok(token) = std::env::var("JIRA_PAT") {
-            if !token.is_empty() {
-                return Ok(token);
-            }
-        }
-        anyhow::bail!(
-            "No Jira token found. Set PARSEC_JIRA_TOKEN or JIRA_PAT environment variable."
-        )
+        crate::env::jira_token().ok_or_else(|| {
+            anyhow::anyhow!(
+                "No Jira token found. Set {} or {} environment variable.",
+                crate::env::PARSEC_JIRA_TOKEN,
+                crate::env::JIRA_PAT,
+            )
+        })
     }
 
+    /// Fetch a single issue via Jira REST API v2.
+    /// Requires: Jira (Cloud or Server/DC 7.x+)
+    /// Endpoint: GET /rest/api/2/issue/{id}
     pub async fn fetch_ticket(&self, id: &str) -> Result<Ticket> {
         let token = Self::resolve_token()?;
 
-        // Use API v2 (compatible with both Cloud and Server/DC)
         let url = format!("{}/rest/api/2/issue/{}", self.base_url, id);
 
         let mut request = self
@@ -88,5 +101,165 @@ impl JiraTracker {
             assignee,
             url: Some(format!("{}/browse/{}", self.base_url, id)),
         })
+    }
+
+    /// Fetch the first board ID for a project via Jira Agile REST API v1.0.
+    /// Requires: Jira Software (Cloud or Server/DC 7.x+)
+    /// Endpoint: GET /rest/agile/1.0/board?projectKeyOrId={project}
+    pub async fn fetch_board_id(&self, project: &str) -> Result<u64> {
+        let token = Self::resolve_token()?;
+        let url = format!(
+            "{}/rest/agile/1.0/board?projectKeyOrId={}",
+            self.base_url, project
+        );
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json");
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to fetch boards from Jira")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Jira Agile API returned {} for boards: {}", status, body);
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse board response")?;
+
+        body["values"]
+            .as_array()
+            .and_then(|boards| boards.first())
+            .and_then(|b| b["id"].as_u64())
+            .ok_or_else(|| anyhow::anyhow!("No board found for project {project}"))
+    }
+
+    /// Fetch the active sprint for a board via Jira Agile REST API v1.0.
+    /// Requires: Jira Software (Cloud or Server/DC 7.x+)
+    /// Endpoint: GET /rest/agile/1.0/board/{id}/sprint?state=active
+    pub async fn fetch_active_sprint(&self, board_id: u64) -> Result<SprintInfo> {
+        let token = Self::resolve_token()?;
+        let url = format!(
+            "{}/rest/agile/1.0/board/{}/sprint?state=active",
+            self.base_url, board_id
+        );
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json");
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to fetch sprints from Jira")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Jira Agile API returned {} for sprints: {}", status, body);
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse sprint response")?;
+
+        let sprint = body["values"]
+            .as_array()
+            .and_then(|sprints| sprints.first())
+            .ok_or_else(|| anyhow::anyhow!("No active sprint found for board {board_id}"))?;
+
+        Ok(SprintInfo {
+            id: sprint["id"].as_u64().unwrap_or(0),
+            name: sprint["name"].as_str().unwrap_or("").to_string(),
+            start_date: sprint["startDate"].as_str().map(String::from),
+            end_date: sprint["endDate"].as_str().map(String::from),
+        })
+    }
+
+    /// Fetch all issues in a sprint via Jira Agile REST API v1.0.
+    /// Requires: Jira Software (Cloud or Server/DC 7.x+)
+    /// Endpoint: GET /rest/agile/1.0/sprint/{id}/issue?fields=summary,status,assignee
+    pub async fn fetch_sprint_issues(&self, sprint_id: u64) -> Result<Vec<BoardTicket>> {
+        let token = Self::resolve_token()?;
+        let url = format!(
+            "{}/rest/agile/1.0/sprint/{}/issue?fields=summary,status,assignee&maxResults=200",
+            self.base_url, sprint_id
+        );
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json");
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to fetch sprint issues from Jira")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!(
+                "Jira Agile API returned {} for sprint issues: {}",
+                status,
+                body
+            );
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse sprint issues response")?;
+
+        let issues = body["issues"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .map(|issue| BoardTicket {
+                        key: issue["key"].as_str().unwrap_or("").to_string(),
+                        summary: issue["fields"]["summary"]
+                            .as_str()
+                            .unwrap_or("")
+                            .to_string(),
+                        status: issue["fields"]["status"]["name"]
+                            .as_str()
+                            .unwrap_or("Unknown")
+                            .to_string(),
+                        assignee: issue["fields"]["assignee"]["displayName"]
+                            .as_str()
+                            .map(String::from),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(issues)
     }
 }

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -18,7 +18,7 @@ pub struct Ticket {
 
 /// Load environment variables from `~/.claude/.atlassian-env` if the file exists.
 /// This provides seamless integration with Claude's Jira skill.
-fn load_atlassian_env() {
+pub fn load_atlassian_env() {
     let env_path: PathBuf = dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".claude")
@@ -70,8 +70,9 @@ pub async fn fetch_ticket(
         }
         TrackerProvider::Gitlab | TrackerProvider::None => {
             // Auto-detect Jira: try if env vars available, but don't block on failure
-            if std::env::var("JIRA_BASE_URL").is_ok()
-                && (std::env::var("JIRA_PAT").is_ok() || std::env::var("PARSEC_JIRA_TOKEN").is_ok())
+            if std::env::var(crate::env::JIRA_BASE_URL).is_ok()
+                && (std::env::var(crate::env::JIRA_PAT).is_ok()
+                    || std::env::var(crate::env::PARSEC_JIRA_TOKEN).is_ok())
             {
                 if let Ok(Some(ticket)) = fetch_jira_ticket(config, id).await {
                     return Ok(Some(ticket));
@@ -107,9 +108,12 @@ async fn fetch_jira_ticket(config: &ParsecConfig, id: &str) -> Result<Option<Tic
         .jira
         .as_ref()
         .map(|j| j.base_url.clone())
-        .or_else(|| std::env::var("JIRA_BASE_URL").ok())
+        .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok())
         .ok_or_else(|| {
-            anyhow::anyhow!("Jira base URL not found. Set it in config or JIRA_BASE_URL env var.")
+            anyhow::anyhow!(
+                "Jira base URL not found. Set it in config or {} env var.",
+                crate::env::JIRA_BASE_URL,
+            )
         })?;
 
     let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());


### PR DESCRIPTION
## Summary

- **Vertical board output**: Replace tabled grid with per-status vertical sections — terminal-width independent, shows ticket summary
- **Config/env defaults**: Add `project`, `board_id`, `assignee` to `JiraConfig` with resolution chain (CLI > env > config > fallback)
- **Assignee filtering**: `--assignee` flag + `--all` to bypass, default from config
- **Enhanced JSON**: Sprint `id`, per-ticket `status`/`url`, `total_count`
- **Centralized env vars**: New `src/env.rs` module — all env var names and token resolvers in one place
- **README modernization**: Badges, AI-Native CLI section, `parsec board` docs, env var table

## Test plan

- [x] `cargo check` / `cargo fmt --check` / `cargo clippy` — all clean
- [ ] `parsec board` (no args, with config.toml defaults) — vertical list output
- [ ] `parsec board --all` — shows all tickets, ignores assignee filter
- [ ] `parsec board --json` — includes sprint.id, status, url, total_count
- [ ] `parsec board --assignee other.user` — filters by specified assignee
- [ ] Existing commands unaffected (start, ship, list, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)