### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,26 +26,26 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo check
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -54,11 +54,11 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo clippy -- -D warnings
 
   build:
@@ -68,7 +68,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         if: steps.check.outputs.exists == 'false'
 
       - name: Publish to crates.io

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager — ticket to PR in one command. Parallel AI agent workflows with Jira & GitHub Issues integration."

--- a/README.md
+++ b/README.md
@@ -914,6 +914,11 @@ draft = false         # Create PRs as drafts
 [hooks]
 # Commands to run in new worktrees after creation
 post_create = ["npm install"]
+
+[tracker.auto_transition]
+# on_start = "In Progress"   # Transition when `parsec start` runs
+# on_ship = "In Review"      # Transition when `parsec ship` runs
+# on_merge = "Done"           # Transition when `parsec merge` runs
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -291,13 +291,14 @@ $ parsec status PROJ-1234
 Push the branch, create a PR (GitHub) or MR (GitLab), and clean up the worktree. The forge is auto-detected from the remote URL.
 
 ```
-parsec ship <ticket> [--draft] [--no-pr]
+parsec ship <ticket> [--draft] [--no-pr] [--base <branch>]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--draft` | Create the PR/MR as a draft |
 | `--no-pr` | Push only, skip PR/MR creation |
+| `--base <branch>` | Target base branch for PR (overrides config `default_base` and worktree base) |
 
 ```bash
 # Push + PR + cleanup
@@ -764,6 +765,7 @@ $ parsec config show
   auto_pr         = true
   auto_cleanup    = true
   draft           = false
+  # default_base  = "develop"  # Target branch for PRs (default: worktree base)
 
 # Output shell integration script
 $ parsec config shell zsh

--- a/README.md
+++ b/README.md
@@ -286,6 +286,32 @@ $ parsec status PROJ-1234
 
 ---
 
+### `parsec ticket [ticket]`
+
+View ticket details from the configured tracker. Auto-detects the ticket from the current worktree if no argument is given.
+
+```
+parsec ticket [ticket]
+```
+
+```bash
+# Auto-detect from current worktree
+$ parsec ticket
+CL-2283: Implement rate limiting for API endpoints
+  Status: In Progress
+  Assignee: eric.signal
+  URL: https://jira.example.com/browse/CL-2283
+
+# Explicit ticket
+$ parsec ticket CL-2283
+
+# JSON output
+$ parsec ticket CL-2283 --json
+{"id":"CL-2283","title":"Implement rate limiting","status":"In Progress","assignee":"eric.signal","url":"https://jira.example.com/browse/CL-2283"}
+```
+
+---
+
 ### `parsec ship <ticket>`
 
 Push the branch, create a PR (GitHub) or MR (GitLab), and clean up the worktree. The forge is auto-detected from the remote URL.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # git-parsec
 
+[![Crates.io](https://img.shields.io/crates/v/git-parsec.svg)](https://crates.io/crates/git-parsec)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/erishforG/git-parsec/actions/workflows/ci.yml/badge.svg)](https://github.com/erishforG/git-parsec/actions)
+
 > Git worktree lifecycle manager for parallel AI agent workflows
 
 **parsec** manages isolated git worktrees tied to tickets (Jira, GitHub Issues), enabling multiple AI agents or developers to work on the same repository in parallel without lock conflicts.
@@ -79,6 +83,41 @@ Removed 1 worktree(s):
 - **Auto-cleanup** -- Remove worktrees for merged branches automatically
 - **GitHub and GitLab** -- PR and MR creation for both platforms
 - **Stacked PRs** -- Create dependent PR chains with `--on` and sync the entire stack
+- **Sprint board view** -- See the active sprint as a Kanban board with `parsec board`
+
+## Why AI-Native?
+
+Traditional AI agents waste tokens calling raw APIs. Each Jira or GitHub API call costs dozens of tokens for auth setup, pagination, and response parsing. **parsec packages git + tracker operations into single commands with structured output.**
+
+### Before: Raw API Calls
+
+```bash
+# Agent needs: sprint tickets + status + worktree info + PR status
+# Step 1: Authenticate with Jira API
+# Step 2: Find active sprint (GET /rest/agile/1.0/board/{id}/sprint?state=active)
+# Step 3: Fetch sprint issues (GET /rest/agile/1.0/sprint/{id}/issue)
+# Step 4: For each ticket, check local worktrees (git worktree list, parse output)
+# Step 5: For each ticket, check PR status (GitHub API)
+# → 5+ API calls, 100+ tokens, custom parsing logic
+```
+
+### After: One parsec Command
+
+```bash
+parsec board --json
+# → Sprint + status-grouped tickets + worktree/PR flags in one structured JSON
+```
+
+### Key Benefits for AI Agents
+
+| Capability | What it means |
+|------------|---------------|
+| `--json` on every command | Structured output AI can parse instantly |
+| `parsec start` | git worktree + Jira fetch + state management in one call |
+| `parsec board --json` | Sprint + tickets + worktree/PR status in one call |
+| `parsec ship` | Push + PR creation + cleanup in one call |
+| Env var defaults | Zero-arg commands after one-time setup |
+| Conflict detection | AI agents can check before parallel edits |
 
 ## Installation
 
@@ -659,6 +698,49 @@ $ parsec ship PROJ-1   # PR to main
 $ parsec ship PROJ-2   # PR to feature/PROJ-1
 $ parsec ship PROJ-3   # PR to feature/PROJ-2
 ```
+
+---
+
+### `parsec board`
+
+Show the active sprint as a vertical board view. Fetches tickets from Jira grouped by status column, with worktree and PR indicators.
+
+```
+parsec board [--project <KEY>] [--board-id <ID>] [--assignee <name>] [--all]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-p, --project <KEY>` | Jira project key (default from env/config) |
+| `--board-id <ID>` | Jira board ID (auto-detected from project) |
+| `--assignee <name>` | Filter by assignee (default from env/config) |
+| `--all` | Show all tickets (ignore assignee filter) |
+
+```bash
+# Show your tickets (with PARSEC_JIRA_ASSIGNEE configured)
+$ parsec board
+
+26.04.06 ~ 26.04.20
+
+In Progress (3)
+  CL-2283 [wt]  로그 분석 서비스 개발
+  CL-2284 [wt]  FDE 대시보드 관련
+  CL-2291       반품 요청 API 개발
+
+In Review (2)
+  CL-2281 [pr]  ai 커피챗 준비
+  CL-2280       이관 요청할 API 정리
+
+# Show all team tickets
+$ parsec board --all
+
+# JSON output for AI agents
+$ parsec board --json
+{"sprint":{"id":123,"name":"...","start":"...","end":"..."},"total_count":48,"columns":{"In Progress":[...],...}}
+```
+
+Defaults can be set via environment variables or config file (see below).
+
 ---
 
 ### `parsec config`
@@ -788,6 +870,9 @@ provider = "jira"
 [tracker.jira]
 base_url = "https://yourcompany.atlassian.net"
 # Auth: PARSEC_JIRA_TOKEN or JIRA_PAT env var
+# project = "CL"            # Default project for board
+# board_id = 123            # Default board ID
+# assignee = "eric.signal"  # Default assignee filter
 
 [tracker.gitlab]
 base_url = "https://gitlab.com"
@@ -817,6 +902,9 @@ post_create = ["npm install"]
 | `GH_TOKEN` | Fallback GitHub token |
 | `PARSEC_GITLAB_TOKEN` | GitLab token for MR creation |
 | `GITLAB_TOKEN` | Fallback GitLab token |
+| `PARSEC_JIRA_PROJECT` | Default Jira project key for `board` |
+| `PARSEC_JIRA_BOARD_ID` | Default Jira board ID for `board` |
+| `PARSEC_JIRA_ASSIGNEE` | Default assignee filter for `board` |
 
 Token priority: `PARSEC_*_TOKEN` > platform-specific variables.
 
@@ -837,6 +925,7 @@ Token priority: `PARSEC_*_TOKEN` > platform-specific variables.
 | Stacked PRs | Yes | Yes | No | No | Yes |
 | Auto-cleanup merged | Yes | No | No | Manual | No |
 | Post-create hooks | Yes | No | Yes | No | No |
+| AI token efficiency | Single-command ops | N/A | N/A | N/A | N/A |
 | GUI | CLI only | Desktop + TUI | CLI | CLI | CLI |
 | Zero config start | Yes | No | Yes | No | No |
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -713,7 +713,9 @@ pub async fn merge(
                         .and_then(|e| e.undo_info.as_ref())
                         .and_then(|u| u.branch.clone())
                     {
-                        let _ = git::delete_branch(&repo_root, branch);
+                        if let Err(e) = git::delete_branch(&repo_root, branch) {
+                            eprintln!("warning: failed to delete local branch '{}': {}", branch, e);
+                        }
                     }
 
                     if mode == Mode::Human {
@@ -1085,7 +1087,9 @@ pub async fn undo(repo: &Path, dry_run: bool, mode: Mode) -> Result<()> {
                 }
             }
             if let Some(branch) = &undo_info.branch {
-                let _ = git::delete_branch(&repo_root, branch);
+                if let Err(e) = git::delete_branch(&repo_root, branch) {
+                    eprintln!("warning: failed to delete branch '{}': {e}", branch);
+                }
             }
 
             // Remove from state

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -686,6 +686,13 @@ pub async fn merge(
         Some(result) => {
             output::print_merge(&ticket_id, pr_number, &result, method, mode);
 
+            // Prune stale remote-tracking references after remote branch deletion
+            if delete_branch {
+                if let Err(e) = git::fetch(&repo_root) {
+                    eprintln!("warning: failed to prune remote-tracking references: {e}");
+                }
+            }
+
             // Auto-transition ticket status
             if let Some(ref auto) = config.tracker.auto_transition {
                 if let Some(ref status) = auto.on_merge {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1130,6 +1130,43 @@ pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
     Ok(())
 }
 
+pub async fn ticket(repo: &Path, ticket_override: Option<&str>, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
+
+    // Resolve ticket: explicit arg > auto-detect from current worktree
+    let ticket_id = if let Some(t) = ticket_override {
+        t.to_string()
+    } else {
+        // Try to detect from current worktree
+        let manager = WorktreeManager::new(repo, &config)?;
+        let workspaces = manager.list()?;
+        let current_dir = std::env::current_dir()?;
+
+        workspaces
+            .iter()
+            .find(|ws| current_dir.starts_with(&ws.path))
+            .map(|ws| ws.ticket.clone())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Not inside a parsec worktree. Specify a ticket: `parsec ticket <TICKET>`"
+                )
+            })?
+    };
+
+    // Fetch ticket from tracker
+    let ticket = tracker::fetch_ticket(&config, &ticket_id, Some(repo))
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Could not fetch ticket '{}'. Check your tracker configuration.",
+                ticket_id
+            )
+        })?;
+
+    output::print_ticket(&ticket, mode);
+    Ok(())
+}
+
 pub async fn board(
     repo: &Path,
     board_id_override: Option<u64>,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -115,7 +115,8 @@ pub async fn adopt(
 
     // Auto-detect existing PR for the adopted branch
     if let Ok(remote_url) = git::run_output(manager.repo_root(), &["remote", "get-url", "origin"]) {
-        if let Ok(Some(pr_number)) = github::find_pr_by_branch(&remote_url, &workspace.branch).await
+        if let Ok(Some(pr_number)) =
+            github::find_pr_by_branch(&remote_url, &workspace.branch, &config).await
         {
             // Record synthetic Ship entry so merge/pr-status can find the PR
             let pr_url = if let Some(remote) = github::parse_github_remote(&remote_url) {
@@ -171,7 +172,9 @@ pub async fn list(repo: &Path, no_pr: bool, mode: Mode) -> Result<()> {
             // Fetch live PR status from GitHub
             if let Some(ref remote_url) = remote_url {
                 for (_ticket, (pr_num, state)) in pr_map.iter_mut() {
-                    if let Ok(Some(status)) = github::get_pr_status(remote_url, *pr_num).await {
+                    if let Ok(Some(status)) =
+                        github::get_pr_status(remote_url, *pr_num, &config).await
+                    {
                         *state = status.state;
                     }
                 }
@@ -255,50 +258,67 @@ pub async fn ship(
 
         let remote_url = git::get_remote_url(manager.repo_root());
         if let Ok(ref remote_url) = remote_url {
-            match github::create_pr(
-                remote_url,
-                &result.branch,
-                &result.base_branch,
-                &pr_title,
-                &pr_body,
-                draft || config.ship.draft,
-            )
-            .await
+            // Check if a PR already exists for this branch (#98)
+            if let Ok(Some(existing_pr)) =
+                github::find_pr_by_branch(remote_url, &result.branch, &config).await
             {
-                Ok(Some(pr)) => {
-                    result.pr_url = Some(pr.url);
-                }
-                Ok(None) => {
-                    // GitHub had no token — try GitLab
-                    match gitlab::create_mr(
-                        remote_url,
-                        &result.branch,
-                        &result.base_branch,
-                        &pr_title,
-                        &pr_body,
-                        draft || config.ship.draft,
+                let remote = github::parse_github_remote(remote_url);
+                let pr_url = if let Some(r) = remote {
+                    format!(
+                        "https://{}/{}/{}/pull/{}",
+                        r.host, r.owner, r.repo, existing_pr
                     )
-                    .await
-                    {
-                        Ok(Some(mr)) => {
-                            result.pr_url = Some(mr.url);
-                        }
-                        Ok(None) => {
-                            eprintln!(
-                                "note: PR/MR creation skipped — no token found.\n      \
-                                 Set PARSEC_GITHUB_TOKEN or PARSEC_GITLAB_TOKEN to enable."
-                            );
-                            pr_failed = true;
-                        }
-                        Err(e) => {
-                            eprintln!("error: GitLab MR creation failed: {e}");
-                            pr_failed = true;
+                } else {
+                    format!("PR #{}", existing_pr)
+                };
+                result.pr_url = Some(pr_url);
+            } else {
+                match github::create_pr(
+                    remote_url,
+                    &result.branch,
+                    &result.base_branch,
+                    &pr_title,
+                    &pr_body,
+                    draft || config.ship.draft,
+                    &config,
+                )
+                .await
+                {
+                    Ok(Some(pr)) => {
+                        result.pr_url = Some(pr.url);
+                    }
+                    Ok(None) => {
+                        // GitHub had no token — try GitLab
+                        match gitlab::create_mr(
+                            remote_url,
+                            &result.branch,
+                            &result.base_branch,
+                            &pr_title,
+                            &pr_body,
+                            draft || config.ship.draft,
+                        )
+                        .await
+                        {
+                            Ok(Some(mr)) => {
+                                result.pr_url = Some(mr.url);
+                            }
+                            Ok(None) => {
+                                eprintln!(
+                                    "note: PR/MR creation skipped — no token found.\n      \
+                                     Set PARSEC_GITHUB_TOKEN or PARSEC_GITLAB_TOKEN to enable."
+                                );
+                                pr_failed = true;
+                            }
+                            Err(e) => {
+                                eprintln!("error: GitLab MR creation failed: {e}");
+                                pr_failed = true;
+                            }
                         }
                     }
-                }
-                Err(e) => {
-                    eprintln!("error: PR creation failed: {e}");
-                    pr_failed = true;
+                    Err(e) => {
+                        eprintln!("error: PR creation failed: {e}");
+                        pr_failed = true;
+                    }
                 }
             }
         }
@@ -497,6 +517,7 @@ pub async fn open(
 }
 
 pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
     let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
     let oplog = crate::oplog::OpLog::load(&repo_root)?;
     let remote_url = git::run_output(repo, &["remote", "get-url", "origin"])?;
@@ -521,7 +542,6 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
     // Fallback: search active workspaces for PRs by branch name
     let mut all_entries = entries;
     if all_entries.is_empty() {
-        let config = ParsecConfig::load()?;
         let manager = WorktreeManager::new(repo, &config)?;
         let workspaces = match ticket {
             Some(t) => vec![manager.get(t)?],
@@ -529,7 +549,9 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
         };
 
         for ws in &workspaces {
-            if let Ok(Some(pr_number)) = github::find_pr_by_branch(&remote_url, &ws.branch).await {
+            if let Ok(Some(pr_number)) =
+                github::find_pr_by_branch(&remote_url, &ws.branch, &config).await
+            {
                 all_entries.push((ws.ticket.clone(), pr_number, String::new()));
             }
         }
@@ -545,7 +567,7 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
 
     let mut statuses = Vec::new();
     for (ticket_id, pr_number, _url) in &all_entries {
-        match crate::github::get_pr_status(&remote_url, *pr_number).await? {
+        match crate::github::get_pr_status(&remote_url, *pr_number, &config).await? {
             Some(status) => statuses.push((ticket_id.clone(), status)),
             None => {
                 anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
@@ -602,7 +624,7 @@ pub async fn merge(
             let ws = manager.get(&ticket_id).with_context(|| {
                 format!("ticket {ticket_id} not found in active workspaces or oplog")
             })?;
-            github::find_pr_by_branch(&remote_url, &ws.branch)
+            github::find_pr_by_branch(&remote_url, &ws.branch, &config)
                 .await?
                 .ok_or_else(|| {
                     anyhow::anyhow!(
@@ -619,7 +641,7 @@ pub async fn merge(
             eprint!("Waiting for CI to pass...");
         }
         loop {
-            match github::get_check_runs(&remote_url, pr_number).await? {
+            match github::get_check_runs(&remote_url, pr_number, &config).await? {
                 Some(ci) => {
                     if ci.overall == "passing" {
                         if mode == Mode::Human {
@@ -650,7 +672,7 @@ pub async fn merge(
     let delete_branch = !no_delete_branch;
 
     // Merge the PR
-    match github::merge_pr(&remote_url, pr_number, method, delete_branch).await? {
+    match github::merge_pr(&remote_url, pr_number, method, delete_branch, &config).await? {
         Some(result) => {
             output::print_merge(&ticket_id, pr_number, &result, method, mode);
 
@@ -774,7 +796,7 @@ pub async fn ci(
             let ws = manager.get(&ticket_id).with_context(|| {
                 format!("ticket {ticket_id} not found in active workspaces or oplog")
             })?;
-            match github::find_pr_by_branch(&remote_url, &ws.branch).await? {
+            match github::find_pr_by_branch(&remote_url, &ws.branch, &config).await? {
                 Some(pr_number) => targets.push((ticket_id, pr_number)),
                 None => {
                     anyhow::bail!(
@@ -789,7 +811,7 @@ pub async fn ci(
         let mut statuses: Vec<(String, crate::github::CiStatus)> = Vec::new();
 
         for (ticket_id, pr_number) in &targets {
-            match github::get_check_runs(&remote_url, *pr_number).await? {
+            match github::get_check_runs(&remote_url, *pr_number, &config).await? {
                 Some(ci) => statuses.push((ticket_id.clone(), ci)),
                 None => {
                     anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -363,9 +363,25 @@ pub async fn ship(
     Ok(())
 }
 
-pub async fn clean(repo: &Path, all: bool, dry_run: bool, mode: Mode) -> Result<()> {
+pub async fn clean(repo: &Path, all: bool, dry_run: bool, orphans: bool, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
+
+    if orphans {
+        // Orphan-only mode: just clean state entries without existing directories
+        let orphan_list = manager.clean_orphans(dry_run)?;
+        output::print_clean(&orphan_list, dry_run, mode);
+        return Ok(());
+    }
+
+    // Regular clean — also report orphans as a hint
+    let orphan_list = manager.clean_orphans(true)?; // dry-run detection only
+    if !orphan_list.is_empty() {
+        eprintln!(
+            "note: {} orphan state entry(ies) found (directory missing). Use `parsec clean --orphans` to remove.",
+            orphan_list.len()
+        );
+    }
 
     let removed = manager.clean(all, dry_run)?;
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -136,12 +136,12 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
 
-    // Push + cleanup (sync git operations)
-    let mut result = manager.ship(ticket)?;
+    // Phase 1: Push only (don't clean up yet)
+    let mut result = manager.ship_push(ticket)?;
 
-    // Create GitHub PR (async, uses reqwest)
+    // Phase 2: Create PR/MR (async)
+    let mut pr_failed = false;
     if !no_pr && config.ship.auto_pr {
-        // Fetch ticket info for URL (works for any tracker)
         let ticket_url =
             match tracker::fetch_ticket(&config, ticket, Some(manager.repo_root())).await {
                 Ok(Some(t)) => t.url,
@@ -162,7 +162,6 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
 
         let remote_url = git::get_remote_url(manager.repo_root());
         if let Ok(ref remote_url) = remote_url {
-            // Try GitHub first
             match github::create_pr(
                 remote_url,
                 &result.branch,
@@ -196,17 +195,35 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
                                 "note: PR/MR creation skipped — no token found.\n      \
                                  Set PARSEC_GITHUB_TOKEN or PARSEC_GITLAB_TOKEN to enable."
                             );
+                            pr_failed = true;
                         }
                         Err(e) => {
-                            eprintln!("warning: GitLab MR creation failed: {e}");
+                            eprintln!("error: GitLab MR creation failed: {e}");
+                            pr_failed = true;
                         }
                     }
                 }
                 Err(e) => {
-                    eprintln!("warning: PR creation failed: {e}");
+                    eprintln!("error: PR creation failed: {e}");
+                    pr_failed = true;
                 }
             }
         }
+    }
+
+    // Phase 3: Cleanup only if PR succeeded (or no PR requested)
+    if !pr_failed {
+        let cleaned_up = manager.ship_cleanup(ticket)?;
+        result.cleaned_up = cleaned_up;
+    } else {
+        eprintln!(
+            "note: worktree preserved at {} — fix the issue and retry `parsec ship {}`",
+            manager
+                .get(ticket)
+                .map(|ws| ws.path.display().to_string())
+                .unwrap_or_default(),
+            ticket
+        );
     }
 
     output::print_ship(&result, mode);
@@ -216,13 +233,18 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
         crate::oplog::OpKind::Ship,
         Some(ticket),
         &format!(
-            "Shipped branch '{}'{}",
+            "Shipped branch '{}'{}{}",
             result.branch,
             result
                 .pr_url
                 .as_ref()
                 .map(|u| format!(" -> {}", u))
-                .unwrap_or_default()
+                .unwrap_or_default(),
+            if pr_failed {
+                " (partial: PR failed)"
+            } else {
+                ""
+            },
         ),
         Some(crate::oplog::UndoInfo {
             branch: Some(result.branch.clone()),
@@ -232,6 +254,10 @@ pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mod
         }),
     ) {
         eprintln!("warning: failed to write oplog: {e}");
+    }
+
+    if pr_failed {
+        anyhow::bail!("Ship partial: branch pushed but PR/MR creation failed. Worktree preserved.");
     }
 
     Ok(())

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1339,6 +1339,84 @@ pub async fn ticket(
     Ok(())
 }
 
+pub async fn inbox(repo: &Path, pick: bool, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
+
+    // Inbox currently supports Jira only
+    if !matches!(
+        config.tracker.provider,
+        TrackerProvider::Jira | TrackerProvider::None
+    ) {
+        anyhow::bail!("Inbox currently supports Jira only.");
+    }
+
+    // Load atlassian env for auto-detection
+    tracker::load_atlassian_env();
+
+    // Resolve Jira base URL and email
+    let base_url = config
+        .tracker
+        .jira
+        .as_ref()
+        .map(|j| j.base_url.clone())
+        .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Jira not configured. Run `parsec config init` or set {}.",
+                crate::env::JIRA_BASE_URL,
+            )
+        })?;
+    let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());
+    let jira = JiraTracker::new(&base_url, email.as_deref());
+
+    // JQL: assigned to current user, open statuses, ordered by priority
+    let jql =
+        "assignee = currentUser() AND status in (\"To Do\", \"In Progress\") ORDER BY priority DESC";
+
+    let tickets = jira.search_assigned_issues(jql).await?;
+
+    // Filter out tickets that already have an active parsec worktree
+    let manager = WorktreeManager::new(repo, &config)?;
+    let active_tickets: HashSet<String> =
+        manager.list()?.iter().map(|ws| ws.ticket.clone()).collect();
+
+    let inbox_tickets: Vec<_> = tickets
+        .into_iter()
+        .filter(|t| !active_tickets.contains(&t.key))
+        .collect();
+
+    if pick {
+        if inbox_tickets.is_empty() {
+            anyhow::bail!("No assigned tickets without active worktrees.");
+        }
+        let items: Vec<String> = inbox_tickets
+            .iter()
+            .map(|t| format!("{} — {} [{}]", t.key, t.summary, t.priority))
+            .collect();
+        let selection = dialoguer::Select::new()
+            .with_prompt("Pick a ticket to start")
+            .items(&items)
+            .default(0)
+            .interact()?;
+        let chosen = &inbox_tickets[selection];
+        eprintln!("Starting workspace for {} ...", chosen.key.bold());
+        // Delegate to `start` command
+        return start(
+            repo,
+            &chosen.key,
+            None,
+            Some(chosen.summary.clone()),
+            None,
+            None,
+            mode,
+        )
+        .await;
+    }
+
+    output::print_inbox(&inbox_tickets, mode);
+    Ok(())
+}
+
 pub async fn board(
     repo: &Path,
     board_id_override: Option<u64>,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -143,14 +143,58 @@ pub async fn adopt(
     Ok(())
 }
 
-pub async fn list(repo: &Path, mode: Mode) -> Result<()> {
+pub async fn list(repo: &Path, no_pr: bool, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
-
     let workspaces = manager.list()?;
 
-    output::print_list(&workspaces, mode);
+    // Build PR info map from oplog Ship entries
+    let mut pr_map: std::collections::HashMap<String, (u64, String)> =
+        std::collections::HashMap::new();
+    if !no_pr {
+        if let Ok(oplog) = crate::oplog::OpLog::load(manager.repo_root()) {
+            let remote_url = git::get_remote_url(manager.repo_root()).ok();
+            for entry in &oplog.entries {
+                if matches!(entry.op, crate::oplog::OpKind::Ship) {
+                    if let Some(ref ticket) = entry.ticket {
+                        if let Some(pr_url) = extract_pr_url(&entry.detail) {
+                            if let Some(pr_num) = extract_pr_number(&pr_url) {
+                                pr_map
+                                    .entry(ticket.clone())
+                                    .or_insert((pr_num, "open".to_string()));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Fetch live PR status from GitHub
+            if let Some(ref remote_url) = remote_url {
+                for (_ticket, (pr_num, state)) in pr_map.iter_mut() {
+                    if let Ok(Some(status)) = github::get_pr_status(remote_url, *pr_num).await {
+                        *state = status.state;
+                    }
+                }
+            }
+        }
+    }
+
+    output::print_list(&workspaces, &pr_map, mode);
     Ok(())
+}
+
+fn extract_pr_url(detail: &str) -> Option<String> {
+    // Oplog detail for Ship contains the PR URL after " -> "
+    detail
+        .split(" -> ")
+        .nth(1)
+        .map(|s| s.trim().to_string())
+        .filter(|s| s.starts_with("http"))
+}
+
+fn extract_pr_number(url: &str) -> Option<u64> {
+    // Extract PR number from URL like "https://github.com/owner/repo/pull/123"
+    url.rsplit('/').next().and_then(|s| s.parse().ok())
 }
 
 pub async fn status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<()> {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -324,11 +324,20 @@ pub async fn ship(
         }
     }
 
-    // Phase 3: Cleanup only if PR succeeded (or no PR requested)
-    if !pr_failed {
-        let cleaned_up = manager.ship_cleanup(ticket)?;
-        result.cleaned_up = cleaned_up;
-    } else {
+    // Auto-comment PR link on the ticket if configured
+    if config.tracker.comment_on_ship {
+        if let Some(ref pr_url) = result.pr_url {
+            let comment_body = format!("PR opened: {}", pr_url);
+            if let Err(e) =
+                tracker::post_comment(&config, ticket, &comment_body, Some(manager.repo_root()))
+                    .await
+            {
+                eprintln!("warning: failed to post comment on ticket: {e}");
+            }
+        }
+    }
+
+    if pr_failed {
         eprintln!(
             "note: worktree preserved at {} — fix the issue and retry `parsec ship {}`",
             manager
@@ -683,30 +692,32 @@ pub async fn merge(
                 }
             }
 
-            // Clean up local worktree if it exists
-            if let Ok(ws) = manager.get(&ticket_id) {
-                if ws.path.exists() {
-                    if let Err(e) = git::worktree_remove(&repo_root, &ws.path) {
-                        eprintln!("warning: failed to remove worktree: {e}");
+            // Clean up local worktree if it exists and auto_cleanup is enabled
+            if config.ship.auto_cleanup {
+                if let Ok(ws) = manager.get(&ticket_id) {
+                    if ws.path.exists() {
+                        if let Err(e) = git::worktree_remove(&repo_root, &ws.path) {
+                            eprintln!("warning: failed to remove worktree: {e}");
+                        }
                     }
-                }
-                // Update state
-                let mut state = crate::worktree::ParsecState::load(&repo_root)?;
-                state.remove_workspace(&ticket_id);
-                state.save(&repo_root)?;
+                    // Update state
+                    let mut state = crate::worktree::ParsecState::load(&repo_root)?;
+                    state.remove_workspace(&ticket_id);
+                    state.save(&repo_root)?;
 
-                // Delete local branch
-                if let Some(branch) = &oplog
-                    .get_entries(Some(&ticket_id))
-                    .last()
-                    .and_then(|e| e.undo_info.as_ref())
-                    .and_then(|u| u.branch.clone())
-                {
-                    let _ = git::delete_branch(&repo_root, branch);
-                }
+                    // Delete local branch
+                    if let Some(branch) = &oplog
+                        .get_entries(Some(&ticket_id))
+                        .last()
+                        .and_then(|e| e.undo_info.as_ref())
+                        .and_then(|u| u.branch.clone())
+                    {
+                        let _ = git::delete_branch(&repo_root, branch);
+                    }
 
-                if mode == Mode::Human {
-                    println!("  {}", "Local worktree cleaned up.".dimmed());
+                    if mode == Mode::Human {
+                        println!("  {}", "Local worktree cleaned up.".dimmed());
+                    }
                 }
             }
 
@@ -1278,8 +1289,14 @@ pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
     Ok(())
 }
 
-pub async fn ticket(repo: &Path, ticket_override: Option<&str>, mode: Mode) -> Result<()> {
+pub async fn ticket(
+    repo: &Path,
+    ticket_override: Option<&str>,
+    comment: Option<String>,
+    mode: Mode,
+) -> Result<()> {
     let config = ParsecConfig::load()?;
+    let repo_root = git::get_repo_root(repo)?;
 
     // Resolve ticket: explicit arg > auto-detect from current worktree
     let ticket_id = if let Some(t) = ticket_override {
@@ -1300,6 +1317,13 @@ pub async fn ticket(repo: &Path, ticket_override: Option<&str>, mode: Mode) -> R
                 )
             })?
     };
+
+    // If --comment is provided, post the comment and return
+    if let Some(comment_text) = comment {
+        tracker::post_comment(&config, &ticket_id, &comment_text, Some(&repo_root)).await?;
+        output::print_comment(&ticket_id, mode);
+        return Ok(());
+    }
 
     // Fetch ticket from tracker
     let ticket = tracker::fetch_ticket(&config, &ticket_id, Some(repo))

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -132,12 +132,27 @@ pub async fn status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<()>
     Ok(())
 }
 
-pub async fn ship(repo: &Path, ticket: &str, draft: bool, no_pr: bool, mode: Mode) -> Result<()> {
+pub async fn ship(
+    repo: &Path,
+    ticket: &str,
+    draft: bool,
+    no_pr: bool,
+    base_override: Option<String>,
+    mode: Mode,
+) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
 
     // Phase 1: Push only (don't clean up yet)
     let mut result = manager.ship_push(ticket)?;
+
+    // Resolve base branch: --base CLI > config default_base > worktree's base_branch
+    if let Some(base) = base_override {
+        result.base_branch = base;
+    } else if let Some(ref default_base) = config.ship.default_base {
+        result.base_branch = default_base.clone();
+    }
+    // else: keep the worktree's original base_branch
 
     // Phase 2: Create PR/MR (async)
     let mut pr_failed = false;

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -23,8 +23,9 @@ pub async fn start(
     existing_branch: Option<&str>,
     mode: Mode,
 ) -> Result<()> {
-    let config = ParsecConfig::load()?;
+    let mut config = ParsecConfig::load()?;
     let repo_root = git::get_repo_root(repo)?;
+    config.resolve_for_repo(&repo_root);
 
     let ticket_title = if let Some(t) = title {
         // Manual title provided — skip tracker lookup
@@ -77,8 +78,9 @@ pub async fn adopt(
     title: Option<String>,
     mode: Mode,
 ) -> Result<()> {
-    let config = ParsecConfig::load()?;
+    let mut config = ParsecConfig::load()?;
     let repo_root = git::get_repo_root(repo)?;
+    config.resolve_for_repo(&repo_root);
 
     let ticket_title = if let Some(t) = title {
         Some(t)
@@ -221,8 +223,9 @@ pub async fn ship(
     base_override: Option<String>,
     mode: Mode,
 ) -> Result<()> {
-    let config = ParsecConfig::load()?;
+    let mut config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
+    config.resolve_for_repo(manager.repo_root());
 
     // Phase 1: Push only (don't clean up yet)
     let mut result = manager.ship_push(ticket)?;
@@ -445,10 +448,11 @@ pub async fn open(
     force_ticket: bool,
     mode: Mode,
 ) -> Result<()> {
-    let config = ParsecConfig::load()?;
+    let mut config = ParsecConfig::load()?;
 
     // Try to find PR URL from oplog
     let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    config.resolve_for_repo(&repo_root);
     let oplog = crate::oplog::OpLog::load(&repo_root)?;
     let pr_url: Option<String> = oplog.get_entries(Some(ticket)).iter().rev().find_map(|e| {
         if matches!(e.op, crate::oplog::OpKind::Ship) {
@@ -1295,8 +1299,9 @@ pub async fn ticket(
     comment: Option<String>,
     mode: Mode,
 ) -> Result<()> {
-    let config = ParsecConfig::load()?;
+    let mut config = ParsecConfig::load()?;
     let repo_root = git::get_repo_root(repo)?;
+    config.resolve_for_repo(&repo_root);
 
     // Resolve ticket: explicit arg > auto-detect from current worktree
     let ticket_id = if let Some(t) = ticket_override {
@@ -1340,7 +1345,10 @@ pub async fn ticket(
 }
 
 pub async fn inbox(repo: &Path, pick: bool, mode: Mode) -> Result<()> {
-    let config = ParsecConfig::load()?;
+    let mut config = ParsecConfig::load()?;
+    if let Ok(repo_root) = git::get_repo_root(repo) {
+        config.resolve_for_repo(&repo_root);
+    }
 
     // Inbox currently supports Jira only
     if !matches!(
@@ -1425,7 +1433,10 @@ pub async fn board(
     show_all: bool,
     mode: Mode,
 ) -> Result<()> {
-    let config = ParsecConfig::load()?;
+    let mut config = ParsecConfig::load()?;
+    if let Ok(repo_root) = git::get_repo_root(repo) {
+        config.resolve_for_repo(&repo_root);
+    }
 
     // Board view currently supports Jira only
     if !matches!(

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1609,6 +1609,21 @@ pub async fn config_show(mode: Mode) -> Result<()> {
     Ok(())
 }
 
+pub async fn root(repo_path: &Path) -> Result<()> {
+    let repo_root = git::get_main_repo_root(repo_path)?;
+    print!("{}", repo_root.display());
+    Ok(())
+}
+
+pub async fn init_shell(shell: &str) -> Result<()> {
+    let script = match shell {
+        "bash" => INIT_SHELL_BASH,
+        _ => INIT_SHELL_ZSH,
+    };
+    print!("{}", script);
+    Ok(())
+}
+
 pub async fn config_shell(shell: &str, _mode: Mode) -> Result<()> {
     let script = match shell {
         "bash" => SHELL_INTEGRATION_BASH,
@@ -1652,6 +1667,72 @@ function parsec() {
         fi
     else
         command parsec "$@"
+    fi
+}
+"#;
+
+const INIT_SHELL_ZSH: &str = r#"
+# parsec shell integration - add to ~/.zshrc
+# eval "$(parsec init zsh)"
+function parsec() {
+    if [[ "$1" == "switch" && -n "$2" ]]; then
+        local dir
+        dir=$(command parsec switch "${@:2}" 2>&1)
+        if [[ $? -eq 0 && -d "$dir" ]]; then
+            cd "$dir"
+        else
+            echo "$dir" >&2
+            return 1
+        fi
+    else
+        # Save repo root before merge (CWD may be deleted after)
+        local saved_root=""
+        if [[ "$1" == "merge" ]]; then
+            saved_root=$(command parsec root 2>/dev/null)
+        fi
+        command parsec "$@"
+        local exit_code=$?
+        # After merge, if CWD was deleted (worktree cleaned up), cd to main repo
+        if [[ "$1" == "merge" && $exit_code -eq 0 ]] && [[ ! -d "$(pwd)" ]]; then
+            if [[ -n "$saved_root" && -d "$saved_root" ]]; then
+                cd "$saved_root"
+                echo "  cd $saved_root"
+            fi
+        fi
+        return $exit_code
+    fi
+}
+"#;
+
+const INIT_SHELL_BASH: &str = r#"
+# parsec shell integration - add to ~/.bashrc
+# eval "$(parsec init bash)"
+function parsec() {
+    if [[ "$1" == "switch" && -n "$2" ]]; then
+        local dir
+        dir=$(command parsec switch "${@:2}" 2>&1)
+        if [[ $? -eq 0 && -d "$dir" ]]; then
+            cd "$dir"
+        else
+            echo "$dir" >&2
+            return 1
+        fi
+    else
+        # Save repo root before merge (CWD may be deleted after)
+        local saved_root=""
+        if [[ "$1" == "merge" ]]; then
+            saved_root=$(command parsec root 2>/dev/null)
+        fi
+        command parsec "$@"
+        local exit_code=$?
+        # After merge, if CWD was deleted (worktree cleaned up), cd to main repo
+        if [[ "$1" == "merge" && $exit_code -eq 0 ]] && [[ ! -d "$(pwd)" ]]; then
+            if [[ -n "$saved_root" && -d "$saved_root" ]]; then
+                cd "$saved_root"
+                echo "  cd $saved_root"
+            fi
+        fi
+        return $exit_code
     fi
 }
 "#;

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -113,6 +113,33 @@ pub async fn adopt(
         eprintln!("warning: failed to write oplog: {e}");
     }
 
+    // Auto-detect existing PR for the adopted branch
+    if let Ok(remote_url) = git::run_output(manager.repo_root(), &["remote", "get-url", "origin"]) {
+        if let Ok(Some(pr_number)) = github::find_pr_by_branch(&remote_url, &workspace.branch).await
+        {
+            // Record synthetic Ship entry so merge/pr-status can find the PR
+            let pr_url = if let Some(remote) = github::parse_github_remote(&remote_url) {
+                format!(
+                    "https://{}/{}/{}/pull/{}",
+                    remote.host, remote.owner, remote.repo, pr_number
+                )
+            } else {
+                format!("pull/{}", pr_number)
+            };
+            if let Err(e) = crate::oplog::record(
+                manager.repo_root(),
+                crate::oplog::OpKind::Ship,
+                Some(ticket),
+                &format!("Adopted branch '{}' -> {}", workspace.branch, pr_url),
+                None,
+            ) {
+                eprintln!("warning: failed to record PR in oplog: {e}");
+            } else if mode != Mode::Quiet {
+                eprintln!("  Detected existing PR #{}", pr_number);
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -431,16 +458,33 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
         })
         .collect();
 
-    if entries.is_empty() {
-        if let Some(t) = ticket {
-            anyhow::bail!("no shipped PR found for {t}. Ship it first with `parsec ship {t}`.");
-        } else {
-            anyhow::bail!("no shipped PRs found. Ship a ticket first with `parsec ship`.");
+    // Fallback: search active workspaces for PRs by branch name
+    let mut all_entries = entries;
+    if all_entries.is_empty() {
+        let config = ParsecConfig::load()?;
+        let manager = WorktreeManager::new(repo, &config)?;
+        let workspaces = match ticket {
+            Some(t) => vec![manager.get(t)?],
+            None => manager.list()?,
+        };
+
+        for ws in &workspaces {
+            if let Ok(Some(pr_number)) = github::find_pr_by_branch(&remote_url, &ws.branch).await {
+                all_entries.push((ws.ticket.clone(), pr_number, String::new()));
+            }
+        }
+
+        if all_entries.is_empty() {
+            if let Some(t) = ticket {
+                anyhow::bail!("no PR found for {t}. Ship it first with `parsec ship {t}`, or check your GitHub token.");
+            } else {
+                anyhow::bail!("no PRs found. Ship a ticket first with `parsec ship`, or check your GitHub token.");
+            }
         }
     }
 
     let mut statuses = Vec::new();
-    for (ticket_id, pr_number, _url) in &entries {
+    for (ticket_id, pr_number, _url) in &all_entries {
         match crate::github::get_pr_status(&remote_url, *pr_number).await? {
             Some(status) => statuses.push((ticket_id.clone(), status)),
             None => {
@@ -502,7 +546,8 @@ pub async fn merge(
                 .await?
                 .ok_or_else(|| {
                     anyhow::anyhow!(
-                        "no PR found for {ticket_id}. Ship it first with `parsec ship {ticket_id}`."
+                        "no open PR found for {ticket_id} (branch '{}'). Either ship it with `parsec ship {ticket_id}`, or check that PARSEC_GITHUB_TOKEN is set.",
+                        ws.branch
                     )
                 })?
         }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -241,23 +241,20 @@ pub async fn ship(
     // Phase 2: Create PR/MR (async)
     let mut pr_failed = false;
     if !no_pr && config.ship.auto_pr {
-        let ticket_url =
+        let (ticket_title, ticket_url) =
             match tracker::fetch_ticket(&config, ticket, Some(manager.repo_root())).await {
-                Ok(Some(t)) => t.url,
-                _ => None,
+                Ok(Some(t)) => (Some(t.title), t.url),
+                _ => (None, None),
             };
 
-        let pr_title = result
-            .ticket_title
-            .as_ref()
+        // Prefer freshly fetched title over stored one
+        let effective_title = ticket_title.as_deref().or(result.ticket_title.as_deref());
+
+        let pr_title = effective_title
             .map(|t| format!("{}: {}", result.ticket, t))
             .unwrap_or_else(|| result.ticket.clone());
 
-        let pr_body = build_pr_body(
-            &result.ticket,
-            result.ticket_title.as_deref(),
-            ticket_url.as_deref(),
-        );
+        let pr_body = build_pr_body(&result.ticket, effective_title, ticket_url.as_deref());
 
         let remote_url = git::get_remote_url(manager.repo_root());
         if let Ok(ref remote_url) = remote_url {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,15 +1,17 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use colored::Colorize;
 
-use crate::config::ParsecConfig;
+use crate::config::{ParsecConfig, TrackerProvider};
 use crate::conflict;
 use crate::git;
 use crate::github;
 use crate::gitlab;
-use crate::output::{self, Mode};
+use crate::output::{self, BoardTicketDisplay, Mode};
 use crate::tracker;
+use crate::tracker::jira::JiraTracker;
 use crate::worktree::WorktreeManager;
 
 pub async fn start(
@@ -1084,6 +1086,164 @@ pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
     }
 
     output::print_sync(&synced, &failed, "rebase (stack)", mode);
+    Ok(())
+}
+
+pub async fn board(
+    repo: &Path,
+    board_id_override: Option<u64>,
+    project_override: Option<String>,
+    assignee_override: Option<String>,
+    show_all: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+
+    // Board view currently supports Jira only
+    if !matches!(
+        config.tracker.provider,
+        TrackerProvider::Jira | TrackerProvider::None
+    ) {
+        anyhow::bail!("Board view currently supports Jira only.");
+    }
+
+    // Load atlassian env for auto-detection
+    tracker::load_atlassian_env();
+
+    // Resolve Jira base URL and email
+    let base_url = config
+        .tracker
+        .jira
+        .as_ref()
+        .map(|j| j.base_url.clone())
+        .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Jira not configured. Run `parsec config init` or set {}.",
+                crate::env::JIRA_BASE_URL,
+            )
+        })?;
+    let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());
+    let jira = JiraTracker::new(&base_url, email.as_deref());
+
+    // Resolve project key: --project CLI > PARSEC_JIRA_PROJECT env > config > worktree inference
+    let project = if let Some(p) = project_override {
+        p
+    } else if let Ok(p) = std::env::var(crate::env::PARSEC_JIRA_PROJECT) {
+        p
+    } else if let Some(p) = config.tracker.jira.as_ref().and_then(|j| j.project.clone()) {
+        p
+    } else {
+        let config2 = ParsecConfig::load()?;
+        let manager = WorktreeManager::new(repo, &config2)?;
+        let workspaces = manager.list()?;
+        workspaces
+            .iter()
+            .find_map(|ws| ws.ticket.split('-').next().map(String::from))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Could not infer project key. Use --project <KEY>, set {}, or start a worktree first.",
+                    crate::env::PARSEC_JIRA_PROJECT,
+                )
+            })?
+    };
+
+    // Resolve board ID: --board-id CLI > PARSEC_JIRA_BOARD_ID env > config > API fetch
+    let board_id = if let Some(id) = board_id_override {
+        id
+    } else if let Ok(id_str) = std::env::var(crate::env::PARSEC_JIRA_BOARD_ID) {
+        id_str.parse::<u64>().map_err(|_| {
+            anyhow::anyhow!(
+                "{} must be a valid number, got: {}",
+                crate::env::PARSEC_JIRA_BOARD_ID,
+                id_str,
+            )
+        })?
+    } else if let Some(id) = config.tracker.jira.as_ref().and_then(|j| j.board_id) {
+        id
+    } else {
+        jira.fetch_board_id(&project).await?
+    };
+
+    // Resolve assignee filter: --assignee CLI > PARSEC_JIRA_ASSIGNEE env > config > none
+    let assignee_filter = if show_all {
+        None
+    } else if let Some(a) = assignee_override {
+        Some(a)
+    } else if let Ok(a) = std::env::var(crate::env::PARSEC_JIRA_ASSIGNEE) {
+        Some(a)
+    } else {
+        config
+            .tracker
+            .jira
+            .as_ref()
+            .and_then(|j| j.assignee.clone())
+    };
+
+    // Fetch active sprint
+    let sprint = jira.fetch_active_sprint(board_id).await?;
+
+    // Fetch sprint issues
+    let tickets = jira.fetch_sprint_issues(sprint.id).await?;
+
+    // Collect active worktree ticket set
+    let config3 = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config3)?;
+    let active_worktree_tickets: HashSet<String> =
+        manager.list()?.iter().map(|ws| ws.ticket.clone()).collect();
+
+    // Collect shipped PR ticket set from oplog
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let oplog = crate::oplog::OpLog::load(&repo_root)?;
+    let shipped_tickets: HashSet<String> = oplog
+        .entries
+        .iter()
+        .filter(|e| matches!(e.op, crate::oplog::OpKind::Ship))
+        .filter_map(|e| e.ticket.clone())
+        .collect();
+
+    // Annotate tickets and group by status
+    let mut column_map: Vec<(String, Vec<BoardTicketDisplay>)> = Vec::new();
+
+    // Preserve unique status order as encountered
+    let mut seen_statuses: Vec<String> = Vec::new();
+    for ticket in &tickets {
+        if !seen_statuses.contains(&ticket.status) {
+            seen_statuses.push(ticket.status.clone());
+        }
+    }
+
+    for status in &seen_statuses {
+        let col_tickets: Vec<BoardTicketDisplay> = tickets
+            .iter()
+            .filter(|t| &t.status == status)
+            .filter(|t| {
+                // Apply assignee filter if set
+                if let Some(ref filter) = assignee_filter {
+                    t.assignee.as_deref() == Some(filter.as_str())
+                } else {
+                    true
+                }
+            })
+            .map(|t| BoardTicketDisplay {
+                key: t.key.clone(),
+                summary: t.summary.clone(),
+                assignee: t.assignee.clone(),
+                has_worktree: active_worktree_tickets.contains(&t.key),
+                has_pr: shipped_tickets.contains(&t.key),
+                url: Some(format!(
+                    "{}/browse/{}",
+                    base_url.trim_end_matches('/'),
+                    t.key
+                )),
+            })
+            .collect();
+        if !col_tickets.is_empty() {
+            column_map.push((status.clone(), col_tickets));
+        }
+    }
+
+    output::print_board(Some(&sprint), &column_map, mode);
     Ok(())
 }
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -45,6 +45,13 @@ pub async fn start(
 
     output::print_start(&workspace, mode);
 
+    // Auto-transition ticket status
+    if let Some(ref auto) = config.tracker.auto_transition {
+        if let Some(ref status) = auto.on_start {
+            tracker::try_transition(&config, ticket, status).await;
+        }
+    }
+
     if let Err(e) = crate::oplog::record(
         manager.repo_root(),
         crate::oplog::OpKind::Start,
@@ -242,6 +249,13 @@ pub async fn ship(
     }
 
     output::print_ship(&result, mode);
+
+    // Auto-transition ticket status
+    if let Some(ref auto) = config.tracker.auto_transition {
+        if let Some(ref status) = auto.on_ship {
+            tracker::try_transition(&config, ticket, status).await;
+        }
+    }
 
     if let Err(e) = crate::oplog::record(
         manager.repo_root(),
@@ -534,6 +548,13 @@ pub async fn merge(
     match github::merge_pr(&remote_url, pr_number, method, delete_branch).await? {
         Some(result) => {
             output::print_merge(&ticket_id, pr_number, &result, method, mode);
+
+            // Auto-transition ticket status
+            if let Some(ref auto) = config.tracker.auto_transition {
+                if let Some(ref status) = auto.on_merge {
+                    tracker::try_transition(&config, &ticket_id, status).await;
+                }
+            }
 
             // Clean up local worktree if it exists
             if let Ok(ws) = manager.get(&ticket_id) {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -74,6 +74,16 @@ pub enum Command {
         ticket: Option<String>,
     },
 
+    /// View ticket details from tracker
+    ///
+    /// Fetches and displays ticket information (title, status, assignee)
+    /// from the configured tracker. Auto-detects the ticket from the
+    /// current worktree if no ticket is specified.
+    Ticket {
+        /// Ticket identifier (auto-detects from current worktree if omitted)
+        ticket: Option<String>,
+    },
+
     /// Push, create PR/MR, and clean up a workspace
     ///
     /// Pushes the branch to remote, creates a GitHub PR or GitLab MR
@@ -380,6 +390,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::List => commands::list(&repo_path, output_mode).await,
         Command::Status { ticket } => {
             commands::status(&repo_path, ticket.as_deref(), output_mode).await
+        }
+        Command::Ticket { ticket } => {
+            commands::ticket(&repo_path, ticket.as_deref(), output_mode).await
         }
         Command::Ship {
             ticket,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -63,7 +63,12 @@ pub enum Command {
     ///
     /// Shows a table of all parsec-managed worktrees with ticket, branch,
     /// status, creation time, and path. Use --json for machine-readable output.
-    List,
+    /// PR status is fetched automatically; use --no-pr to skip API calls.
+    List {
+        /// Skip PR status lookup (faster, works offline)
+        #[arg(long)]
+        no_pr: bool,
+    },
 
     /// Show detailed status of a workspace
     ///
@@ -387,7 +392,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             )
             .await
         }
-        Command::List => commands::list(&repo_path, output_mode).await,
+        Command::List { no_pr } => commands::list(&repo_path, no_pr, output_mode).await,
         Command::Status { ticket } => {
             commands::status(&repo_path, ticket.as_deref(), output_mode).await
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -87,6 +87,10 @@ pub enum Command {
     Ticket {
         /// Ticket identifier (auto-detects from current worktree if omitted)
         ticket: Option<String>,
+
+        /// Post a comment on the ticket
+        #[arg(long)]
+        comment: Option<String>,
     },
 
     /// Push, create PR/MR, and clean up a workspace
@@ -400,8 +404,8 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Status { ticket } => {
             commands::status(&repo_path, ticket.as_deref(), output_mode).await
         }
-        Command::Ticket { ticket } => {
-            commands::ticket(&repo_path, ticket.as_deref(), output_mode).await
+        Command::Ticket { ticket, comment } => {
+            commands::ticket(&repo_path, ticket.as_deref(), comment, output_mode).await
         }
         Command::Ship {
             ticket,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -262,6 +262,29 @@ pub enum Command {
         dry_run: bool,
     },
 
+    /// Show the sprint board as a Kanban view
+    ///
+    /// Fetches the active sprint from Jira and displays tickets grouped
+    /// by status column. Active worktrees are marked with [wt] and
+    /// shipped PRs with [pr]. Currently supports Jira only.
+    Board {
+        /// Jira board ID (auto-detected from project if omitted)
+        #[arg(long)]
+        board_id: Option<u64>,
+
+        /// Jira project key (inferred from active worktrees if omitted)
+        #[arg(long, short)]
+        project: Option<String>,
+
+        /// Filter by assignee (default from config/env)
+        #[arg(long)]
+        assignee: Option<String>,
+
+        /// Show all tickets (ignore assignee filter)
+        #[arg(long)]
+        all: bool,
+    },
+
     /// Show or manage stacked PR dependencies
     ///
     /// Displays the dependency graph of worktrees created with --on.
@@ -412,6 +435,12 @@ pub async fn run(cli: Cli) -> Result<()> {
             commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
         }
         Command::Undo { dry_run } => commands::undo(&repo_path, dry_run, output_mode).await,
+        Command::Board {
+            board_id,
+            project,
+            assignee,
+            all,
+        } => commands::board(&repo_path, board_id, project, assignee, all, output_mode).await,
         Command::Stack { sync } => {
             if sync {
                 commands::stack_sync(&repo_path, output_mode).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -123,6 +123,10 @@ pub enum Command {
         /// Dry run - show what would be removed
         #[arg(long)]
         dry_run: bool,
+
+        /// Remove orphan entries (state entries without existing directory)
+        #[arg(long)]
+        orphans: bool,
     },
 
     /// Detect file conflicts across active worktrees
@@ -405,9 +409,11 @@ pub async fn run(cli: Cli) -> Result<()> {
             no_pr,
             base,
         } => commands::ship(&repo_path, &ticket, draft, no_pr, base, output_mode).await,
-        Command::Clean { all, dry_run } => {
-            commands::clean(&repo_path, all, dry_run, output_mode).await
-        }
+        Command::Clean {
+            all,
+            dry_run,
+            orphans,
+        } => commands::clean(&repo_path, all, dry_run, orphans, output_mode).await,
         Command::Sync {
             ticket,
             all,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -202,7 +202,7 @@ pub enum Command {
     ///
     /// Outputs the absolute path to the worktree for a given ticket.
     /// When called without a ticket, shows an interactive picker.
-    /// With shell integration (eval "$(parsec config shell zsh)"),
+    /// With shell integration (eval "$(parsec init zsh)"),
     /// this command changes your directory automatically.
     Switch {
         /// Ticket identifier (interactive picker if omitted)
@@ -334,6 +334,23 @@ pub enum Command {
         sync: bool,
     },
 
+    /// Print the main repository root path
+    ///
+    /// Outputs the absolute path to the main (non-worktree) repository root.
+    /// Useful for scripting and shell integration after worktree cleanup.
+    Root,
+
+    /// Output shell integration script
+    ///
+    /// Prints a shell function that wraps parsec for auto-cd on switch
+    /// and auto-recovery after merge cleanup. Supports zsh and bash.
+    /// Add eval "$(parsec init zsh)" to your ~/.zshrc.
+    Init {
+        /// Shell type (zsh or bash)
+        #[arg(default_value = "zsh")]
+        shell: String,
+    },
+
     /// Configure parsec
     ///
     /// Manage parsec configuration: run interactive setup, view current
@@ -355,10 +372,10 @@ pub enum ConfigAction {
     ///
     /// Prints the active configuration from ~/.config/parsec/config.toml.
     Show,
-    /// Output shell integration script
+    /// Output shell integration script (deprecated: use `parsec init` instead)
     ///
     /// Prints a shell function that wraps parsec switch to auto-cd.
-    /// Add eval "$(parsec config shell zsh)" to your ~/.zshrc.
+    /// Prefer `parsec init zsh` which also handles merge CWD recovery.
     Shell {
         /// Shell type (zsh or bash)
         #[arg(default_value = "zsh")]
@@ -494,6 +511,8 @@ pub async fn run(cli: Cli) -> Result<()> {
                 commands::stack(&repo_path, output_mode).await
             }
         }
+        Command::Root => commands::root(&repo_path).await,
+        Command::Init { shell } => commands::init_shell(&shell).await,
         Command::Config { action } => match action {
             ConfigAction::Init => commands::config_init(output_mode).await,
             ConfigAction::Show => commands::config_show(output_mode).await,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -289,6 +289,18 @@ pub enum Command {
         dry_run: bool,
     },
 
+    /// List assigned tickets without active worktrees
+    ///
+    /// Fetches tickets assigned to you from Jira that don't yet have a
+    /// parsec worktree. Shows a table of ticket key, title, priority,
+    /// and status. Use --pick to interactively select one and auto-start
+    /// a workspace.
+    Inbox {
+        /// Interactively pick a ticket and run `parsec start`
+        #[arg(long)]
+        pick: bool,
+    },
+
     /// Show the sprint board as a Kanban view
     ///
     /// Fetches the active sprint from Jira and displays tickets grouped
@@ -468,6 +480,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
         }
         Command::Undo { dry_run } => commands::undo(&repo_path, dry_run, output_mode).await,
+        Command::Inbox { pick } => commands::inbox(&repo_path, pick, output_mode).await,
         Command::Board {
             board_id,
             project,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,6 +90,10 @@ pub enum Command {
         /// Skip PR creation, only push
         #[arg(long)]
         no_pr: bool,
+
+        /// Target base branch for PR (default from config or worktree base)
+        #[arg(long)]
+        base: Option<String>,
     },
 
     /// Remove merged or stale worktrees
@@ -381,7 +385,8 @@ pub async fn run(cli: Cli) -> Result<()> {
             ticket,
             draft,
             no_pr,
-        } => commands::ship(&repo_path, &ticket, draft, no_pr, output_mode).await,
+            base,
+        } => commands::ship(&repo_path, &ticket, draft, no_pr, base, output_mode).await,
         Command::Clean { all, dry_run } => {
             commands::clean(&repo_path, all, dry_run, output_mode).await
         }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -107,6 +107,9 @@ impl Default for WorkspaceConfig {
 pub struct JiraConfig {
     pub base_url: String,
     pub email: Option<String>,
+    pub project: Option<String>,
+    pub board_id: Option<u64>,
+    pub assignee: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -282,6 +285,9 @@ impl ParsecConfig {
                 } else {
                     Some(email_input)
                 },
+                project: None,
+                board_id: None,
+                assignee: None,
             });
         }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -87,6 +87,9 @@ pub struct WorkspaceConfig {
     pub base_dir: String, // only used for Internal layout
     #[serde(default = "default_branch_prefix")]
     pub branch_prefix: String,
+    /// Default base branch for worktree creation (e.g. "develop")
+    #[serde(default)]
+    pub default_base: Option<String>,
 }
 
 impl Default for WorkspaceConfig {
@@ -95,6 +98,7 @@ impl Default for WorkspaceConfig {
             layout: default_layout(),
             base_dir: default_base_dir(),
             branch_prefix: default_branch_prefix(),
+            default_base: None,
         }
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -157,6 +157,8 @@ pub struct ShipConfig {
     pub auto_cleanup: bool,
     #[serde(default)]
     pub draft: bool,
+    #[serde(default)]
+    pub default_base: Option<String>,
 }
 
 impl Default for ShipConfig {
@@ -165,6 +167,7 @@ impl Default for ShipConfig {
             auto_pr: true,
             auto_cleanup: true,
             draft: false,
+            default_base: None,
         }
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use dialoguer::{Confirm, Input, Select};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
 // Default value helpers required by serde
@@ -224,6 +224,27 @@ pub struct GithubHostConfig {
 }
 
 // ---------------------------------------------------------------------------
+// RepoTrackerOverride / RepoOverrideConfig
+// ---------------------------------------------------------------------------
+
+/// Tracker overrides that can be set per-repo.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RepoTrackerOverride {
+    pub provider: Option<TrackerProvider>,
+    #[serde(default)]
+    pub jira: Option<JiraConfig>,
+    #[serde(default)]
+    pub gitlab: Option<GitlabConfig>,
+}
+
+/// Per-repo configuration overrides.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RepoOverrideConfig {
+    #[serde(default)]
+    pub tracker: Option<RepoTrackerOverride>,
+}
+
+// ---------------------------------------------------------------------------
 // ParsecConfig
 // ---------------------------------------------------------------------------
 
@@ -241,6 +262,10 @@ pub struct ParsecConfig {
     /// "github.example.com". Serializes as `[github."hostname"]` in TOML.
     #[serde(default)]
     pub github: HashMap<String, GithubHostConfig>,
+    /// Per-repo configuration overrides. Keys are "owner/repo" strings.
+    /// Serializes as `[repos."owner/repo"]` in TOML.
+    #[serde(default)]
+    pub repos: HashMap<String, RepoOverrideConfig>,
 }
 
 impl ParsecConfig {
@@ -290,6 +315,54 @@ impl ParsecConfig {
             .with_context(|| format!("Failed to write config file: {}", path.display()))?;
 
         Ok(())
+    }
+
+    /// Apply per-repo tracker overrides for the repository at `repo_root`.
+    ///
+    /// Runs `git remote get-url origin`, parses `owner/repo` from the URL,
+    /// and merges any matching `[repos."owner/repo".tracker]` settings into
+    /// `self.tracker`. Silently ignores errors (no remote, no match, etc.).
+    pub fn resolve_for_repo(&mut self, repo_root: &Path) {
+        // Get the origin remote URL; silently skip if unavailable.
+        let remote_url = match std::process::Command::new("git")
+            .args(["remote", "get-url", "origin"])
+            .current_dir(repo_root)
+            .output()
+        {
+            Ok(out) if out.status.success() => String::from_utf8(out.stdout).unwrap_or_default(),
+            _ => return,
+        };
+        let remote_url = remote_url.trim();
+
+        // Parse owner/repo from the URL.
+        let parsed = crate::github::parse_github_remote(remote_url);
+        let remote = match parsed {
+            Some(r) => r,
+            None => return,
+        };
+        let key = format!("{}/{}", remote.owner, remote.repo);
+
+        // Look up the per-repo override.
+        let repo_cfg = match self.repos.get(&key) {
+            Some(r) => r.clone(),
+            None => return,
+        };
+
+        let tracker_override = match repo_cfg.tracker {
+            Some(t) => t,
+            None => return,
+        };
+
+        // Apply overrides.
+        if let Some(provider) = tracker_override.provider {
+            self.tracker.provider = provider;
+        }
+        if let Some(jira) = tracker_override.jira {
+            self.tracker.jira = Some(jira);
+        }
+        if let Some(gitlab) = tracker_override.gitlab {
+            self.tracker.gitlab = Some(gitlab);
+        }
     }
 
     /// Interactively prompt the user to configure parsec and return the resulting config.

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -140,6 +140,9 @@ pub struct TrackerConfig {
     pub gitlab: Option<GitlabConfig>,
     #[serde(default)]
     pub auto_transition: Option<AutoTransitionConfig>,
+    /// When true, auto-post PR link as comment on the ticket during `parsec ship`
+    #[serde(default)]
+    pub comment_on_ship: bool,
 }
 
 impl Default for TrackerConfig {
@@ -149,6 +152,7 @@ impl Default for TrackerConfig {
             jira: None,
             gitlab: None,
             auto_transition: None,
+            comment_on_ship: false,
         }
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use dialoguer::{Confirm, Input, Select};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 // ---------------------------------------------------------------------------
@@ -208,6 +209,17 @@ pub struct AutoTransitionConfig {
 }
 
 // ---------------------------------------------------------------------------
+// GithubHostConfig
+// ---------------------------------------------------------------------------
+
+/// Per-host GitHub configuration (e.g. token for github.com or a GHE instance).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GithubHostConfig {
+    /// Personal access token for this host.
+    pub token: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
 // ParsecConfig
 // ---------------------------------------------------------------------------
 
@@ -221,6 +233,10 @@ pub struct ParsecConfig {
     pub ship: ShipConfig,
     #[serde(default)]
     pub hooks: HooksConfig,
+    /// Per-host GitHub tokens. Keys are hostnames like "github.com" or
+    /// "github.example.com". Serializes as `[github."hostname"]` in TOML.
+    #[serde(default)]
+    pub github: HashMap<String, GithubHostConfig>,
 }
 
 impl ParsecConfig {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -133,6 +133,8 @@ pub struct TrackerConfig {
     pub jira: Option<JiraConfig>,
     #[serde(default)]
     pub gitlab: Option<GitlabConfig>,
+    #[serde(default)]
+    pub auto_transition: Option<AutoTransitionConfig>,
 }
 
 impl Default for TrackerConfig {
@@ -141,6 +143,7 @@ impl Default for TrackerConfig {
             provider: default_provider(),
             jira: None,
             gitlab: None,
+            auto_transition: None,
         }
     }
 }
@@ -181,6 +184,23 @@ pub struct HooksConfig {
     /// Commands to run after creating a worktree (in the worktree directory)
     #[serde(default)]
     pub post_create: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// AutoTransitionConfig
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AutoTransitionConfig {
+    /// Target status name when `parsec start` is run (e.g. "In Progress")
+    #[serde(default)]
+    pub on_start: Option<String>,
+    /// Target status name when `parsec ship` is run (e.g. "In Review")
+    #[serde(default)]
+    pub on_ship: Option<String>,
+    /// Target status name when `parsec merge` is run (e.g. "Done")
+    #[serde(default)]
+    pub on_merge: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/conflict/detector.rs
+++ b/src/conflict/detector.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::git;
 use crate::worktree::Workspace;
@@ -26,30 +26,31 @@ pub fn detect(workspaces: &[Workspace]) -> Result<Vec<FileConflict>> {
             continue;
         }
 
-        // Get merge-base between workspace branch and base branch
-        // Run from the workspace path
-        let merge_base = match git::get_merge_base(&ws.path, &ws.base_branch, "HEAD") {
-            Ok(base) => base,
-            Err(_) => {
-                skipped.push(ws.ticket.clone());
-                continue;
-            }
-        };
+        // Try origin/base first (more reliable in worktrees), fall back to local base
+        let origin_base = format!("origin/{}", ws.base_branch);
+        let merge_base = git::get_merge_base(&ws.path, &origin_base, "HEAD")
+            .or_else(|_| git::get_merge_base(&ws.path, &ws.base_branch, "HEAD"));
 
-        // Get changed files
-        let changed = match git::get_changed_files(&ws.path, &merge_base, "HEAD") {
-            Ok(files) => files,
-            Err(_) => {
-                skipped.push(ws.ticket.clone());
-                continue;
-            }
-        };
+        let mut all_changed: HashSet<String> = HashSet::new();
 
-        if changed.is_empty() {
-            skipped.push(ws.ticket.clone());
+        // Committed changes (merge_base..HEAD)
+        if let Ok(ref base) = merge_base {
+            if let Ok(files) = git::get_changed_files(&ws.path, base, "HEAD") {
+                all_changed.extend(files);
+            }
         }
 
-        for file in changed {
+        // Uncommitted changes (staged + unstaged)
+        if let Ok(files) = git::get_uncommitted_files(&ws.path) {
+            all_changed.extend(files);
+        }
+
+        if all_changed.is_empty() {
+            skipped.push(ws.ticket.clone());
+            continue;
+        }
+
+        for file in all_changed {
             file_map.entry(file).or_default().push(ws.ticket.clone());
         }
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,70 @@
+//! Centralized environment variable definitions for parsec.
+//!
+//! All env var names and token resolution logic live here so that
+//! adding or renaming a variable only requires touching one file.
+
+// ---------------------------------------------------------------------------
+// Jira
+// ---------------------------------------------------------------------------
+
+pub const PARSEC_JIRA_TOKEN: &str = "PARSEC_JIRA_TOKEN";
+pub const JIRA_PAT: &str = "JIRA_PAT";
+pub const JIRA_BASE_URL: &str = "JIRA_BASE_URL";
+pub const PARSEC_JIRA_PROJECT: &str = "PARSEC_JIRA_PROJECT";
+pub const PARSEC_JIRA_BOARD_ID: &str = "PARSEC_JIRA_BOARD_ID";
+pub const PARSEC_JIRA_ASSIGNEE: &str = "PARSEC_JIRA_ASSIGNEE";
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+pub const PARSEC_GITHUB_TOKEN: &str = "PARSEC_GITHUB_TOKEN";
+pub const GITHUB_TOKEN: &str = "GITHUB_TOKEN";
+pub const GH_TOKEN: &str = "GH_TOKEN";
+
+// ---------------------------------------------------------------------------
+// GitLab
+// ---------------------------------------------------------------------------
+
+pub const PARSEC_GITLAB_TOKEN: &str = "PARSEC_GITLAB_TOKEN";
+pub const GITLAB_TOKEN: &str = "GITLAB_TOKEN";
+
+// ---------------------------------------------------------------------------
+// Token resolvers
+// ---------------------------------------------------------------------------
+
+/// Resolve Jira API token. Priority: PARSEC_JIRA_TOKEN > JIRA_PAT
+pub fn jira_token() -> Option<String> {
+    for var in [PARSEC_JIRA_TOKEN, JIRA_PAT] {
+        if let Ok(token) = std::env::var(var) {
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+    None
+}
+
+/// Resolve GitHub token. Priority: PARSEC_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN
+pub fn github_token() -> Option<String> {
+    for var in [PARSEC_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN] {
+        if let Ok(token) = std::env::var(var) {
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+    None
+}
+
+/// Resolve GitLab token. Priority: PARSEC_GITLAB_TOKEN > GITLAB_TOKEN
+pub fn gitlab_token() -> Option<String> {
+    for var in [PARSEC_GITLAB_TOKEN, GITLAB_TOKEN] {
+        if let Ok(token) = std::env::var(var) {
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+    None
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -153,7 +153,10 @@ pub fn get_remote_url(repo: &Path) -> Result<String> {
 
 /// Push `branch` to origin and set the upstream tracking reference.
 pub fn push_branch(repo: &Path, branch: &str) -> Result<()> {
-    run(repo, &["push", "-u", "origin", branch])
+    run(
+        repo,
+        &["push", "--force-with-lease", "-u", "origin", branch],
+    )
 }
 
 /// Return the name of the currently checked-out branch.

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -283,7 +283,7 @@ pub fn delete_branch(repo: &Path, branch: &str) -> Result<()> {
 
 /// Fetch all refs from `origin`.
 pub fn fetch(repo: &Path) -> Result<()> {
-    run(repo, &["fetch", "origin"])
+    run(repo, &["fetch", "origin", "--prune"])
 }
 
 /// Fetch from origin if a remote exists. Non-fatal if no remote configured.

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -109,6 +109,23 @@ pub fn get_main_repo_root(path: &Path) -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("git common dir has no parent: {:?}", canonical))
 }
 
+/// Get files with uncommitted changes (staged + unstaged) in the working tree.
+pub fn get_uncommitted_files(repo: &Path) -> Result<Vec<String>> {
+    // Staged changes
+    let staged = run_output(repo, &["diff", "--name-only", "--cached"])?;
+    // Unstaged changes
+    let unstaged = run_output(repo, &["diff", "--name-only"])?;
+
+    let mut files: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for line in staged.lines().chain(unstaged.lines()) {
+        let line = line.trim();
+        if !line.is_empty() {
+            files.insert(line.to_owned());
+        }
+    }
+    Ok(files.into_iter().collect())
+}
+
 /// Return `true` if `branch` has been fully merged into `base`.
 pub fn is_branch_merged(repo: &Path, branch: &str, base: &str) -> Result<bool> {
     // `git branch --merged <base>` lists branches merged into base.

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -2,6 +2,8 @@ use anyhow::{bail, Context, Result};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
+use crate::config::ParsecConfig;
+
 /// Result of PR creation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrResult {
@@ -76,24 +78,25 @@ pub fn parse_github_remote(url: &str) -> Option<GitHubRemote> {
     })
 }
 
-/// Resolve a GitHub token from environment variables, then `gh auth token` as fallback.
-/// Checks: PARSEC_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN > `gh auth token`
-fn resolve_github_token() -> Option<String> {
-    if let Some(token) = crate::env::github_token() {
-        return Some(token);
-    }
-
-    // Fallback: try `gh auth token` if gh CLI is installed
-    if let Ok(output) = std::process::Command::new("gh")
-        .args(["auth", "token"])
-        .output()
-    {
-        if output.status.success() {
-            let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+/// Resolve a GitHub token for the given host.
+///
+/// Resolution priority:
+/// 1. `config.github.<host>.token` — host-specific config
+/// 2. `PARSEC_GITHUB_TOKEN` env var — explicit override
+/// 3. `GITHUB_TOKEN` / `GH_TOKEN` — generic fallback
+fn resolve_github_token(host: &str, config: &ParsecConfig) -> Option<String> {
+    // 1. Host-specific config token
+    if let Some(host_cfg) = config.github.get(host) {
+        if let Some(ref token) = host_cfg.token {
             if !token.is_empty() {
-                return Some(token);
+                return Some(token.clone());
             }
         }
+    }
+
+    // 2 & 3. Environment variables (PARSEC_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN)
+    if let Some(token) = crate::env::github_token() {
+        return Some(token);
     }
 
     None
@@ -112,15 +115,19 @@ pub struct PrStatus {
 }
 
 /// Fetch the status of a GitHub PR by number.
-pub async fn get_pr_status(remote_url: &str, pr_number: u64) -> Result<Option<PrStatus>> {
-    let token = match resolve_github_token() {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
+pub async fn get_pr_status(
+    remote_url: &str,
+    pr_number: u64,
+    config: &ParsecConfig,
+) -> Result<Option<PrStatus>> {
     let remote = parse_github_remote(remote_url).ok_or_else(|| {
         anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
     })?;
+
+    let token = match resolve_github_token(&remote.host, config) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
 
     let api_base = remote.api_base();
     let client = Client::new();
@@ -237,15 +244,19 @@ pub struct CiStatus {
 
 /// Fetch check runs for a PR by number.
 /// Returns None if no GitHub token is available.
-pub async fn get_check_runs(remote_url: &str, pr_number: u64) -> Result<Option<CiStatus>> {
-    let token = match resolve_github_token() {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
+pub async fn get_check_runs(
+    remote_url: &str,
+    pr_number: u64,
+    config: &ParsecConfig,
+) -> Result<Option<CiStatus>> {
     let remote = parse_github_remote(remote_url).ok_or_else(|| {
         anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
     })?;
+
+    let token = match resolve_github_token(&remote.host, config) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
 
     let api_base = remote.api_base();
     let client = Client::new();
@@ -328,15 +339,19 @@ pub async fn get_check_runs(remote_url: &str, pr_number: u64) -> Result<Option<C
 
 /// Find an open PR by branch name.
 /// Returns the PR number if found, None if no token or no matching PR.
-pub async fn find_pr_by_branch(remote_url: &str, branch: &str) -> Result<Option<u64>> {
-    let token = match resolve_github_token() {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
+pub async fn find_pr_by_branch(
+    remote_url: &str,
+    branch: &str,
+    config: &ParsecConfig,
+) -> Result<Option<u64>> {
     let remote = parse_github_remote(remote_url).ok_or_else(|| {
         anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
     })?;
+
+    let token = match resolve_github_token(&remote.host, config) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
 
     let api_base = remote.api_base();
     let client = Client::new();
@@ -375,15 +390,16 @@ pub async fn merge_pr(
     pr_number: u64,
     method: &str,
     delete_branch: bool,
+    config: &ParsecConfig,
 ) -> Result<Option<MergeResult>> {
-    let token = match resolve_github_token() {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
     let remote = parse_github_remote(remote_url).ok_or_else(|| {
         anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
     })?;
+
+    let token = match resolve_github_token(&remote.host, config) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
 
     let api_base = remote.api_base();
     let client = Client::new();
@@ -467,15 +483,16 @@ pub async fn create_pr(
     title: &str,
     body: &str,
     draft: bool,
+    config: &ParsecConfig,
 ) -> Result<Option<PrResult>> {
-    let token = match resolve_github_token() {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
     let remote = parse_github_remote(remote_url).ok_or_else(|| {
         anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
     })?;
+
+    let token = match resolve_github_token(&remote.host, config) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
 
     let api_url = format!(
         "{}/repos/{}/{}/pulls",

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -79,14 +79,7 @@ pub fn parse_github_remote(url: &str) -> Option<GitHubRemote> {
 /// Resolve a GitHub token from environment variables.
 /// Checks: PARSEC_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN
 fn resolve_github_token() -> Option<String> {
-    for var in &["PARSEC_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] {
-        if let Ok(token) = std::env::var(var) {
-            if !token.is_empty() {
-                return Some(token);
-            }
-        }
-    }
-    None
+    crate::env::github_token()
 }
 
 /// PR status information

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -456,14 +456,31 @@ pub async fn merge_pr(
                 "{}/repos/{}/{}/git/refs/heads/{}",
                 api_base, remote.owner, remote.repo, branch_name
             );
-            let _ = client
+            match client
                 .delete(&del_url)
                 .header("Accept", "application/vnd.github+json")
                 .header("X-GitHub-Api-Version", "2022-11-28")
                 .header("User-Agent", "git-parsec")
                 .bearer_auth(&token)
                 .send()
-                .await;
+                .await
+            {
+                Ok(resp) if !resp.status().is_success() => {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    eprintln!(
+                        "warning: failed to delete remote branch '{}': {} {}",
+                        branch_name, status, body
+                    );
+                }
+                Err(e) => {
+                    eprintln!(
+                        "warning: failed to delete remote branch '{}': {}",
+                        branch_name, e
+                    );
+                }
+                _ => {} // success
+            }
         }
     }
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -84,7 +84,7 @@ pub fn parse_github_remote(url: &str) -> Option<GitHubRemote> {
 /// 1. `config.github.<host>.token` — host-specific config
 /// 2. `PARSEC_GITHUB_TOKEN` env var — explicit override
 /// 3. `GITHUB_TOKEN` / `GH_TOKEN` — generic fallback
-fn resolve_github_token(host: &str, config: &ParsecConfig) -> Option<String> {
+pub fn resolve_github_token(host: &str, config: &ParsecConfig) -> Option<String> {
     // 1. Host-specific config token
     if let Some(host_cfg) = config.github.get(host) {
         if let Some(ref token) = host_cfg.token {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -76,10 +76,27 @@ pub fn parse_github_remote(url: &str) -> Option<GitHubRemote> {
     })
 }
 
-/// Resolve a GitHub token from environment variables.
-/// Checks: PARSEC_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN
+/// Resolve a GitHub token from environment variables, then `gh auth token` as fallback.
+/// Checks: PARSEC_GITHUB_TOKEN > GITHUB_TOKEN > GH_TOKEN > `gh auth token`
 fn resolve_github_token() -> Option<String> {
-    crate::env::github_token()
+    if let Some(token) = crate::env::github_token() {
+        return Some(token);
+    }
+
+    // Fallback: try `gh auth token` if gh CLI is installed
+    if let Ok(output) = std::process::Command::new("gh")
+        .args(["auth", "token"])
+        .output()
+    {
+        if output.status.success() {
+            let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+
+    None
 }
 
 /// PR status information

--- a/src/gitlab/mod.rs
+++ b/src/gitlab/mod.rs
@@ -51,14 +51,7 @@ pub fn parse_gitlab_remote(url: &str) -> Option<GitLabRemote> {
 /// Resolve a GitLab token from environment variables.
 /// Checks: PARSEC_GITLAB_TOKEN > GITLAB_TOKEN
 fn resolve_gitlab_token() -> Option<String> {
-    for var in &["PARSEC_GITLAB_TOKEN", "GITLAB_TOKEN"] {
-        if let Ok(token) = std::env::var(var) {
-            if !token.is_empty() {
-                return Some(token);
-            }
-        }
-    }
-    None
+    crate::env::gitlab_token()
 }
 
 /// Create a GitLab merge request.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod config;
 mod conflict;
+mod env;
 mod git;
 mod github;
 mod gitlab;

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -2,9 +2,11 @@ use colored::Colorize;
 use tabled::settings::Style;
 use tabled::{Table, Tabled};
 
+use super::BoardTicketDisplay;
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
+use crate::tracker::jira::SprintInfo;
 use crate::worktree::{ShipResult, Workspace, WorkspaceStatus};
 
 // ---------------------------------------------------------------------------
@@ -591,6 +593,66 @@ pub fn print_stack(workspaces: &[Workspace]) {
             println!();
         }
         print_tree(root, &children_map, "", true);
+    }
+}
+
+pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTicketDisplay>)]) {
+    // Sprint header: show dates in compact form
+    if let Some(s) = sprint {
+        let start = s
+            .start_date
+            .as_deref()
+            .and_then(|d| d.get(..10))
+            .unwrap_or("");
+        let end = s
+            .end_date
+            .as_deref()
+            .and_then(|d| d.get(..10))
+            .unwrap_or("");
+        // Use short date format: strip leading "20" → "26.04.06"
+        let fmt_date = |d: &str| -> String {
+            if d.len() >= 10 {
+                let without_century = &d[2..];
+                without_century.replace('-', ".")
+            } else {
+                d.to_string()
+            }
+        };
+        if !start.is_empty() && !end.is_empty() {
+            println!(
+                "{}",
+                format!("{} ~ {}", fmt_date(start), fmt_date(end)).dimmed()
+            );
+        }
+        println!();
+    }
+
+    if columns.is_empty() {
+        println!("{}", "No tickets in sprint.".dimmed());
+        return;
+    }
+
+    for (i, (status, tickets)) in columns.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        // Status header: bold name + dimmed count
+        println!(
+            "{} {}",
+            status.bold(),
+            format!("({})", tickets.len()).dimmed()
+        );
+
+        for ticket in tickets {
+            let indicator = if ticket.has_worktree {
+                format!(" {}", "[wt]".green())
+            } else if ticket.has_pr {
+                format!(" {}", "[pr]".blue())
+            } else {
+                "     ".to_string()
+            };
+            println!("  {}{}  {}", ticket.key, indicator, ticket.summary.dimmed());
+        }
     }
 }
 

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -6,7 +6,7 @@ use super::BoardTicketDisplay;
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
-use crate::tracker::jira::SprintInfo;
+use crate::tracker::jira::{InboxTicket, SprintInfo};
 use crate::tracker::Ticket as TrackerTicket;
 use crate::worktree::{ShipResult, Workspace, WorkspaceStatus};
 
@@ -709,6 +709,57 @@ fn mask_token(token: &str) -> String {
 
 pub fn print_comment(ticket_id: &str) {
     println!("{} Comment posted on {}", "✓".green(), ticket_id.bold());
+}
+
+pub fn print_inbox(tickets: &[InboxTicket]) {
+    if tickets.is_empty() {
+        println!(
+            "{}",
+            "No assigned tickets without active worktrees.".dimmed()
+        );
+        return;
+    }
+
+    #[derive(Tabled)]
+    struct InboxRow {
+        #[tabled(rename = "Ticket")]
+        ticket: String,
+        #[tabled(rename = "Title")]
+        title: String,
+        #[tabled(rename = "Priority")]
+        priority: String,
+        #[tabled(rename = "Status")]
+        status: String,
+    }
+
+    let rows: Vec<InboxRow> = tickets
+        .iter()
+        .map(|t| {
+            let priority = match t.priority.as_str() {
+                "Highest" | "Critical" => t.priority.clone().red().bold().to_string(),
+                "High" => t.priority.clone().red().to_string(),
+                "Medium" => t.priority.clone().yellow().to_string(),
+                "Low" => t.priority.clone().green().to_string(),
+                "Lowest" => t.priority.clone().dimmed().to_string(),
+                _ => t.priority.clone(),
+            };
+            // Truncate long titles for table readability
+            let title = if t.summary.len() > 60 {
+                format!("{}...", &t.summary[..57])
+            } else {
+                t.summary.clone()
+            };
+            InboxRow {
+                ticket: t.key.clone(),
+                title,
+                priority,
+                status: t.status.clone(),
+            }
+        })
+        .collect();
+
+    let table = Table::new(rows).with(Style::modern()).to_string();
+    println!("{}", table);
 }
 
 pub fn print_config_show(config: &ParsecConfig) {

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -698,6 +698,15 @@ pub fn print_ticket(ticket: &TrackerTicket) {
     }
 }
 
+fn mask_token(token: &str) -> String {
+    if token.len() <= 8 {
+        return "*".repeat(token.len());
+    }
+    let prefix = &token[..4];
+    let suffix = &token[token.len() - 4..];
+    format!("{}****...{}", prefix, suffix)
+}
+
 pub fn print_config_show(config: &ParsecConfig) {
     println!("{}", "[workspace]".bold());
     println!("  layout          = {}", config.workspace.layout);
@@ -723,6 +732,18 @@ pub fn print_config_show(config: &ParsecConfig) {
     println!("  auto_pr         = {}", config.ship.auto_pr);
     println!("  auto_cleanup    = {}", config.ship.auto_cleanup);
     println!("  draft           = {}", config.ship.draft);
+    if !config.github.is_empty() {
+        println!();
+        let mut hosts: Vec<&String> = config.github.keys().collect();
+        hosts.sort();
+        for host in hosts {
+            let host_cfg = &config.github[host];
+            println!("{}", format!("[github.\"{}\"]", host).bold());
+            if let Some(ref token) = host_cfg.token {
+                println!("  token           = {}", mask_token(token).dimmed());
+            }
+        }
+    }
     if !config.hooks.post_create.is_empty() {
         println!();
         println!("{}", "[hooks]".bold());

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -15,20 +15,6 @@ use crate::worktree::{ShipResult, Workspace, WorkspaceStatus};
 // ---------------------------------------------------------------------------
 
 #[derive(Tabled)]
-struct WorkspaceRow {
-    #[tabled(rename = "Ticket")]
-    ticket: String,
-    #[tabled(rename = "Branch")]
-    branch: String,
-    #[tabled(rename = "Status")]
-    status: String,
-    #[tabled(rename = "Created")]
-    created: String,
-    #[tabled(rename = "Path")]
-    path: String,
-}
-
-#[derive(Tabled)]
 struct ConflictRow {
     #[tabled(rename = "File")]
     file: String,
@@ -45,16 +31,6 @@ fn status_label(status: &WorkspaceStatus) -> String {
         WorkspaceStatus::Active => "active".green().to_string(),
         WorkspaceStatus::Shipped => "shipped".yellow().to_string(),
         WorkspaceStatus::Merged => "merged".blue().to_string(),
-    }
-}
-
-fn workspace_to_row(ws: &Workspace) -> WorkspaceRow {
-    WorkspaceRow {
-        ticket: ws.ticket.clone(),
-        branch: ws.branch.clone(),
-        status: status_label(&ws.status),
-        created: ws.created_at.format("%Y-%m-%d %H:%M").to_string(),
-        path: ws.path.display().to_string(),
     }
 }
 
@@ -99,12 +75,55 @@ pub fn print_adopt(workspace: &Workspace) {
     );
 }
 
-pub fn print_list(workspaces: &[Workspace]) {
+pub fn print_list(
+    workspaces: &[Workspace],
+    pr_map: &std::collections::HashMap<String, (u64, String)>,
+) {
     if workspaces.is_empty() {
         println!("{}", "No active workspaces.".dimmed());
         return;
     }
-    let rows: Vec<WorkspaceRow> = workspaces.iter().map(workspace_to_row).collect();
+
+    #[derive(Tabled)]
+    struct WorkspaceRowWithPr {
+        #[tabled(rename = "Ticket")]
+        ticket: String,
+        #[tabled(rename = "Branch")]
+        branch: String,
+        #[tabled(rename = "Status")]
+        status: String,
+        #[tabled(rename = "PR")]
+        pr: String,
+        #[tabled(rename = "Created")]
+        created: String,
+        #[tabled(rename = "Path")]
+        path: String,
+    }
+
+    let rows: Vec<WorkspaceRowWithPr> = workspaces
+        .iter()
+        .map(|ws| {
+            let pr = if let Some((num, state)) = pr_map.get(&ws.ticket) {
+                let label = format!("#{}", num);
+                match state.as_str() {
+                    "open" => label.green().to_string(),
+                    "closed" => label.red().to_string(),
+                    "merged" => label.cyan().to_string(),
+                    _ => label,
+                }
+            } else {
+                "-".dimmed().to_string()
+            };
+            WorkspaceRowWithPr {
+                ticket: ws.ticket.clone(),
+                branch: ws.branch.clone(),
+                status: status_label(&ws.status),
+                pr,
+                created: ws.created_at.format("%Y-%m-%d %H:%M").to_string(),
+                path: ws.path.display().to_string(),
+            }
+        })
+        .collect();
     let table = Table::new(rows).with(Style::modern()).to_string();
     println!("{}", table);
 }

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -807,4 +807,24 @@ pub fn print_config_show(config: &ParsecConfig) {
             println!("  post_create     = {}", cmd);
         }
     }
+    if !config.repos.is_empty() {
+        println!();
+        let mut repo_keys: Vec<&String> = config.repos.keys().collect();
+        repo_keys.sort();
+        for key in repo_keys {
+            let repo_cfg = &config.repos[key];
+            if let Some(ref tracker) = repo_cfg.tracker {
+                println!("{}", format!("[repos.\"{}\".tracker]", key).bold());
+                if let Some(ref provider) = tracker.provider {
+                    println!("  provider       = {}", provider);
+                }
+                if let Some(ref jira) = tracker.jira {
+                    println!("  jira.base_url  = {}", jira.base_url);
+                }
+                if let Some(ref gitlab) = tracker.gitlab {
+                    println!("  gitlab.base_url = {}", gitlab.base_url);
+                }
+            }
+        }
+    }
 }

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -684,6 +684,9 @@ pub fn print_config_show(config: &ParsecConfig) {
     println!("  layout          = {}", config.workspace.layout);
     println!("  base_dir        = {}", config.workspace.base_dir);
     println!("  branch_prefix   = {}", config.workspace.branch_prefix);
+    if let Some(ref default_base) = config.workspace.default_base {
+        println!("  default_base    = {}", default_base);
+    }
     println!();
     println!("{}", "[tracker]".bold());
     println!("  provider       = {}", config.tracker.provider);

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -707,6 +707,10 @@ fn mask_token(token: &str) -> String {
     format!("{}****...{}", prefix, suffix)
 }
 
+pub fn print_comment(ticket_id: &str) {
+    println!("{} Comment posted on {}", "✓".green(), ticket_id.bold());
+}
+
 pub fn print_config_show(config: &ParsecConfig) {
     println!("{}", "[workspace]".bold());
     println!("  layout          = {}", config.workspace.layout);
@@ -727,6 +731,7 @@ pub fn print_config_show(config: &ParsecConfig) {
     if let Some(gitlab) = &config.tracker.gitlab {
         println!("  gitlab.base_url = {}", gitlab.base_url);
     }
+    println!("  comment_on_ship = {}", config.tracker.comment_on_ship);
     println!();
     println!("{}", "[ship]".bold());
     println!("  auto_pr         = {}", config.ship.auto_pr);

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -7,6 +7,7 @@ use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
 use crate::tracker::jira::SprintInfo;
+use crate::tracker::Ticket as TrackerTicket;
 use crate::worktree::{ShipResult, Workspace, WorkspaceStatus};
 
 // ---------------------------------------------------------------------------
@@ -662,6 +663,19 @@ pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTic
             };
             println!("  {}{}  {}", ticket.key, indicator, ticket.summary.dimmed());
         }
+    }
+}
+
+pub fn print_ticket(ticket: &TrackerTicket) {
+    println!("{}: {}", ticket.id.yellow().bold(), ticket.title.bold());
+    if let Some(ref status) = ticket.status {
+        println!("  {} {}", "Status:".bold(), status);
+    }
+    if let Some(ref assignee) = ticket.assignee {
+        println!("  {} {}", "Assignee:".bold(), assignee);
+    }
+    if let Some(ref url) = ticket.url {
+        println!("  {} {}", "URL:".bold(), url.cyan());
     }
 }
 

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -133,7 +133,16 @@ pub fn print_status(workspaces: &[Workspace]) {
 }
 
 pub fn print_ship(result: &ShipResult) {
-    println!("{}", format!("Shipped {}!", result.ticket).green().bold());
+    if result.pr_url.is_some() || result.cleaned_up {
+        println!("{}", format!("Shipped {}!", result.ticket).green().bold());
+    } else {
+        println!(
+            "{}",
+            format!("Shipped {} (partial — PR failed)", result.ticket)
+                .yellow()
+                .bold()
+        );
+    }
     if let Some(url) = &result.pr_url {
         println!("  {} {}", "PR:".bold(), url.cyan());
     }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -6,6 +6,7 @@ use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
 use crate::tracker::jira::SprintInfo;
+use crate::tracker::Ticket as TrackerTicket;
 use crate::worktree::{ShipResult, Workspace};
 
 fn emit<T: Serialize>(value: &T) {
@@ -181,6 +182,10 @@ pub fn print_undo_preview(entry: &OpEntry) {
         "undo_info": entry.undo_info,
     });
     println!("{}", value);
+}
+
+pub fn print_ticket(ticket: &TrackerTicket) {
+    emit(ticket);
 }
 
 pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTicketDisplay>)]) {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,9 +1,11 @@
 use serde::Serialize;
 use serde_json::json;
 
+use super::BoardTicketDisplay;
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
+use crate::tracker::jira::SprintInfo;
 use crate::worktree::{ShipResult, Workspace};
 
 fn emit<T: Serialize>(value: &T) {
@@ -177,6 +179,56 @@ pub fn print_undo_preview(entry: &OpEntry) {
         "would_undo": format!("{}", entry.op),
         "ticket": entry.ticket,
         "undo_info": entry.undo_info,
+    });
+    println!("{}", value);
+}
+
+pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTicketDisplay>)]) {
+    let sprint_json = sprint.map(|s| {
+        json!({
+            "id": s.id,
+            "name": s.name,
+            "start": s.start_date,
+            "end": s.end_date,
+        })
+    });
+
+    let total_count: usize = columns.iter().map(|(_, tickets)| tickets.len()).sum();
+
+    let columns_json: serde_json::Map<String, serde_json::Value> = columns
+        .iter()
+        .map(|(name, tickets)| {
+            let ticket_list: Vec<serde_json::Value> = tickets
+                .iter()
+                .map(|t| {
+                    let mut obj = json!({
+                        "key": t.key,
+                        "summary": t.summary,
+                        "status": name,
+                    });
+                    if let Some(ref assignee) = t.assignee {
+                        obj["assignee"] = json!(assignee);
+                    }
+                    if let Some(ref url) = t.url {
+                        obj["url"] = json!(url);
+                    }
+                    if t.has_worktree {
+                        obj["worktree"] = json!(true);
+                    }
+                    if t.has_pr {
+                        obj["pr"] = json!(true);
+                    }
+                    obj
+                })
+                .collect();
+            (name.clone(), json!(ticket_list))
+        })
+        .collect();
+
+    let value = json!({
+        "sprint": sprint_json,
+        "total_count": total_count,
+        "columns": columns_json,
     });
     println!("{}", value);
 }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -5,7 +5,7 @@ use super::BoardTicketDisplay;
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
-use crate::tracker::jira::SprintInfo;
+use crate::tracker::jira::{InboxTicket, SprintInfo};
 use crate::tracker::Ticket as TrackerTicket;
 use crate::worktree::{ShipResult, Workspace};
 
@@ -209,6 +209,10 @@ pub fn print_comment(ticket_id: &str) {
         "status": "ok",
     });
     println!("{}", value);
+}
+
+pub fn print_inbox(tickets: &[InboxTicket]) {
+    emit(&tickets);
 }
 
 pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTicketDisplay>)]) {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -25,8 +25,22 @@ pub fn print_adopt(workspace: &Workspace) {
     emit(workspace);
 }
 
-pub fn print_list(workspaces: &[Workspace]) {
-    emit(&workspaces);
+pub fn print_list(
+    workspaces: &[Workspace],
+    pr_map: &std::collections::HashMap<String, (u64, String)>,
+) {
+    let value: Vec<serde_json::Value> = workspaces
+        .iter()
+        .map(|ws| {
+            let mut obj = serde_json::to_value(ws).unwrap_or(serde_json::json!({}));
+            if let Some((num, state)) = pr_map.get(&ws.ticket) {
+                obj["pr_number"] = serde_json::json!(num);
+                obj["pr_state"] = serde_json::json!(state);
+            }
+            obj
+        })
+        .collect();
+    emit(&value);
 }
 
 pub fn print_status(workspaces: &[Workspace]) {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -202,6 +202,15 @@ pub fn print_ticket(ticket: &TrackerTicket) {
     emit(ticket);
 }
 
+pub fn print_comment(ticket_id: &str) {
+    let value = json!({
+        "action": "comment",
+        "ticket": ticket_id,
+        "status": "ok",
+    });
+    println!("{}", value);
+}
+
 pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTicketDisplay>)]) {
     let sprint_json = sprint.map(|s| {
         json!({

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,6 +5,7 @@ use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
 use crate::tracker::jira::SprintInfo;
+use crate::tracker::Ticket as TrackerTicket;
 use crate::worktree::{ShipResult, Workspace};
 
 /// A ticket annotated with parsec-specific indicators for board display.
@@ -203,5 +204,13 @@ pub fn print_board(
         Mode::Quiet => {}
         Mode::Json => json::print_board(sprint, columns),
         Mode::Human => human::print_board(sprint, columns),
+    }
+}
+
+pub fn print_ticket(ticket: &TrackerTicket, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_ticket(ticket),
+        Mode::Human => human::print_ticket(ticket),
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -41,11 +41,15 @@ pub fn print_adopt(workspace: &Workspace, mode: Mode) {
     }
 }
 
-pub fn print_list(workspaces: &[Workspace], mode: Mode) {
+pub fn print_list(
+    workspaces: &[Workspace],
+    pr_map: &std::collections::HashMap<String, (u64, String)>,
+    mode: Mode,
+) {
     match mode {
         Mode::Quiet => {}
-        Mode::Json => json::print_list(workspaces),
-        Mode::Human => human::print_list(workspaces),
+        Mode::Json => json::print_list(workspaces, pr_map),
+        Mode::Human => human::print_list(workspaces, pr_map),
     }
 }
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,7 +4,18 @@ mod json;
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
+use crate::tracker::jira::SprintInfo;
 use crate::worktree::{ShipResult, Workspace};
+
+/// A ticket annotated with parsec-specific indicators for board display.
+pub struct BoardTicketDisplay {
+    pub key: String,
+    pub summary: String,
+    pub assignee: Option<String>,
+    pub has_worktree: bool,
+    pub has_pr: bool,
+    pub url: Option<String>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Mode {
@@ -181,4 +192,16 @@ pub fn print_diff_stat(stat: &str, ticket: &str, mode: Mode) {
 
 pub fn print_diff_full_json(files: &[(String, String)], ticket: &str) {
     json::print_diff_full(files, ticket);
+}
+
+pub fn print_board(
+    sprint: Option<&SprintInfo>,
+    columns: &[(String, Vec<BoardTicketDisplay>)],
+    mode: Mode,
+) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_board(sprint, columns),
+        Mode::Human => human::print_board(sprint, columns),
+    }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -218,3 +218,11 @@ pub fn print_ticket(ticket: &TrackerTicket, mode: Mode) {
         Mode::Human => human::print_ticket(ticket),
     }
 }
+
+pub fn print_comment(ticket_id: &str, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_comment(ticket_id),
+        Mode::Human => human::print_comment(ticket_id),
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,7 +4,7 @@ mod json;
 use crate::config::ParsecConfig;
 use crate::conflict::FileConflict;
 use crate::oplog::OpEntry;
-use crate::tracker::jira::SprintInfo;
+use crate::tracker::jira::{InboxTicket, SprintInfo};
 use crate::tracker::Ticket as TrackerTicket;
 use crate::worktree::{ShipResult, Workspace};
 
@@ -224,5 +224,13 @@ pub fn print_comment(ticket_id: &str, mode: Mode) {
         Mode::Quiet => {}
         Mode::Json => json::print_comment(ticket_id),
         Mode::Human => human::print_comment(ticket_id),
+    }
+}
+
+pub fn print_inbox(tickets: &[InboxTicket], mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_inbox(tickets),
+        Mode::Human => human::print_inbox(tickets),
     }
 }

--- a/src/tracker/github_issues.rs
+++ b/src/tracker/github_issues.rs
@@ -80,6 +80,57 @@ impl GithubIssueTracker {
         })
     }
 
+    /// Post a comment on a GitHub issue.
+    /// Endpoint: POST /repos/{owner}/{repo}/issues/{number}/comments
+    pub async fn add_comment(&self, id: &str, body: &str) -> Result<()> {
+        let issue_num = id.trim_start_matches('#');
+
+        let token = Self::resolve_token().ok_or_else(|| {
+            anyhow::anyhow!("No GitHub token found. Set GITHUB_TOKEN or GH_TOKEN.")
+        })?;
+
+        let remote = self
+            .resolve_remote()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine GitHub remote from repository."))?;
+
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}/comments",
+            remote.api_base(),
+            remote.owner,
+            remote.repo,
+            issue_num
+        );
+
+        let payload = serde_json::json!({
+            "body": body
+        });
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "git-parsec")
+            .bearer_auth(&token)
+            .json(&payload)
+            .send()
+            .await
+            .context("Failed to send comment request to GitHub Issues API")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let resp_body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "GitHub Issues comment API returned {} for #{}: {}",
+                status,
+                issue_num,
+                resp_body
+            );
+        }
+
+        Ok(())
+    }
+
     fn resolve_remote(&self) -> Option<crate::github::GitHubRemote> {
         let repo_root = self.repo_root.as_ref()?;
         let remote_url = crate::git::get_remote_url(repo_root).ok()?;

--- a/src/tracker/github_issues.rs
+++ b/src/tracker/github_issues.rs
@@ -3,28 +3,32 @@ use reqwest::Client;
 use std::path::{Path, PathBuf};
 
 use super::Ticket;
+use crate::config::ParsecConfig;
 
 pub struct GithubIssueTracker {
     repo_root: Option<PathBuf>,
+    config: ParsecConfig,
     client: Client,
 }
 
 impl GithubIssueTracker {
-    pub fn new(repo_root: Option<&Path>) -> Self {
+    pub fn new(repo_root: Option<&Path>, config: &ParsecConfig) -> Self {
         Self {
             repo_root: repo_root.map(|p| p.to_path_buf()),
+            config: config.clone(),
             client: Client::new(),
         }
     }
 
-    fn resolve_token() -> Option<String> {
-        crate::env::github_token()
+    fn resolve_token(&self) -> Option<String> {
+        let remote = self.resolve_remote()?;
+        crate::github::resolve_github_token(&remote.host, &self.config)
     }
 
     pub async fn fetch_ticket(&self, id: &str) -> Result<Ticket> {
         let issue_num = id.trim_start_matches('#');
 
-        let token = match Self::resolve_token() {
+        let token = match self.resolve_token() {
             Some(t) => t,
             None => return Ok(self.fallback_ticket(id)),
         };
@@ -85,8 +89,11 @@ impl GithubIssueTracker {
     pub async fn add_comment(&self, id: &str, body: &str) -> Result<()> {
         let issue_num = id.trim_start_matches('#');
 
-        let token = Self::resolve_token().ok_or_else(|| {
-            anyhow::anyhow!("No GitHub token found. Set GITHUB_TOKEN or GH_TOKEN.")
+        let token = self.resolve_token().ok_or_else(|| {
+            anyhow::anyhow!(
+                "No GitHub token found. Configure [github.\"<host>\"] in parsec config \
+                 or set GITHUB_TOKEN."
+            )
         })?;
 
         let remote = self

--- a/src/tracker/github_issues.rs
+++ b/src/tracker/github_issues.rs
@@ -18,14 +18,7 @@ impl GithubIssueTracker {
     }
 
     fn resolve_token() -> Option<String> {
-        for var in &["PARSEC_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] {
-            if let Ok(token) = std::env::var(var) {
-                if !token.is_empty() {
-                    return Some(token);
-                }
-            }
-        }
-        None
+        crate::env::github_token()
     }
 
     pub async fn fetch_ticket(&self, id: &str) -> Result<Ticket> {

--- a/src/tracker/jira.rs
+++ b/src/tracker/jira.rs
@@ -19,6 +19,15 @@ pub struct BoardTicket {
     pub assignee: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InboxTicket {
+    pub key: String,
+    pub summary: String,
+    pub status: String,
+    pub priority: String,
+    pub url: String,
+}
+
 pub struct JiraTracker {
     base_url: String,
     email: Option<String>,
@@ -410,6 +419,74 @@ impl JiraTracker {
                         assignee: issue["fields"]["assignee"]["displayName"]
                             .as_str()
                             .map(String::from),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(issues)
+    }
+
+    /// Search for issues assigned to the current user via JQL.
+    /// Endpoint: GET /rest/api/2/search?jql=...&fields=summary,status,priority,assignee
+    pub async fn search_assigned_issues(&self, jql: &str) -> Result<Vec<InboxTicket>> {
+        let token = Self::resolve_token()?;
+        let url = format!("{}/rest/api/2/search", self.base_url);
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json")
+            .query(&[
+                ("jql", jql),
+                ("fields", "summary,status,priority,assignee"),
+                ("maxResults", "50"),
+            ]);
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to search Jira issues")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Jira search API returned {} : {}", status, body);
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse Jira search response")?;
+
+        let issues = body["issues"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .map(|issue| {
+                        let key = issue["key"].as_str().unwrap_or("").to_string();
+                        InboxTicket {
+                            url: format!("{}/browse/{}", self.base_url, key),
+                            key,
+                            summary: issue["fields"]["summary"]
+                                .as_str()
+                                .unwrap_or("")
+                                .to_string(),
+                            status: issue["fields"]["status"]["name"]
+                                .as_str()
+                                .unwrap_or("Unknown")
+                                .to_string(),
+                            priority: issue["fields"]["priority"]["name"]
+                                .as_str()
+                                .unwrap_or("None")
+                                .to_string(),
+                        }
                     })
                     .collect()
             })

--- a/src/tracker/jira.rs
+++ b/src/tracker/jira.rs
@@ -197,6 +197,120 @@ impl JiraTracker {
         })
     }
 
+    /// Fetch available transitions for an issue.
+    /// Endpoint: GET /rest/api/2/issue/{key}/transitions
+    pub async fn fetch_transitions(&self, key: &str) -> Result<Vec<(String, String)>> {
+        let token = Self::resolve_token()?;
+        let url = format!("{}/rest/api/2/issue/{}/transitions", self.base_url, key);
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json");
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to fetch transitions")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!(
+                "Jira transitions API returned {} for {}: {}",
+                status,
+                key,
+                body
+            );
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse transitions response")?;
+
+        let transitions = body["transitions"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let id = t["id"].as_str()?.to_string();
+                        let name = t["to"]["name"]
+                            .as_str()
+                            .or_else(|| t["name"].as_str())?
+                            .to_string();
+                        Some((id, name))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(transitions)
+    }
+
+    /// Transition an issue to a new status by name.
+    /// Finds the matching transition ID, then POST /rest/api/2/issue/{key}/transitions
+    pub async fn transition_issue(&self, key: &str, target_status: &str) -> Result<()> {
+        let transitions = self.fetch_transitions(key).await?;
+
+        let transition_id = transitions
+            .iter()
+            .find(|(_, name)| name.eq_ignore_ascii_case(target_status))
+            .map(|(id, _)| id.clone())
+            .ok_or_else(|| {
+                let available: Vec<&str> = transitions.iter().map(|(_, n)| n.as_str()).collect();
+                anyhow::anyhow!(
+                    "No transition to '{}' found for {}. Available: {:?}",
+                    target_status,
+                    key,
+                    available
+                )
+            })?;
+
+        let token = Self::resolve_token()?;
+        let url = format!("{}/rest/api/2/issue/{}/transitions", self.base_url, key);
+
+        let payload = serde_json::json!({
+            "transition": { "id": transition_id }
+        });
+
+        let mut request = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&payload);
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to send transition request")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!(
+                "Jira transition API returned {} for {}: {}",
+                status,
+                key,
+                body
+            );
+        }
+
+        Ok(())
+    }
+
     /// Fetch all issues in a sprint via Jira Agile REST API v1.0.
     /// Requires: Jira Software (Cloud or Server/DC 7.x+)
     /// Endpoint: GET /rest/agile/1.0/sprint/{id}/issue?fields=summary,status,assignee

--- a/src/tracker/jira.rs
+++ b/src/tracker/jira.rs
@@ -311,6 +311,47 @@ impl JiraTracker {
         Ok(())
     }
 
+    /// Post a comment on a Jira issue.
+    /// Endpoint: POST /rest/api/2/issue/{key}/comment
+    pub async fn add_comment(&self, key: &str, body: &str) -> Result<()> {
+        let token = Self::resolve_token()?;
+        let url = format!("{}/rest/api/2/issue/{}/comment", self.base_url, key);
+
+        let payload = serde_json::json!({
+            "body": body
+        });
+
+        let mut request = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&payload);
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to send comment request to Jira")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let resp_body = response.text().await.unwrap_or_default();
+            bail!(
+                "Jira comment API returned {} for {}: {}",
+                status,
+                key,
+                resp_body
+            );
+        }
+
+        Ok(())
+    }
+
     /// Fetch all issues in a sprint via Jira Agile REST API v1.0.
     /// Requires: Jira Software (Cloud or Server/DC 7.x+)
     /// Endpoint: GET /rest/agile/1.0/sprint/{id}/issue?fields=summary,status,assignee

--- a/src/tracker/jira.rs
+++ b/src/tracker/jira.rs
@@ -1,6 +1,23 @@
 use super::Ticket;
 use anyhow::{bail, Context, Result};
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SprintInfo {
+    pub id: u64,
+    pub name: String,
+    pub start_date: Option<String>,
+    pub end_date: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoardTicket {
+    pub key: String,
+    pub summary: String,
+    pub status: String,
+    pub assignee: Option<String>,
+}
 
 pub struct JiraTracker {
     base_url: String,
@@ -20,25 +37,21 @@ impl JiraTracker {
     /// Resolve the Jira API token from environment.
     /// Priority: PARSEC_JIRA_TOKEN > JIRA_PAT
     fn resolve_token() -> Result<String> {
-        if let Ok(token) = std::env::var("PARSEC_JIRA_TOKEN") {
-            if !token.is_empty() {
-                return Ok(token);
-            }
-        }
-        if let Ok(token) = std::env::var("JIRA_PAT") {
-            if !token.is_empty() {
-                return Ok(token);
-            }
-        }
-        anyhow::bail!(
-            "No Jira token found. Set PARSEC_JIRA_TOKEN or JIRA_PAT environment variable."
-        )
+        crate::env::jira_token().ok_or_else(|| {
+            anyhow::anyhow!(
+                "No Jira token found. Set {} or {} environment variable.",
+                crate::env::PARSEC_JIRA_TOKEN,
+                crate::env::JIRA_PAT,
+            )
+        })
     }
 
+    /// Fetch a single issue via Jira REST API v2.
+    /// Requires: Jira (Cloud or Server/DC 7.x+)
+    /// Endpoint: GET /rest/api/2/issue/{id}
     pub async fn fetch_ticket(&self, id: &str) -> Result<Ticket> {
         let token = Self::resolve_token()?;
 
-        // Use API v2 (compatible with both Cloud and Server/DC)
         let url = format!("{}/rest/api/2/issue/{}", self.base_url, id);
 
         let mut request = self
@@ -88,5 +101,165 @@ impl JiraTracker {
             assignee,
             url: Some(format!("{}/browse/{}", self.base_url, id)),
         })
+    }
+
+    /// Fetch the first board ID for a project via Jira Agile REST API v1.0.
+    /// Requires: Jira Software (Cloud or Server/DC 7.x+)
+    /// Endpoint: GET /rest/agile/1.0/board?projectKeyOrId={project}
+    pub async fn fetch_board_id(&self, project: &str) -> Result<u64> {
+        let token = Self::resolve_token()?;
+        let url = format!(
+            "{}/rest/agile/1.0/board?projectKeyOrId={}",
+            self.base_url, project
+        );
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json");
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to fetch boards from Jira")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Jira Agile API returned {} for boards: {}", status, body);
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse board response")?;
+
+        body["values"]
+            .as_array()
+            .and_then(|boards| boards.first())
+            .and_then(|b| b["id"].as_u64())
+            .ok_or_else(|| anyhow::anyhow!("No board found for project {project}"))
+    }
+
+    /// Fetch the active sprint for a board via Jira Agile REST API v1.0.
+    /// Requires: Jira Software (Cloud or Server/DC 7.x+)
+    /// Endpoint: GET /rest/agile/1.0/board/{id}/sprint?state=active
+    pub async fn fetch_active_sprint(&self, board_id: u64) -> Result<SprintInfo> {
+        let token = Self::resolve_token()?;
+        let url = format!(
+            "{}/rest/agile/1.0/board/{}/sprint?state=active",
+            self.base_url, board_id
+        );
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json");
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to fetch sprints from Jira")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Jira Agile API returned {} for sprints: {}", status, body);
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse sprint response")?;
+
+        let sprint = body["values"]
+            .as_array()
+            .and_then(|sprints| sprints.first())
+            .ok_or_else(|| anyhow::anyhow!("No active sprint found for board {board_id}"))?;
+
+        Ok(SprintInfo {
+            id: sprint["id"].as_u64().unwrap_or(0),
+            name: sprint["name"].as_str().unwrap_or("").to_string(),
+            start_date: sprint["startDate"].as_str().map(String::from),
+            end_date: sprint["endDate"].as_str().map(String::from),
+        })
+    }
+
+    /// Fetch all issues in a sprint via Jira Agile REST API v1.0.
+    /// Requires: Jira Software (Cloud or Server/DC 7.x+)
+    /// Endpoint: GET /rest/agile/1.0/sprint/{id}/issue?fields=summary,status,assignee
+    pub async fn fetch_sprint_issues(&self, sprint_id: u64) -> Result<Vec<BoardTicket>> {
+        let token = Self::resolve_token()?;
+        let url = format!(
+            "{}/rest/agile/1.0/sprint/{}/issue?fields=summary,status,assignee&maxResults=200",
+            self.base_url, sprint_id
+        );
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json");
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to fetch sprint issues from Jira")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!(
+                "Jira Agile API returned {} for sprint issues: {}",
+                status,
+                body
+            );
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse sprint issues response")?;
+
+        let issues = body["issues"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .map(|issue| BoardTicket {
+                        key: issue["key"].as_str().unwrap_or("").to_string(),
+                        summary: issue["fields"]["summary"]
+                            .as_str()
+                            .unwrap_or("")
+                            .to_string(),
+                        status: issue["fields"]["status"]["name"]
+                            .as_str()
+                            .unwrap_or("Unknown")
+                            .to_string(),
+                        assignee: issue["fields"]["assignee"]["displayName"]
+                            .as_str()
+                            .map(String::from),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(issues)
     }
 }

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -18,7 +18,7 @@ pub struct Ticket {
 
 /// Load environment variables from `~/.claude/.atlassian-env` if the file exists.
 /// This provides seamless integration with Claude's Jira skill.
-fn load_atlassian_env() {
+pub fn load_atlassian_env() {
     let env_path: PathBuf = dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".claude")
@@ -70,8 +70,9 @@ pub async fn fetch_ticket(
         }
         TrackerProvider::Gitlab | TrackerProvider::None => {
             // Auto-detect Jira: try if env vars available, but don't block on failure
-            if std::env::var("JIRA_BASE_URL").is_ok()
-                && (std::env::var("JIRA_PAT").is_ok() || std::env::var("PARSEC_JIRA_TOKEN").is_ok())
+            if std::env::var(crate::env::JIRA_BASE_URL).is_ok()
+                && (std::env::var(crate::env::JIRA_PAT).is_ok()
+                    || std::env::var(crate::env::PARSEC_JIRA_TOKEN).is_ok())
             {
                 if let Ok(Some(ticket)) = fetch_jira_ticket(config, id).await {
                     return Ok(Some(ticket));
@@ -107,9 +108,12 @@ async fn fetch_jira_ticket(config: &ParsecConfig, id: &str) -> Result<Option<Tic
         .jira
         .as_ref()
         .map(|j| j.base_url.clone())
-        .or_else(|| std::env::var("JIRA_BASE_URL").ok())
+        .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok())
         .ok_or_else(|| {
-            anyhow::anyhow!("Jira base URL not found. Set it in config or JIRA_BASE_URL env var.")
+            anyhow::anyhow!(
+                "Jira base URL not found. Set it in config or {} env var.",
+                crate::env::JIRA_BASE_URL,
+            )
         })?;
 
     let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -33,6 +33,12 @@ fn load_atlassian_env() {
             if let Some((key, value)) = line.split_once('=') {
                 let key = key.trim();
                 let value = value.trim();
+                // Only allow specific prefixes for security
+                let allowed_prefixes = ["JIRA_", "PARSEC_", "CONFLUENCE_", "ATLASSIAN_"];
+                if !allowed_prefixes.iter().any(|p| key.starts_with(p)) {
+                    eprintln!("warning: ignoring disallowed env var '{}' in .atlassian-env (allowed prefixes: JIRA_, PARSEC_, CONFLUENCE_, ATLASSIAN_)", key);
+                    continue;
+                }
                 // Only set if not already in environment (env vars take precedence)
                 if std::env::var(key).is_err() {
                     std::env::set_var(key, value);

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -2,6 +2,7 @@ pub mod github_issues;
 pub mod jira;
 
 use anyhow::Result;
+use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -96,6 +97,44 @@ pub async fn fetch_ticket(
             }
 
             Ok(None)
+        }
+    }
+}
+
+/// Try to transition a ticket's status. Warns on failure but never blocks.
+pub async fn try_transition(config: &ParsecConfig, ticket: &str, target_status: &str) {
+    // Only works for Jira currently
+    if !matches!(
+        config.tracker.provider,
+        TrackerProvider::Jira | TrackerProvider::None
+    ) {
+        return;
+    }
+
+    // Need atlassian env loaded
+    load_atlassian_env();
+
+    let base_url = config
+        .tracker
+        .jira
+        .as_ref()
+        .map(|j| j.base_url.clone())
+        .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok());
+
+    let base_url = match base_url {
+        Some(url) => url,
+        None => return,
+    };
+
+    let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());
+    let jira = jira::JiraTracker::new(&base_url, email.as_deref());
+
+    match jira.transition_issue(ticket, target_status).await {
+        Ok(()) => {
+            eprintln!("  {} Ticket status → {}", "✓".green(), target_status);
+        }
+        Err(e) => {
+            eprintln!("  warning: failed to transition ticket: {e}");
         }
     }
 }

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -65,7 +65,7 @@ pub async fn fetch_ticket(
     match config.tracker.provider {
         TrackerProvider::Jira => fetch_jira_ticket(config, id).await,
         TrackerProvider::Github => {
-            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+            let tracker = github_issues::GithubIssueTracker::new(repo_root, config);
             let ticket = tracker.fetch_ticket(id).await?;
             Ok(Some(ticket))
         }
@@ -87,7 +87,7 @@ pub async fn fetch_ticket(
                     if crate::github::parse_github_remote(&remote_url).is_some() {
                         let clean_id = id.trim_start_matches('#');
                         if clean_id.chars().all(|c| c.is_ascii_digit()) {
-                            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+                            let tracker = github_issues::GithubIssueTracker::new(repo_root, config);
                             if let Ok(ticket) = tracker.fetch_ticket(id).await {
                                 return Ok(Some(ticket));
                             }
@@ -170,7 +170,7 @@ pub async fn post_comment(
             tracker.add_comment(id, body).await
         }
         TrackerProvider::Github => {
-            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+            let tracker = github_issues::GithubIssueTracker::new(repo_root, config);
             tracker.add_comment(id, body).await
         }
         TrackerProvider::Gitlab | TrackerProvider::None => {
@@ -193,7 +193,7 @@ pub async fn post_comment(
                     if crate::github::parse_github_remote(&remote_url).is_some() {
                         let clean_id = id.trim_start_matches('#');
                         if clean_id.chars().all(|c| c.is_ascii_digit()) {
-                            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+                            let tracker = github_issues::GithubIssueTracker::new(repo_root, config);
                             return tracker.add_comment(id, body).await;
                         }
                     }

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -139,6 +139,75 @@ pub async fn try_transition(config: &ParsecConfig, ticket: &str, target_status: 
     }
 }
 
+/// Post a comment on a ticket via the configured tracker.
+///
+/// Follows the same auto-detection logic as `fetch_ticket`: explicit provider
+/// first, then Jira env-var auto-detect, then GitHub remote auto-detect.
+pub async fn post_comment(
+    config: &ParsecConfig,
+    id: &str,
+    body: &str,
+    repo_root: Option<&Path>,
+) -> Result<()> {
+    load_atlassian_env();
+
+    match config.tracker.provider {
+        TrackerProvider::Jira => {
+            let base_url = config
+                .tracker
+                .jira
+                .as_ref()
+                .map(|j| j.base_url.clone())
+                .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Jira base URL not found. Set it in config or {} env var.",
+                        crate::env::JIRA_BASE_URL,
+                    )
+                })?;
+            let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());
+            let tracker = jira::JiraTracker::new(&base_url, email.as_deref());
+            tracker.add_comment(id, body).await
+        }
+        TrackerProvider::Github => {
+            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+            tracker.add_comment(id, body).await
+        }
+        TrackerProvider::Gitlab | TrackerProvider::None => {
+            // Auto-detect Jira
+            if std::env::var(crate::env::JIRA_BASE_URL).is_ok()
+                && (std::env::var(crate::env::JIRA_PAT).is_ok()
+                    || std::env::var(crate::env::PARSEC_JIRA_TOKEN).is_ok())
+            {
+                let base_url = std::env::var(crate::env::JIRA_BASE_URL)?;
+                let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());
+                let tracker = jira::JiraTracker::new(&base_url, email.as_deref());
+                if tracker.add_comment(id, body).await.is_ok() {
+                    return Ok(());
+                }
+            }
+
+            // Auto-detect GitHub
+            if let Some(root) = repo_root {
+                if let Ok(remote_url) = crate::git::get_remote_url(root) {
+                    if crate::github::parse_github_remote(&remote_url).is_some() {
+                        let clean_id = id.trim_start_matches('#');
+                        if clean_id.chars().all(|c| c.is_ascii_digit()) {
+                            let tracker = github_issues::GithubIssueTracker::new(repo_root);
+                            return tracker.add_comment(id, body).await;
+                        }
+                    }
+                }
+            }
+
+            anyhow::bail!(
+                "No tracker configured to post comments. \
+                 Set tracker.provider in config or configure environment variables."
+            )
+        }
+    }
+}
+
 /// Internal: fetch from Jira, resolving base_url from config or env var.
 async fn fetch_jira_ticket(config: &ParsecConfig, id: &str) -> Result<Option<Ticket>> {
     // Resolve base_url: config > JIRA_BASE_URL env var

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -402,7 +402,12 @@ impl WorktreeManager {
 
         let cleaned_up = match git::worktree_remove(&self.repo_root, &workspace.path) {
             Ok(()) => {
-                let _ = git::delete_branch(&self.repo_root, &workspace.branch);
+                if let Err(e) = git::delete_branch(&self.repo_root, &workspace.branch) {
+                    eprintln!(
+                        "warning: failed to delete branch '{}': {e}",
+                        workspace.branch
+                    );
+                }
                 true
             }
             Err(e) => {
@@ -459,7 +464,9 @@ impl WorktreeManager {
             for ws in &candidates {
                 match git::worktree_remove(&self.repo_root, &ws.path) {
                     Ok(()) => {
-                        let _ = git::delete_branch(&self.repo_root, &ws.branch);
+                        if let Err(e) = git::delete_branch(&self.repo_root, &ws.branch) {
+                            eprintln!("warning: failed to delete branch '{}': {e}", ws.branch);
+                        }
                     }
                     Err(e) => {
                         eprintln!(

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -357,9 +357,9 @@ impl WorktreeManager {
     // ship (push + cleanup only, PR creation is in commands.rs)
     // -----------------------------------------------------------------------
 
-    pub fn ship(&self, ticket: &str) -> Result<ShipResult> {
-        let mut state =
-            ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
+    /// Phase 1: Push the branch only, don't clean up yet.
+    pub fn ship_push(&self, ticket: &str) -> Result<ShipResult> {
+        let state = ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
 
         let workspace = state
             .get_workspace(ticket)
@@ -375,23 +375,43 @@ impl WorktreeManager {
         git::push_branch(&workspace.path, &workspace.branch)
             .with_context(|| format!("failed to push branch '{}'", workspace.branch))?;
 
-        // Optionally clean up the worktree and local branch.
-        let cleaned_up = if self.config.ship.auto_cleanup {
-            match git::worktree_remove(&self.repo_root, &workspace.path) {
-                Ok(()) => {
-                    let _ = git::delete_branch(&self.repo_root, &workspace.branch);
-                    true
-                }
-                Err(e) => {
-                    eprintln!("warning: failed to remove worktree: {e}");
-                    false
-                }
-            }
-        } else {
-            false
+        Ok(ShipResult {
+            ticket: ticket.to_owned(),
+            branch: workspace.branch,
+            base_branch: workspace.base_branch,
+            ticket_title: workspace.ticket_title,
+            pr_url: None,
+            cleaned_up: false,
+        })
+    }
+
+    /// Phase 2: Clean up worktree and branch after successful PR creation.
+    pub fn ship_cleanup(&self, ticket: &str) -> Result<bool> {
+        if !self.config.ship.auto_cleanup {
+            return Ok(false);
+        }
+
+        let state = ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
+
+        let workspace = match state.get_workspace(ticket) {
+            Some(ws) => ws.clone(),
+            None => return Ok(false), // Already cleaned up
         };
 
-        // Update persisted state.
+        let cleaned_up = match git::worktree_remove(&self.repo_root, &workspace.path) {
+            Ok(()) => {
+                let _ = git::delete_branch(&self.repo_root, &workspace.branch);
+                true
+            }
+            Err(e) => {
+                eprintln!("warning: failed to remove worktree: {e}");
+                false
+            }
+        };
+
+        // Update persisted state
+        let mut state =
+            ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
         if cleaned_up {
             state.remove_workspace(ticket);
         } else if let Some(ws) = state.workspaces.get_mut(ticket) {
@@ -399,16 +419,18 @@ impl WorktreeManager {
         }
         state
             .save(&self.repo_root)
-            .context("failed to save parsec state after ship")?;
+            .context("failed to save parsec state after ship cleanup")?;
 
-        Ok(ShipResult {
-            ticket: ticket.to_owned(),
-            branch: workspace.branch,
-            base_branch: workspace.base_branch,
-            ticket_title: workspace.ticket_title,
-            pr_url: None, // Set by commands.rs after async PR creation
-            cleaned_up,
-        })
+        Ok(cleaned_up)
+    }
+
+    /// Combined push + cleanup (backwards compat).
+    #[allow(dead_code)]
+    pub fn ship(&self, ticket: &str) -> Result<ShipResult> {
+        let mut result = self.ship_push(ticket)?;
+        let cleaned_up = self.ship_cleanup(ticket)?;
+        result.cleaned_up = cleaned_up;
+        Ok(result)
     }
 
     // -----------------------------------------------------------------------

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -52,6 +52,8 @@ impl WorktreeManager {
                     // When stacking, use the parent's branch as base
                     let parent_ws = self.get(parent)?;
                     parent_ws.branch.clone()
+                } else if let Some(ref default_base) = self.config.workspace.default_base {
+                    default_base.clone()
                 } else {
                     git::get_default_branch(&self.repo_root)
                         .context("failed to detect default branch")?

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -122,16 +122,42 @@ impl WorktreeManager {
             .context("failed to save parsec state")?;
 
         // Run post-create hooks
-        for hook_cmd in &self.config.hooks.post_create {
-            eprintln!("Running post-create hook: {}", hook_cmd);
-            let status = std::process::Command::new("sh")
-                .args(["-c", hook_cmd])
-                .current_dir(&worktree_path)
-                .status();
-            match status {
-                Ok(s) if s.success() => {}
-                Ok(s) => eprintln!("warning: hook '{}' exited with {}", hook_cmd, s),
-                Err(e) => eprintln!("warning: failed to run hook '{}': {}", hook_cmd, e),
+        if !self.config.hooks.post_create.is_empty() {
+            let skip_prompt = std::env::var("PARSEC_YES")
+                .map(|v| v == "1")
+                .unwrap_or(false);
+
+            let confirmed = if skip_prompt {
+                true
+            } else {
+                eprintln!("The following post-create hooks will be executed:");
+                for hook_cmd in &self.config.hooks.post_create {
+                    eprintln!("  - {}", hook_cmd);
+                }
+                eprint!("Run these hooks? [y/N] ");
+
+                let mut input = String::new();
+                match std::io::stdin().read_line(&mut input) {
+                    Ok(_) => input.trim().eq_ignore_ascii_case("y"),
+                    Err(_) => false,
+                }
+            };
+
+            if confirmed {
+                for hook_cmd in &self.config.hooks.post_create {
+                    eprintln!("Running post-create hook: {}", hook_cmd);
+                    let status = std::process::Command::new("sh")
+                        .args(["-c", hook_cmd])
+                        .current_dir(&worktree_path)
+                        .status();
+                    match status {
+                        Ok(s) if s.success() => {}
+                        Ok(s) => eprintln!("warning: hook '{}' exited with {}", hook_cmd, s),
+                        Err(e) => eprintln!("warning: failed to run hook '{}': {}", hook_cmd, e),
+                    }
+                }
+            } else {
+                eprintln!("Skipping post-create hooks.");
             }
         }
 

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -478,4 +478,32 @@ impl WorktreeManager {
 
         Ok(candidates)
     }
+
+    // -----------------------------------------------------------------------
+    // clean_orphans
+    // -----------------------------------------------------------------------
+
+    /// Remove state entries whose worktree directory no longer exists on disk.
+    pub fn clean_orphans(&self, dry_run: bool) -> Result<Vec<Workspace>> {
+        let mut state =
+            ParsecState::load(&self.repo_root).context("failed to load parsec state")?;
+
+        let orphans: Vec<Workspace> = state
+            .workspaces
+            .values()
+            .filter(|ws| !ws.path.exists())
+            .cloned()
+            .collect();
+
+        if !dry_run {
+            for ws in &orphans {
+                state.remove_workspace(&ws.ticket);
+            }
+            state
+                .save(&self.repo_root)
+                .context("failed to save parsec state after orphan cleanup")?;
+        }
+
+        Ok(orphans)
+    }
 }


### PR DESCRIPTION
## Summary

Major release with host-aware GitHub token resolution, tracker integration improvements, and CLI UX enhancements.

### New Features
- **Host-aware GitHub token resolution** — per-host `[github."hostname"]` config sections (#93)
- **Per-repo tracker override** — `[repos."owner/repo".tracker]` config (#97)
- **`parsec ticket --comment`** — post comments to tickets (#71)
- **`parsec inbox`** — list assigned tickets without active worktrees (#73)
- **`parsec clean --orphans`** — remove orphan state entries (#86)
- **`parsec init zsh/bash`** — shell integration for auto-cd after merge (#111)
- **`parsec root`** — print main repo root path (#111)
- **PR status in `parsec list`** — show PR state inline (#85)
- **Default base branch config** — `[worktree] default_base` (#84)
- **Automatic ticket status transitions** — `on_start`/`on_ship`/`on_merge` (#70)
- **`parsec ticket`** — tracker lookup command (#69)
- **Ship `--base` flag** — override base branch per-ship (#64)

### Bug Fixes
- Fix silent branch deletion failures — now emit warnings (#105)
- Prune stale remote-tracking references after merge (#107)
- GithubIssueTracker uses host-aware token resolution (#102)
- Ship uses `--force-with-lease` for safe push retries (#94)
- Ship detects existing PR before creating duplicate (#98)
- Auto-cleanup moved from ship to merge (#96)
- Conflicts detection with committed and uncommitted changes (#67)
- Merge/pr-status work with adopted branches (#81)
- Preserve worktree on PR failure (#77)

### Other
- CI: cargo audit job, pinned Actions to SHA (#61, #62)
- Restrict .atlassian-env loader to allowed prefixes (#60)
- Confirmation prompt before post_create hook (#59)
- Board: vertical layout, config defaults (#76)

## Test plan
- [x] All features tested via parsec workflow (start → ship → merge → clean)
- [x] Host-aware tokens verified with github.com and GHE
- [x] Per-repo tracker override verified
- [x] Remote branch cleanup confirmed after merge
- [x] Shell integration (parsec init) verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)