### PR TITLE
108: chore: bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager — ticket to PR in one command. Parallel AI agent workflows with Jira & GitHub Issues integration."


### PR DESCRIPTION
## chore: bump version to 0.3.0

**Ticket**: [108](https://github.com/erishforG/git-parsec/issues/108)

Shipped via `parsec ship 108`
