### PR TITLE
fix(ship): prevent worktree cleanup when PR creation fails

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -204,7 +204,30 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
                     eprintln!("warning: PR creation failed: {e}");
                 }
             }
+        } else {
+            eprintln!("warning: could not detect remote URL — PR creation skipped");
         }
+    }
+
+    // Phase 3: Cleanup only if PR succeeded (or no PR was requested)
+    let pr_expected = !no_pr && config.ship.auto_pr;
+    let pr_succeeded = result.pr_url.is_some();
+
+    if !pr_expected || pr_succeeded {
+        match manager.ship_cleanup(ticket) {
+            Ok(cleaned_up) => result.cleaned_up = cleaned_up,
+            Err(e) => eprintln!("warning: cleanup failed: {e}"),
+        }
+    } else {
+        // PR was expected but not created — preserve worktree for retry
+        eprintln!(
+            "note: worktree preserved at {} — fix the issue and retry `parsec ship {}`",
+            manager
+                .get(ticket)
+                .map(|ws| ws.path.display().to_string())
+                .unwrap_or_default(),
+            ticket
+        );
     }
 
     output::print_ship(&result, mode);

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -349,7 +349,35 @@ impl WorktreeManager {
         git::push_branch(&workspace.path, &workspace.branch)
             .with_context(|| format!("failed to push branch '{}'", workspace.branch))?;
 
-        // Optionally clean up the worktree and local branch.
+        // Mark workspace as shipped (cleanup happens later, after PR creation).
+        if let Some(ws) = state.workspaces.get_mut(ticket) {
+            ws.status = WorkspaceStatus::Shipped;
+        }
+        state
+            .save(&self.repo_root)
+            .context("failed to save parsec state after ship")?;
+
+        Ok(ShipResult {
+            ticket: ticket.to_owned(),
+            branch: workspace.branch,
+            base_branch: workspace.base_branch,
+            ticket_title: workspace.ticket_title,
+            pr_url: None, // Set by commands.rs after async PR creation
+            cleaned_up: false,
+        })
+    }
+
+    /// Remove the worktree and local branch after a successful ship.
+    /// Called only when PR creation succeeded (or no PR was requested).
+    pub fn ship_cleanup(&self, ticket: &str) -> Result<bool> {
+        let mut state =
+            ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
+
+        let workspace = match state.get_workspace(ticket).cloned() {
+            Some(ws) => ws,
+            None => return Ok(false),
+        };
+
         let cleaned_up = if self.config.ship.auto_cleanup {
             match git::worktree_remove(&self.repo_root, &workspace.path) {
                 Ok(()) => {
@@ -365,24 +393,14 @@ impl WorktreeManager {
             false
         };
 
-        // Update persisted state.
         if cleaned_up {
             state.remove_workspace(ticket);
-        } else if let Some(ws) = state.workspaces.get_mut(ticket) {
-            ws.status = WorkspaceStatus::Shipped;
+            state
+                .save(&self.repo_root)
+                .context("failed to save parsec state after cleanup")?;
         }
-        state
-            .save(&self.repo_root)
-            .context("failed to save parsec state after ship")?;
 
-        Ok(ShipResult {
-            ticket: ticket.to_owned(),
-            branch: workspace.branch,
-            base_branch: workspace.base_branch,
-            ticket_title: workspace.ticket_title,
-            pr_url: None, // Set by commands.rs after async PR creation
-            cleaned_up,
-        })
+        Ok(cleaned_up)
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Prevent worktree from being cleaned up when PR creation fails (e.g., 401 credential error)
- Fixes #83

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)