### PR TITLE
fix(ship): preserve worktree on PR failure + explicit error handling

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -136,12 +136,12 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
 
-    // Push + cleanup (sync git operations)
-    let mut result = manager.ship(ticket)?;
+    // Phase 1: Push only (don't clean up yet)
+    let mut result = manager.ship_push(ticket)?;
 
-    // Create GitHub PR (async, uses reqwest)
+    // Phase 2: Create PR/MR (async)
+    let mut pr_failed = false;
     if !no_pr && config.ship.auto_pr {
-        // Fetch ticket info for URL (works for any tracker)
         let ticket_url =
             match tracker::fetch_ticket(&config, ticket, Some(manager.repo_root())).await {
                 Ok(Some(t)) => t.url,
@@ -162,7 +162,6 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
 
         let remote_url = git::get_remote_url(manager.repo_root());
         if let Ok(ref remote_url) = remote_url {
-            // Try GitHub first
             match github::create_pr(
                 remote_url,
                 &result.branch,
@@ -196,17 +195,35 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
                                 "note: PR/MR creation skipped — no token found.\n      \
                                  Set PARSEC_GITHUB_TOKEN or PARSEC_GITLAB_TOKEN to enable."
                             );
+                            pr_failed = true;
                         }
                         Err(e) => {
-                            eprintln!("warning: GitLab MR creation failed: {e}");
+                            eprintln!("error: GitLab MR creation failed: {e}");
+                            pr_failed = true;
                         }
                     }
                 }
                 Err(e) => {
-                    eprintln!("warning: PR creation failed: {e}");
+                    eprintln!("error: PR creation failed: {e}");
+                    pr_failed = true;
                 }
             }
         }
+    }
+
+    // Phase 3: Cleanup only if PR succeeded (or no PR requested)
+    if !pr_failed {
+        let cleaned_up = manager.ship_cleanup(ticket)?;
+        result.cleaned_up = cleaned_up;
+    } else {
+        eprintln!(
+            "note: worktree preserved at {} — fix the issue and retry `parsec ship {}`",
+            manager
+                .get(ticket)
+                .map(|ws| ws.path.display().to_string())
+                .unwrap_or_default(),
+            ticket
+        );
     }
 
     output::print_ship(&result, mode);
@@ -216,13 +233,18 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
         crate::oplog::OpKind::Ship,
         Some(ticket),
         &format!(
-            "Shipped branch '{}'{}",
+            "Shipped branch '{}'{}{}",
             result.branch,
             result
                 .pr_url
                 .as_ref()
                 .map(|u| format!(" -> {}", u))
-                .unwrap_or_default()
+                .unwrap_or_default(),
+            if pr_failed {
+                " (partial: PR failed)"
+            } else {
+                ""
+            },
         ),
         Some(crate::oplog::UndoInfo {
             branch: Some(result.branch.clone()),
@@ -232,6 +254,10 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
         }),
     ) {
         eprintln!("warning: failed to write oplog: {e}");
+    }
+
+    if pr_failed {
+        anyhow::bail!("Ship partial: branch pushed but PR/MR creation failed. Worktree preserved.");
     }
 
     Ok(())

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -133,7 +133,16 @@ pub fn print_status(workspaces: &[Workspace]) {
 }
 
 pub fn print_ship(result: &ShipResult) {
-    println!("{}", format!("Shipped {}!", result.ticket).green().bold());
+    if result.pr_url.is_some() || result.cleaned_up {
+        println!("{}", format!("Shipped {}!", result.ticket).green().bold());
+    } else {
+        println!(
+            "{}",
+            format!("Shipped {} (partial — PR failed)", result.ticket)
+                .yellow()
+                .bold()
+        );
+    }
     if let Some(url) = &result.pr_url {
         println!("  {} {}", "PR:".bold(), url.cyan());
     }

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -357,9 +357,9 @@ impl WorktreeManager {
     // ship (push + cleanup only, PR creation is in commands.rs)
     // -----------------------------------------------------------------------
 
-    pub fn ship(&self, ticket: &str) -> Result<ShipResult> {
-        let mut state =
-            ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
+    /// Phase 1: Push the branch only, don't clean up yet.
+    pub fn ship_push(&self, ticket: &str) -> Result<ShipResult> {
+        let state = ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
 
         let workspace = state
             .get_workspace(ticket)
@@ -375,23 +375,43 @@ impl WorktreeManager {
         git::push_branch(&workspace.path, &workspace.branch)
             .with_context(|| format!("failed to push branch '{}'", workspace.branch))?;
 
-        // Optionally clean up the worktree and local branch.
-        let cleaned_up = if self.config.ship.auto_cleanup {
-            match git::worktree_remove(&self.repo_root, &workspace.path) {
-                Ok(()) => {
-                    let _ = git::delete_branch(&self.repo_root, &workspace.branch);
-                    true
-                }
-                Err(e) => {
-                    eprintln!("warning: failed to remove worktree: {e}");
-                    false
-                }
-            }
-        } else {
-            false
+        Ok(ShipResult {
+            ticket: ticket.to_owned(),
+            branch: workspace.branch,
+            base_branch: workspace.base_branch,
+            ticket_title: workspace.ticket_title,
+            pr_url: None,
+            cleaned_up: false,
+        })
+    }
+
+    /// Phase 2: Clean up worktree and branch after successful PR creation.
+    pub fn ship_cleanup(&self, ticket: &str) -> Result<bool> {
+        if !self.config.ship.auto_cleanup {
+            return Ok(false);
+        }
+
+        let state = ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
+
+        let workspace = match state.get_workspace(ticket) {
+            Some(ws) => ws.clone(),
+            None => return Ok(false), // Already cleaned up
         };
 
-        // Update persisted state.
+        let cleaned_up = match git::worktree_remove(&self.repo_root, &workspace.path) {
+            Ok(()) => {
+                let _ = git::delete_branch(&self.repo_root, &workspace.branch);
+                true
+            }
+            Err(e) => {
+                eprintln!("warning: failed to remove worktree: {e}");
+                false
+            }
+        };
+
+        // Update persisted state
+        let mut state =
+            ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
         if cleaned_up {
             state.remove_workspace(ticket);
         } else if let Some(ws) = state.workspaces.get_mut(ticket) {
@@ -399,16 +419,18 @@ impl WorktreeManager {
         }
         state
             .save(&self.repo_root)
-            .context("failed to save parsec state after ship")?;
+            .context("failed to save parsec state after ship cleanup")?;
 
-        Ok(ShipResult {
-            ticket: ticket.to_owned(),
-            branch: workspace.branch,
-            base_branch: workspace.base_branch,
-            ticket_title: workspace.ticket_title,
-            pr_url: None, // Set by commands.rs after async PR creation
-            cleaned_up,
-        })
+        Ok(cleaned_up)
+    }
+
+    /// Combined push + cleanup (backwards compat).
+    #[allow(dead_code)]
+    pub fn ship(&self, ticket: &str) -> Result<ShipResult> {
+        let mut result = self.ship_push(ticket)?;
+        let cleaned_up = self.ship_cleanup(ticket)?;
+        result.cleaned_up = cleaned_up;
+        Ok(result)
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Splits `ship()` into `ship_push()` and `ship_cleanup()` phases — worktree is only removed after successful PR creation
- On PR failure: branch is pushed, worktree preserved, user gets a clear "partial ship" warning
- Explicit `anyhow::bail!` on partial failure with actionable message

Closes #63, closes #66

## Test plan
- [ ] `parsec ship` with valid PR → worktree cleaned up as before
- [ ] `parsec ship` with PR failure (e.g. no GitHub token) → worktree preserved, branch pushed
- [ ] Verify yellow "partial" message in human output
- [ ] `--json` output includes `pr_failed` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)