### PR TITLE
feat(ship): add --base flag and default_base config

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,13 +291,14 @@ $ parsec status PROJ-1234
 Push the branch, create a PR (GitHub) or MR (GitLab), and clean up the worktree. The forge is auto-detected from the remote URL.
 
 ```
-parsec ship <ticket> [--draft] [--no-pr]
+parsec ship <ticket> [--draft] [--no-pr] [--base <branch>]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--draft` | Create the PR/MR as a draft |
 | `--no-pr` | Push only, skip PR/MR creation |
+| `--base <branch>` | Target base branch for PR (overrides config `default_base` and worktree base) |
 
 ```bash
 # Push + PR + cleanup
@@ -764,6 +765,7 @@ $ parsec config show
   auto_pr         = true
   auto_cleanup    = true
   draft           = false
+  # default_base  = "develop"  # Target branch for PRs (default: worktree base)
 
 # Output shell integration script
 $ parsec config shell zsh

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -132,12 +132,27 @@ pub async fn status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<()>
     Ok(())
 }
 
-pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mode) -> Result<()> {
+pub async fn ship(
+    repo: &Path,
+    ticket: &str,
+    draft: bool,
+    no_pr: bool,
+    base_override: Option<String>,
+    mode: Mode,
+) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
 
     // Phase 1: Push only (don't clean up yet)
     let mut result = manager.ship_push(ticket)?;
+
+    // Resolve base branch: --base CLI > config default_base > worktree's base_branch
+    if let Some(base) = base_override {
+        result.base_branch = base;
+    } else if let Some(ref default_base) = config.ship.default_base {
+        result.base_branch = default_base.clone();
+    }
+    // else: keep the worktree's original base_branch
 
     // Phase 2: Create PR/MR (async)
     let mut pr_failed = false;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,6 +90,10 @@ pub enum Command {
         /// Skip PR creation, only push
         #[arg(long)]
         no_pr: bool,
+
+        /// Target base branch for PR (default from config or worktree base)
+        #[arg(long)]
+        base: Option<String>,
     },
 
     /// Remove merged or stale worktrees
@@ -381,7 +385,8 @@ pub async fn run(cli: Cli) -> Result<()> {
             ticket,
             draft,
             no_pr,
-        } => commands::ship(&repo_path, &ticket, draft, no_pr, output_mode).await,
+            base,
+        } => commands::ship(&repo_path, &ticket, draft, no_pr, base, output_mode).await,
         Command::Clean { all, dry_run } => {
             commands::clean(&repo_path, all, dry_run, output_mode).await
         }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -157,6 +157,8 @@ pub struct ShipConfig {
     pub auto_cleanup: bool,
     #[serde(default)]
     pub draft: bool,
+    #[serde(default)]
+    pub default_base: Option<String>,
 }
 
 impl Default for ShipConfig {
@@ -165,6 +167,7 @@ impl Default for ShipConfig {
             auto_pr: true,
             auto_cleanup: true,
             draft: false,
+            default_base: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `--base <branch>` flag to `parsec ship` to override the PR target branch
- Adds `default_base` option in `[ship]` config section
- Resolution priority: `--base` CLI > config `default_base` > worktree's base branch

Closes #64

## Test plan
- [ ] `parsec ship TICKET --base develop` → PR targets `develop`
- [ ] Config `default_base = "develop"` → PR targets `develop` without flag
- [ ] No flag, no config → uses worktree's original base branch
- [ ] `--json` output reflects correct base branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)