### PR TITLE
feat(list): show PR status in worktree list output

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -143,14 +143,58 @@ pub async fn adopt(
     Ok(())
 }
 
-pub async fn list(repo: &Path, mode: Mode) -> Result<()> {
+pub async fn list(repo: &Path, no_pr: bool, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
-
     let workspaces = manager.list()?;
 
-    output::print_list(&workspaces, mode);
+    // Build PR info map from oplog Ship entries
+    let mut pr_map: std::collections::HashMap<String, (u64, String)> =
+        std::collections::HashMap::new();
+    if !no_pr {
+        if let Ok(oplog) = crate::oplog::OpLog::load(manager.repo_root()) {
+            let remote_url = git::get_remote_url(manager.repo_root()).ok();
+            for entry in &oplog.entries {
+                if matches!(entry.op, crate::oplog::OpKind::Ship) {
+                    if let Some(ref ticket) = entry.ticket {
+                        if let Some(pr_url) = extract_pr_url(&entry.detail) {
+                            if let Some(pr_num) = extract_pr_number(&pr_url) {
+                                pr_map
+                                    .entry(ticket.clone())
+                                    .or_insert((pr_num, "open".to_string()));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Fetch live PR status from GitHub
+            if let Some(ref remote_url) = remote_url {
+                for (_ticket, (pr_num, state)) in pr_map.iter_mut() {
+                    if let Ok(Some(status)) = github::get_pr_status(remote_url, *pr_num).await {
+                        *state = status.state;
+                    }
+                }
+            }
+        }
+    }
+
+    output::print_list(&workspaces, &pr_map, mode);
     Ok(())
+}
+
+fn extract_pr_url(detail: &str) -> Option<String> {
+    // Oplog detail for Ship contains the PR URL after " -> "
+    detail
+        .split(" -> ")
+        .nth(1)
+        .map(|s| s.trim().to_string())
+        .filter(|s| s.starts_with("http"))
+}
+
+fn extract_pr_number(url: &str) -> Option<u64> {
+    // Extract PR number from URL like "https://github.com/owner/repo/pull/123"
+    url.rsplit('/').next().and_then(|s| s.parse().ok())
 }
 
 pub async fn status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<()> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -63,7 +63,12 @@ pub enum Command {
     ///
     /// Shows a table of all parsec-managed worktrees with ticket, branch,
     /// status, creation time, and path. Use --json for machine-readable output.
-    List,
+    /// PR status is fetched automatically; use --no-pr to skip API calls.
+    List {
+        /// Skip PR status lookup (faster, works offline)
+        #[arg(long)]
+        no_pr: bool,
+    },
 
     /// Show detailed status of a workspace
     ///
@@ -387,7 +392,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             )
             .await
         }
-        Command::List => commands::list(&repo_path, output_mode).await,
+        Command::List { no_pr } => commands::list(&repo_path, no_pr, output_mode).await,
         Command::Status { ticket } => {
             commands::status(&repo_path, ticket.as_deref(), output_mode).await
         }

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -15,20 +15,6 @@ use crate::worktree::{ShipResult, Workspace, WorkspaceStatus};
 // ---------------------------------------------------------------------------
 
 #[derive(Tabled)]
-struct WorkspaceRow {
-    #[tabled(rename = "Ticket")]
-    ticket: String,
-    #[tabled(rename = "Branch")]
-    branch: String,
-    #[tabled(rename = "Status")]
-    status: String,
-    #[tabled(rename = "Created")]
-    created: String,
-    #[tabled(rename = "Path")]
-    path: String,
-}
-
-#[derive(Tabled)]
 struct ConflictRow {
     #[tabled(rename = "File")]
     file: String,
@@ -45,16 +31,6 @@ fn status_label(status: &WorkspaceStatus) -> String {
         WorkspaceStatus::Active => "active".green().to_string(),
         WorkspaceStatus::Shipped => "shipped".yellow().to_string(),
         WorkspaceStatus::Merged => "merged".blue().to_string(),
-    }
-}
-
-fn workspace_to_row(ws: &Workspace) -> WorkspaceRow {
-    WorkspaceRow {
-        ticket: ws.ticket.clone(),
-        branch: ws.branch.clone(),
-        status: status_label(&ws.status),
-        created: ws.created_at.format("%Y-%m-%d %H:%M").to_string(),
-        path: ws.path.display().to_string(),
     }
 }
 
@@ -99,12 +75,55 @@ pub fn print_adopt(workspace: &Workspace) {
     );
 }
 
-pub fn print_list(workspaces: &[Workspace]) {
+pub fn print_list(
+    workspaces: &[Workspace],
+    pr_map: &std::collections::HashMap<String, (u64, String)>,
+) {
     if workspaces.is_empty() {
         println!("{}", "No active workspaces.".dimmed());
         return;
     }
-    let rows: Vec<WorkspaceRow> = workspaces.iter().map(workspace_to_row).collect();
+
+    #[derive(Tabled)]
+    struct WorkspaceRowWithPr {
+        #[tabled(rename = "Ticket")]
+        ticket: String,
+        #[tabled(rename = "Branch")]
+        branch: String,
+        #[tabled(rename = "Status")]
+        status: String,
+        #[tabled(rename = "PR")]
+        pr: String,
+        #[tabled(rename = "Created")]
+        created: String,
+        #[tabled(rename = "Path")]
+        path: String,
+    }
+
+    let rows: Vec<WorkspaceRowWithPr> = workspaces
+        .iter()
+        .map(|ws| {
+            let pr = if let Some((num, state)) = pr_map.get(&ws.ticket) {
+                let label = format!("#{}", num);
+                match state.as_str() {
+                    "open" => label.green().to_string(),
+                    "closed" => label.red().to_string(),
+                    "merged" => label.cyan().to_string(),
+                    _ => label,
+                }
+            } else {
+                "-".dimmed().to_string()
+            };
+            WorkspaceRowWithPr {
+                ticket: ws.ticket.clone(),
+                branch: ws.branch.clone(),
+                status: status_label(&ws.status),
+                pr,
+                created: ws.created_at.format("%Y-%m-%d %H:%M").to_string(),
+                path: ws.path.display().to_string(),
+            }
+        })
+        .collect();
     let table = Table::new(rows).with(Style::modern()).to_string();
     println!("{}", table);
 }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -25,8 +25,22 @@ pub fn print_adopt(workspace: &Workspace) {
     emit(workspace);
 }
 
-pub fn print_list(workspaces: &[Workspace]) {
-    emit(&workspaces);
+pub fn print_list(
+    workspaces: &[Workspace],
+    pr_map: &std::collections::HashMap<String, (u64, String)>,
+) {
+    let value: Vec<serde_json::Value> = workspaces
+        .iter()
+        .map(|ws| {
+            let mut obj = serde_json::to_value(ws).unwrap_or(serde_json::json!({}));
+            if let Some((num, state)) = pr_map.get(&ws.ticket) {
+                obj["pr_number"] = serde_json::json!(num);
+                obj["pr_state"] = serde_json::json!(state);
+            }
+            obj
+        })
+        .collect();
+    emit(&value);
 }
 
 pub fn print_status(workspaces: &[Workspace]) {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -41,11 +41,15 @@ pub fn print_adopt(workspace: &Workspace, mode: Mode) {
     }
 }
 
-pub fn print_list(workspaces: &[Workspace], mode: Mode) {
+pub fn print_list(
+    workspaces: &[Workspace],
+    pr_map: &std::collections::HashMap<String, (u64, String)>,
+    mode: Mode,
+) {
     match mode {
         Mode::Quiet => {}
-        Mode::Json => json::print_list(workspaces),
-        Mode::Human => human::print_list(workspaces),
+        Mode::Json => json::print_list(workspaces, pr_map),
+        Mode::Human => human::print_list(workspaces, pr_map),
     }
 }
 


### PR DESCRIPTION
## Summary
- Display associated PR number and status when listing worktrees via `parsec list`
- Fixes #85

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)