### PR TITLE
fix(conflicts): detect committed and uncommitted changes with origin fallback

### DIFF
--- a/src/conflict/detector.rs
+++ b/src/conflict/detector.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::git;
 use crate::worktree::Workspace;
@@ -26,30 +26,31 @@ pub fn detect(workspaces: &[Workspace]) -> Result<Vec<FileConflict>> {
             continue;
         }
 
-        // Get merge-base between workspace branch and base branch
-        // Run from the workspace path
-        let merge_base = match git::get_merge_base(&ws.path, &ws.base_branch, "HEAD") {
-            Ok(base) => base,
-            Err(_) => {
-                skipped.push(ws.ticket.clone());
-                continue;
-            }
-        };
+        // Try origin/base first (more reliable in worktrees), fall back to local base
+        let origin_base = format!("origin/{}", ws.base_branch);
+        let merge_base = git::get_merge_base(&ws.path, &origin_base, "HEAD")
+            .or_else(|_| git::get_merge_base(&ws.path, &ws.base_branch, "HEAD"));
 
-        // Get changed files
-        let changed = match git::get_changed_files(&ws.path, &merge_base, "HEAD") {
-            Ok(files) => files,
-            Err(_) => {
-                skipped.push(ws.ticket.clone());
-                continue;
-            }
-        };
+        let mut all_changed: HashSet<String> = HashSet::new();
 
-        if changed.is_empty() {
-            skipped.push(ws.ticket.clone());
+        // Committed changes (merge_base..HEAD)
+        if let Ok(ref base) = merge_base {
+            if let Ok(files) = git::get_changed_files(&ws.path, base, "HEAD") {
+                all_changed.extend(files);
+            }
         }
 
-        for file in changed {
+        // Uncommitted changes (staged + unstaged)
+        if let Ok(files) = git::get_uncommitted_files(&ws.path) {
+            all_changed.extend(files);
+        }
+
+        if all_changed.is_empty() {
+            skipped.push(ws.ticket.clone());
+            continue;
+        }
+
+        for file in all_changed {
             file_map.entry(file).or_default().push(ws.ticket.clone());
         }
     }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -109,6 +109,23 @@ pub fn get_main_repo_root(path: &Path) -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("git common dir has no parent: {:?}", canonical))
 }
 
+/// Get files with uncommitted changes (staged + unstaged) in the working tree.
+pub fn get_uncommitted_files(repo: &Path) -> Result<Vec<String>> {
+    // Staged changes
+    let staged = run_output(repo, &["diff", "--name-only", "--cached"])?;
+    // Unstaged changes
+    let unstaged = run_output(repo, &["diff", "--name-only"])?;
+
+    let mut files: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for line in staged.lines().chain(unstaged.lines()) {
+        let line = line.trim();
+        if !line.is_empty() {
+            files.insert(line.to_owned());
+        }
+    }
+    Ok(files.into_iter().collect())
+}
+
 /// Return `true` if `branch` has been fully merged into `base`.
 pub fn is_branch_merged(repo: &Path, branch: &str, base: &str) -> Result<bool> {
     // `git branch --merged <base>` lists branches merged into base.


### PR DESCRIPTION
## Summary
- Detect both committed and uncommitted changes when checking for conflicts
- Add origin fallback for remote comparison
- Fixes #67

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)