### PR TITLE
107: fix: prune stale remote-tracking references after merge

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -686,6 +686,13 @@ pub async fn merge(
         Some(result) => {
             output::print_merge(&ticket_id, pr_number, &result, method, mode);
 
+            // Prune stale remote-tracking references after remote branch deletion
+            if delete_branch {
+                if let Err(e) = git::fetch(&repo_root) {
+                    eprintln!("warning: failed to prune remote-tracking references: {e}");
+                }
+            }
+
             // Auto-transition ticket status
             if let Some(ref auto) = config.tracker.auto_transition {
                 if let Some(ref status) = auto.on_merge {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -283,7 +283,7 @@ pub fn delete_branch(repo: &Path, branch: &str) -> Result<()> {
 
 /// Fetch all refs from `origin`.
 pub fn fetch(repo: &Path) -> Result<()> {
-    run(repo, &["fetch", "origin"])
+    run(repo, &["fetch", "origin", "--prune"])
 }
 
 /// Fetch from origin if a remote exists. Non-fatal if no remote configured.


### PR DESCRIPTION
## fix: prune stale remote-tracking references after merge

**Ticket**: [107](https://github.com/erishforG/git-parsec/issues/107)

Shipped via `parsec ship 107`
