### PR TITLE
feat(config): add default base branch configuration

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -87,6 +87,9 @@ pub struct WorkspaceConfig {
     pub base_dir: String, // only used for Internal layout
     #[serde(default = "default_branch_prefix")]
     pub branch_prefix: String,
+    /// Default base branch for worktree creation (e.g. "develop")
+    #[serde(default)]
+    pub default_base: Option<String>,
 }
 
 impl Default for WorkspaceConfig {
@@ -95,6 +98,7 @@ impl Default for WorkspaceConfig {
             layout: default_layout(),
             base_dir: default_base_dir(),
             branch_prefix: default_branch_prefix(),
+            default_base: None,
         }
     }
 }

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -684,6 +684,9 @@ pub fn print_config_show(config: &ParsecConfig) {
     println!("  layout          = {}", config.workspace.layout);
     println!("  base_dir        = {}", config.workspace.base_dir);
     println!("  branch_prefix   = {}", config.workspace.branch_prefix);
+    if let Some(ref default_base) = config.workspace.default_base {
+        println!("  default_base    = {}", default_base);
+    }
     println!();
     println!("{}", "[tracker]".bold());
     println!("  provider       = {}", config.tracker.provider);

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -52,6 +52,8 @@ impl WorktreeManager {
                     // When stacking, use the parent's branch as base
                     let parent_ws = self.get(parent)?;
                     parent_ws.branch.clone()
+                } else if let Some(ref default_base) = self.config.workspace.default_base {
+                    default_base.clone()
                 } else {
                     git::get_default_branch(&self.repo_root)
                         .context("failed to detect default branch")?


### PR DESCRIPTION
## Summary
- Add `workspace.default_base` config option for default base branch in worktree creation
- Fixes #84

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)