### PR TITLE
feat: automatic ticket status transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,11 @@ draft = false         # Create PRs as drafts
 [hooks]
 # Commands to run in new worktrees after creation
 post_create = ["npm install"]
+
+[tracker.auto_transition]
+# on_start = "In Progress"   # Transition when `parsec start` runs
+# on_ship = "In Review"      # Transition when `parsec ship` runs
+# on_merge = "Done"           # Transition when `parsec merge` runs
 ```
 
 ---

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -45,6 +45,13 @@ pub async fn start(
 
     output::print_start(&workspace, mode);
 
+    // Auto-transition ticket status
+    if let Some(ref auto) = config.tracker.auto_transition {
+        if let Some(ref status) = auto.on_start {
+            tracker::try_transition(&config, ticket, status).await;
+        }
+    }
+
     if let Err(e) = crate::oplog::record(
         manager.repo_root(),
         crate::oplog::OpKind::Start,
@@ -242,6 +249,13 @@ pub async fn ship(
     }
 
     output::print_ship(&result, mode);
+
+    // Auto-transition ticket status
+    if let Some(ref auto) = config.tracker.auto_transition {
+        if let Some(ref status) = auto.on_ship {
+            tracker::try_transition(&config, ticket, status).await;
+        }
+    }
 
     if let Err(e) = crate::oplog::record(
         manager.repo_root(),
@@ -534,6 +548,13 @@ pub async fn merge(
     match github::merge_pr(&remote_url, pr_number, method, delete_branch).await? {
         Some(result) => {
             output::print_merge(&ticket_id, pr_number, &result, method, mode);
+
+            // Auto-transition ticket status
+            if let Some(ref auto) = config.tracker.auto_transition {
+                if let Some(ref status) = auto.on_merge {
+                    tracker::try_transition(&config, &ticket_id, status).await;
+                }
+            }
 
             // Clean up local worktree if it exists
             if let Ok(ws) = manager.get(&ticket_id) {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -133,6 +133,8 @@ pub struct TrackerConfig {
     pub jira: Option<JiraConfig>,
     #[serde(default)]
     pub gitlab: Option<GitlabConfig>,
+    #[serde(default)]
+    pub auto_transition: Option<AutoTransitionConfig>,
 }
 
 impl Default for TrackerConfig {
@@ -141,6 +143,7 @@ impl Default for TrackerConfig {
             provider: default_provider(),
             jira: None,
             gitlab: None,
+            auto_transition: None,
         }
     }
 }
@@ -181,6 +184,23 @@ pub struct HooksConfig {
     /// Commands to run after creating a worktree (in the worktree directory)
     #[serde(default)]
     pub post_create: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// AutoTransitionConfig
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AutoTransitionConfig {
+    /// Target status name when `parsec start` is run (e.g. "In Progress")
+    #[serde(default)]
+    pub on_start: Option<String>,
+    /// Target status name when `parsec ship` is run (e.g. "In Review")
+    #[serde(default)]
+    pub on_ship: Option<String>,
+    /// Target status name when `parsec merge` is run (e.g. "Done")
+    #[serde(default)]
+    pub on_merge: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tracker/jira.rs
+++ b/src/tracker/jira.rs
@@ -197,6 +197,120 @@ impl JiraTracker {
         })
     }
 
+    /// Fetch available transitions for an issue.
+    /// Endpoint: GET /rest/api/2/issue/{key}/transitions
+    pub async fn fetch_transitions(&self, key: &str) -> Result<Vec<(String, String)>> {
+        let token = Self::resolve_token()?;
+        let url = format!("{}/rest/api/2/issue/{}/transitions", self.base_url, key);
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json");
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to fetch transitions")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!(
+                "Jira transitions API returned {} for {}: {}",
+                status,
+                key,
+                body
+            );
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse transitions response")?;
+
+        let transitions = body["transitions"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let id = t["id"].as_str()?.to_string();
+                        let name = t["to"]["name"]
+                            .as_str()
+                            .or_else(|| t["name"].as_str())?
+                            .to_string();
+                        Some((id, name))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(transitions)
+    }
+
+    /// Transition an issue to a new status by name.
+    /// Finds the matching transition ID, then POST /rest/api/2/issue/{key}/transitions
+    pub async fn transition_issue(&self, key: &str, target_status: &str) -> Result<()> {
+        let transitions = self.fetch_transitions(key).await?;
+
+        let transition_id = transitions
+            .iter()
+            .find(|(_, name)| name.eq_ignore_ascii_case(target_status))
+            .map(|(id, _)| id.clone())
+            .ok_or_else(|| {
+                let available: Vec<&str> = transitions.iter().map(|(_, n)| n.as_str()).collect();
+                anyhow::anyhow!(
+                    "No transition to '{}' found for {}. Available: {:?}",
+                    target_status,
+                    key,
+                    available
+                )
+            })?;
+
+        let token = Self::resolve_token()?;
+        let url = format!("{}/rest/api/2/issue/{}/transitions", self.base_url, key);
+
+        let payload = serde_json::json!({
+            "transition": { "id": transition_id }
+        });
+
+        let mut request = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&payload);
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to send transition request")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!(
+                "Jira transition API returned {} for {}: {}",
+                status,
+                key,
+                body
+            );
+        }
+
+        Ok(())
+    }
+
     /// Fetch all issues in a sprint via Jira Agile REST API v1.0.
     /// Requires: Jira Software (Cloud or Server/DC 7.x+)
     /// Endpoint: GET /rest/agile/1.0/sprint/{id}/issue?fields=summary,status,assignee

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -2,6 +2,7 @@ pub mod github_issues;
 pub mod jira;
 
 use anyhow::Result;
+use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -96,6 +97,44 @@ pub async fn fetch_ticket(
             }
 
             Ok(None)
+        }
+    }
+}
+
+/// Try to transition a ticket's status. Warns on failure but never blocks.
+pub async fn try_transition(config: &ParsecConfig, ticket: &str, target_status: &str) {
+    // Only works for Jira currently
+    if !matches!(
+        config.tracker.provider,
+        TrackerProvider::Jira | TrackerProvider::None
+    ) {
+        return;
+    }
+
+    // Need atlassian env loaded
+    load_atlassian_env();
+
+    let base_url = config
+        .tracker
+        .jira
+        .as_ref()
+        .map(|j| j.base_url.clone())
+        .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok());
+
+    let base_url = match base_url {
+        Some(url) => url,
+        None => return,
+    };
+
+    let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());
+    let jira = jira::JiraTracker::new(&base_url, email.as_deref());
+
+    match jira.transition_issue(ticket, target_status).await {
+        Ok(()) => {
+            eprintln!("  {} Ticket status → {}", "✓".green(), target_status);
+        }
+        Err(e) => {
+            eprintln!("  warning: failed to transition ticket: {e}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `[tracker.auto_transition]` config section with `on_start`, `on_ship`, and `on_merge` fields
- When configured, parsec automatically transitions Jira tickets to the specified status
- Non-blocking: warns on failure but never stops the main operation
- Includes `fetch_transitions()` and `transition_issue()` Jira API methods

Closes #70

## Test plan
- [ ] Configure `on_start = "In Progress"` → `parsec start` transitions ticket
- [ ] Configure `on_ship = "In Review"` → `parsec ship` transitions ticket
- [ ] Configure `on_merge = "Done"` → `parsec merge` transitions ticket
- [ ] Invalid status name → warning printed, operation continues
- [ ] No config → no transition attempted (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)