### PR TITLE
111: feat: add parsec init and parsec root subcommands for shell integration

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1609,6 +1609,21 @@ pub async fn config_show(mode: Mode) -> Result<()> {
     Ok(())
 }
 
+pub async fn root(repo_path: &Path) -> Result<()> {
+    let repo_root = git::get_main_repo_root(repo_path)?;
+    print!("{}", repo_root.display());
+    Ok(())
+}
+
+pub async fn init_shell(shell: &str) -> Result<()> {
+    let script = match shell {
+        "bash" => INIT_SHELL_BASH,
+        _ => INIT_SHELL_ZSH,
+    };
+    print!("{}", script);
+    Ok(())
+}
+
 pub async fn config_shell(shell: &str, _mode: Mode) -> Result<()> {
     let script = match shell {
         "bash" => SHELL_INTEGRATION_BASH,
@@ -1652,6 +1667,72 @@ function parsec() {
         fi
     else
         command parsec "$@"
+    fi
+}
+"#;
+
+const INIT_SHELL_ZSH: &str = r#"
+# parsec shell integration - add to ~/.zshrc
+# eval "$(parsec init zsh)"
+function parsec() {
+    if [[ "$1" == "switch" && -n "$2" ]]; then
+        local dir
+        dir=$(command parsec switch "${@:2}" 2>&1)
+        if [[ $? -eq 0 && -d "$dir" ]]; then
+            cd "$dir"
+        else
+            echo "$dir" >&2
+            return 1
+        fi
+    else
+        # Save repo root before merge (CWD may be deleted after)
+        local saved_root=""
+        if [[ "$1" == "merge" ]]; then
+            saved_root=$(command parsec root 2>/dev/null)
+        fi
+        command parsec "$@"
+        local exit_code=$?
+        # After merge, if CWD was deleted (worktree cleaned up), cd to main repo
+        if [[ "$1" == "merge" && $exit_code -eq 0 ]] && [[ ! -d "$(pwd)" ]]; then
+            if [[ -n "$saved_root" && -d "$saved_root" ]]; then
+                cd "$saved_root"
+                echo "  cd $saved_root"
+            fi
+        fi
+        return $exit_code
+    fi
+}
+"#;
+
+const INIT_SHELL_BASH: &str = r#"
+# parsec shell integration - add to ~/.bashrc
+# eval "$(parsec init bash)"
+function parsec() {
+    if [[ "$1" == "switch" && -n "$2" ]]; then
+        local dir
+        dir=$(command parsec switch "${@:2}" 2>&1)
+        if [[ $? -eq 0 && -d "$dir" ]]; then
+            cd "$dir"
+        else
+            echo "$dir" >&2
+            return 1
+        fi
+    else
+        # Save repo root before merge (CWD may be deleted after)
+        local saved_root=""
+        if [[ "$1" == "merge" ]]; then
+            saved_root=$(command parsec root 2>/dev/null)
+        fi
+        command parsec "$@"
+        local exit_code=$?
+        # After merge, if CWD was deleted (worktree cleaned up), cd to main repo
+        if [[ "$1" == "merge" && $exit_code -eq 0 ]] && [[ ! -d "$(pwd)" ]]; then
+            if [[ -n "$saved_root" && -d "$saved_root" ]]; then
+                cd "$saved_root"
+                echo "  cd $saved_root"
+            fi
+        fi
+        return $exit_code
     fi
 }
 "#;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -202,7 +202,7 @@ pub enum Command {
     ///
     /// Outputs the absolute path to the worktree for a given ticket.
     /// When called without a ticket, shows an interactive picker.
-    /// With shell integration (eval "$(parsec config shell zsh)"),
+    /// With shell integration (eval "$(parsec init zsh)"),
     /// this command changes your directory automatically.
     Switch {
         /// Ticket identifier (interactive picker if omitted)
@@ -334,6 +334,23 @@ pub enum Command {
         sync: bool,
     },
 
+    /// Print the main repository root path
+    ///
+    /// Outputs the absolute path to the main (non-worktree) repository root.
+    /// Useful for scripting and shell integration after worktree cleanup.
+    Root,
+
+    /// Output shell integration script
+    ///
+    /// Prints a shell function that wraps parsec for auto-cd on switch
+    /// and auto-recovery after merge cleanup. Supports zsh and bash.
+    /// Add eval "$(parsec init zsh)" to your ~/.zshrc.
+    Init {
+        /// Shell type (zsh or bash)
+        #[arg(default_value = "zsh")]
+        shell: String,
+    },
+
     /// Configure parsec
     ///
     /// Manage parsec configuration: run interactive setup, view current
@@ -355,10 +372,10 @@ pub enum ConfigAction {
     ///
     /// Prints the active configuration from ~/.config/parsec/config.toml.
     Show,
-    /// Output shell integration script
+    /// Output shell integration script (deprecated: use `parsec init` instead)
     ///
     /// Prints a shell function that wraps parsec switch to auto-cd.
-    /// Add eval "$(parsec config shell zsh)" to your ~/.zshrc.
+    /// Prefer `parsec init zsh` which also handles merge CWD recovery.
     Shell {
         /// Shell type (zsh or bash)
         #[arg(default_value = "zsh")]
@@ -494,6 +511,8 @@ pub async fn run(cli: Cli) -> Result<()> {
                 commands::stack(&repo_path, output_mode).await
             }
         }
+        Command::Root => commands::root(&repo_path).await,
+        Command::Init { shell } => commands::init_shell(&shell).await,
         Command::Config { action } => match action {
             ConfigAction::Init => commands::config_init(output_mode).await,
             ConfigAction::Show => commands::config_show(output_mode).await,


### PR DESCRIPTION
## feat: add parsec init and parsec root subcommands for shell integration

**Ticket**: [111](https://github.com/erishforG/git-parsec/issues/111)

Shipped via `parsec ship 111`
