### PR TITLE
102: fix: GithubIssueTracker should use host-aware token resolution

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -241,23 +241,20 @@ pub async fn ship(
     // Phase 2: Create PR/MR (async)
     let mut pr_failed = false;
     if !no_pr && config.ship.auto_pr {
-        let ticket_url =
+        let (ticket_title, ticket_url) =
             match tracker::fetch_ticket(&config, ticket, Some(manager.repo_root())).await {
-                Ok(Some(t)) => t.url,
-                _ => None,
+                Ok(Some(t)) => (Some(t.title), t.url),
+                _ => (None, None),
             };
 
-        let pr_title = result
-            .ticket_title
-            .as_ref()
+        // Prefer freshly fetched title over stored one
+        let effective_title = ticket_title.as_deref().or(result.ticket_title.as_deref());
+
+        let pr_title = effective_title
             .map(|t| format!("{}: {}", result.ticket, t))
             .unwrap_or_else(|| result.ticket.clone());
 
-        let pr_body = build_pr_body(
-            &result.ticket,
-            result.ticket_title.as_deref(),
-            ticket_url.as_deref(),
-        );
+        let pr_body = build_pr_body(&result.ticket, effective_title, ticket_url.as_deref());
 
         let remote_url = git::get_remote_url(manager.repo_root());
         if let Ok(ref remote_url) = remote_url {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -84,7 +84,7 @@ pub fn parse_github_remote(url: &str) -> Option<GitHubRemote> {
 /// 1. `config.github.<host>.token` — host-specific config
 /// 2. `PARSEC_GITHUB_TOKEN` env var — explicit override
 /// 3. `GITHUB_TOKEN` / `GH_TOKEN` — generic fallback
-fn resolve_github_token(host: &str, config: &ParsecConfig) -> Option<String> {
+pub fn resolve_github_token(host: &str, config: &ParsecConfig) -> Option<String> {
     // 1. Host-specific config token
     if let Some(host_cfg) = config.github.get(host) {
         if let Some(ref token) = host_cfg.token {

--- a/src/tracker/github_issues.rs
+++ b/src/tracker/github_issues.rs
@@ -3,28 +3,32 @@ use reqwest::Client;
 use std::path::{Path, PathBuf};
 
 use super::Ticket;
+use crate::config::ParsecConfig;
 
 pub struct GithubIssueTracker {
     repo_root: Option<PathBuf>,
+    config: ParsecConfig,
     client: Client,
 }
 
 impl GithubIssueTracker {
-    pub fn new(repo_root: Option<&Path>) -> Self {
+    pub fn new(repo_root: Option<&Path>, config: &ParsecConfig) -> Self {
         Self {
             repo_root: repo_root.map(|p| p.to_path_buf()),
+            config: config.clone(),
             client: Client::new(),
         }
     }
 
-    fn resolve_token() -> Option<String> {
-        crate::env::github_token()
+    fn resolve_token(&self) -> Option<String> {
+        let remote = self.resolve_remote()?;
+        crate::github::resolve_github_token(&remote.host, &self.config)
     }
 
     pub async fn fetch_ticket(&self, id: &str) -> Result<Ticket> {
         let issue_num = id.trim_start_matches('#');
 
-        let token = match Self::resolve_token() {
+        let token = match self.resolve_token() {
             Some(t) => t,
             None => return Ok(self.fallback_ticket(id)),
         };
@@ -85,8 +89,11 @@ impl GithubIssueTracker {
     pub async fn add_comment(&self, id: &str, body: &str) -> Result<()> {
         let issue_num = id.trim_start_matches('#');
 
-        let token = Self::resolve_token().ok_or_else(|| {
-            anyhow::anyhow!("No GitHub token found. Set GITHUB_TOKEN or GH_TOKEN.")
+        let token = self.resolve_token().ok_or_else(|| {
+            anyhow::anyhow!(
+                "No GitHub token found. Configure [github.\"<host>\"] in parsec config \
+                 or set GITHUB_TOKEN."
+            )
         })?;
 
         let remote = self

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -65,7 +65,7 @@ pub async fn fetch_ticket(
     match config.tracker.provider {
         TrackerProvider::Jira => fetch_jira_ticket(config, id).await,
         TrackerProvider::Github => {
-            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+            let tracker = github_issues::GithubIssueTracker::new(repo_root, config);
             let ticket = tracker.fetch_ticket(id).await?;
             Ok(Some(ticket))
         }
@@ -87,7 +87,7 @@ pub async fn fetch_ticket(
                     if crate::github::parse_github_remote(&remote_url).is_some() {
                         let clean_id = id.trim_start_matches('#');
                         if clean_id.chars().all(|c| c.is_ascii_digit()) {
-                            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+                            let tracker = github_issues::GithubIssueTracker::new(repo_root, config);
                             if let Ok(ticket) = tracker.fetch_ticket(id).await {
                                 return Ok(Some(ticket));
                             }
@@ -170,7 +170,7 @@ pub async fn post_comment(
             tracker.add_comment(id, body).await
         }
         TrackerProvider::Github => {
-            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+            let tracker = github_issues::GithubIssueTracker::new(repo_root, config);
             tracker.add_comment(id, body).await
         }
         TrackerProvider::Gitlab | TrackerProvider::None => {
@@ -193,7 +193,7 @@ pub async fn post_comment(
                     if crate::github::parse_github_remote(&remote_url).is_some() {
                         let clean_id = id.trim_start_matches('#');
                         if clean_id.chars().all(|c| c.is_ascii_digit()) {
-                            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+                            let tracker = github_issues::GithubIssueTracker::new(repo_root, config);
                             return tracker.add_comment(id, body).await;
                         }
                     }


### PR DESCRIPTION
## fix: GithubIssueTracker should use host-aware token resolution

**Ticket**: [102](https://github.com/erishforG/git-parsec/issues/102)

Shipped via `parsec ship 102`
