### PR TITLE
feat: add parsec ticket command for tracker lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,32 @@ $ parsec status PROJ-1234
 
 ---
 
+### `parsec ticket [ticket]`
+
+View ticket details from the configured tracker. Auto-detects the ticket from the current worktree if no argument is given.
+
+```
+parsec ticket [ticket]
+```
+
+```bash
+# Auto-detect from current worktree
+$ parsec ticket
+CL-2283: Implement rate limiting for API endpoints
+  Status: In Progress
+  Assignee: eric.signal
+  URL: https://jira.example.com/browse/CL-2283
+
+# Explicit ticket
+$ parsec ticket CL-2283
+
+# JSON output
+$ parsec ticket CL-2283 --json
+{"id":"CL-2283","title":"Implement rate limiting","status":"In Progress","assignee":"eric.signal","url":"https://jira.example.com/browse/CL-2283"}
+```
+
+---
+
 ### `parsec ship <ticket>`
 
 Push the branch, create a PR (GitHub) or MR (GitLab), and clean up the worktree. The forge is auto-detected from the remote URL.

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1130,6 +1130,43 @@ pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
     Ok(())
 }
 
+pub async fn ticket(repo: &Path, ticket_override: Option<&str>, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
+
+    // Resolve ticket: explicit arg > auto-detect from current worktree
+    let ticket_id = if let Some(t) = ticket_override {
+        t.to_string()
+    } else {
+        // Try to detect from current worktree
+        let manager = WorktreeManager::new(repo, &config)?;
+        let workspaces = manager.list()?;
+        let current_dir = std::env::current_dir()?;
+
+        workspaces
+            .iter()
+            .find(|ws| current_dir.starts_with(&ws.path))
+            .map(|ws| ws.ticket.clone())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Not inside a parsec worktree. Specify a ticket: `parsec ticket <TICKET>`"
+                )
+            })?
+    };
+
+    // Fetch ticket from tracker
+    let ticket = tracker::fetch_ticket(&config, &ticket_id, Some(repo))
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Could not fetch ticket '{}'. Check your tracker configuration.",
+                ticket_id
+            )
+        })?;
+
+    output::print_ticket(&ticket, mode);
+    Ok(())
+}
+
 pub async fn board(
     repo: &Path,
     board_id_override: Option<u64>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -74,6 +74,16 @@ pub enum Command {
         ticket: Option<String>,
     },
 
+    /// View ticket details from tracker
+    ///
+    /// Fetches and displays ticket information (title, status, assignee)
+    /// from the configured tracker. Auto-detects the ticket from the
+    /// current worktree if no ticket is specified.
+    Ticket {
+        /// Ticket identifier (auto-detects from current worktree if omitted)
+        ticket: Option<String>,
+    },
+
     /// Push, create PR/MR, and clean up a workspace
     ///
     /// Pushes the branch to remote, creates a GitHub PR or GitLab MR
@@ -380,6 +390,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::List => commands::list(&repo_path, output_mode).await,
         Command::Status { ticket } => {
             commands::status(&repo_path, ticket.as_deref(), output_mode).await
+        }
+        Command::Ticket { ticket } => {
+            commands::ticket(&repo_path, ticket.as_deref(), output_mode).await
         }
         Command::Ship {
             ticket,

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -7,6 +7,7 @@ use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
 use crate::tracker::jira::SprintInfo;
+use crate::tracker::Ticket as TrackerTicket;
 use crate::worktree::{ShipResult, Workspace, WorkspaceStatus};
 
 // ---------------------------------------------------------------------------
@@ -662,6 +663,19 @@ pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTic
             };
             println!("  {}{}  {}", ticket.key, indicator, ticket.summary.dimmed());
         }
+    }
+}
+
+pub fn print_ticket(ticket: &TrackerTicket) {
+    println!("{}: {}", ticket.id.yellow().bold(), ticket.title.bold());
+    if let Some(ref status) = ticket.status {
+        println!("  {} {}", "Status:".bold(), status);
+    }
+    if let Some(ref assignee) = ticket.assignee {
+        println!("  {} {}", "Assignee:".bold(), assignee);
+    }
+    if let Some(ref url) = ticket.url {
+        println!("  {} {}", "URL:".bold(), url.cyan());
     }
 }
 

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -6,6 +6,7 @@ use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
 use crate::tracker::jira::SprintInfo;
+use crate::tracker::Ticket as TrackerTicket;
 use crate::worktree::{ShipResult, Workspace};
 
 fn emit<T: Serialize>(value: &T) {
@@ -181,6 +182,10 @@ pub fn print_undo_preview(entry: &OpEntry) {
         "undo_info": entry.undo_info,
     });
     println!("{}", value);
+}
+
+pub fn print_ticket(ticket: &TrackerTicket) {
+    emit(ticket);
 }
 
 pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTicketDisplay>)]) {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,6 +5,7 @@ use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
 use crate::tracker::jira::SprintInfo;
+use crate::tracker::Ticket as TrackerTicket;
 use crate::worktree::{ShipResult, Workspace};
 
 /// A ticket annotated with parsec-specific indicators for board display.
@@ -203,5 +204,13 @@ pub fn print_board(
         Mode::Quiet => {}
         Mode::Json => json::print_board(sprint, columns),
         Mode::Human => human::print_board(sprint, columns),
+    }
+}
+
+pub fn print_ticket(ticket: &TrackerTicket, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_ticket(ticket),
+        Mode::Human => human::print_ticket(ticket),
     }
 }


### PR DESCRIPTION
## Summary
- New `parsec ticket [TICKET]` command to fetch and display ticket details from configured tracker
- Auto-detects ticket from current worktree if no argument given
- Supports human (colored) and JSON output modes

Closes #69

## Test plan
- [ ] `parsec ticket CL-1234` → shows ticket details (title, status, assignee, URL)
- [ ] `parsec ticket` inside worktree → auto-detects and shows ticket
- [ ] `parsec ticket` outside worktree → clear error message
- [ ] `parsec ticket CL-1234 --json` → structured JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)