### PR TITLE
115: feat: parsec init --install for automatic shell integration setup

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1682,6 +1682,73 @@ pub async fn init_shell(shell: &str) -> Result<()> {
     Ok(())
 }
 
+pub async fn init_install(shell: &str) -> Result<()> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    let (config_path, eval_line) = match shell {
+        "bash" => (
+            home.join(".bashrc"),
+            "eval \"$(parsec init bash)\"".to_string(),
+        ),
+        _ => (
+            home.join(".zshrc"),
+            "eval \"$(parsec init zsh)\"".to_string(),
+        ),
+    };
+
+    // Check if already installed
+    if config_path.exists() {
+        let existing = std::fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?;
+        if existing.contains("parsec init") {
+            println!(
+                "{}",
+                format!(
+                    "Shell integration already present in {}. Nothing to do.",
+                    config_path.display()
+                )
+                .yellow()
+            );
+            return Ok(());
+        }
+    }
+
+    let confirmed = dialoguer::Confirm::new()
+        .with_prompt(format!(
+            "Add shell integration to {}?",
+            config_path.display()
+        ))
+        .default(true)
+        .interact()
+        .context("Failed to read confirmation")?;
+
+    if !confirmed {
+        println!("{}", "Skipped.".dimmed());
+        return Ok(());
+    }
+
+    // Append the eval line with a comment
+    let append = format!("\n# parsec shell integration\n{}\n", eval_line);
+    use std::io::Write;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&config_path)
+        .with_context(|| format!("Failed to open {} for writing", config_path.display()))?;
+    file.write_all(append.as_bytes())
+        .with_context(|| format!("Failed to write to {}", config_path.display()))?;
+
+    println!(
+        "{}",
+        format!(
+            "Shell integration added to {}. Run `source {}` or restart your shell.",
+            config_path.display(),
+            config_path.display()
+        )
+        .green()
+    );
+    Ok(())
+}
+
 pub async fn config_shell(shell: &str, _mode: Mode) -> Result<()> {
     let script = match shell {
         "bash" => SHELL_INTEGRATION_BASH,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1682,7 +1682,7 @@ pub async fn init_shell(shell: &str) -> Result<()> {
     Ok(())
 }
 
-pub async fn init_install(shell: &str) -> Result<()> {
+pub async fn init_install(shell: &str, yes: bool) -> Result<()> {
     let home = dirs::home_dir().context("Could not determine home directory")?;
     let (config_path, eval_line) = match shell {
         "bash" => (
@@ -1712,18 +1712,20 @@ pub async fn init_install(shell: &str) -> Result<()> {
         }
     }
 
-    let confirmed = dialoguer::Confirm::new()
-        .with_prompt(format!(
-            "Add shell integration to {}?",
-            config_path.display()
-        ))
-        .default(true)
-        .interact()
-        .context("Failed to read confirmation")?;
+    if !yes {
+        let confirmed = dialoguer::Confirm::new()
+            .with_prompt(format!(
+                "Add shell integration to {}?",
+                config_path.display()
+            ))
+            .default(true)
+            .interact()
+            .context("Failed to read confirmation")?;
 
-    if !confirmed {
-        println!("{}", "Skipped.".dimmed());
-        return Ok(());
+        if !confirmed {
+            println!("{}", "Skipped.".dimmed());
+            return Ok(());
+        }
     }
 
     // Append the eval line with a comment

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -348,10 +348,14 @@ pub enum Command {
     /// Prints a shell function that wraps parsec for auto-cd on switch
     /// and auto-recovery after merge cleanup. Supports zsh and bash.
     /// Add eval "$(parsec init zsh)" to your ~/.zshrc.
+    /// Use --install to automatically append the integration to your shell config.
     Init {
         /// Shell type (zsh or bash)
         #[arg(default_value = "zsh")]
         shell: String,
+        /// Automatically install shell integration into shell config file
+        #[arg(long)]
+        install: bool,
     },
 
     /// Configure parsec
@@ -522,7 +526,13 @@ pub async fn run(cli: Cli) -> Result<()> {
             }
         }
         Command::Root => commands::root(&repo_path).await,
-        Command::Init { shell } => commands::init_shell(&shell).await,
+        Command::Init { shell, install } => {
+            if install {
+                commands::init_install(&shell).await
+            } else {
+                commands::init_shell(&shell).await
+            }
+        }
         Command::Config { action } => match action {
             ConfigAction::Init => commands::config_init(output_mode).await,
             ConfigAction::Show => commands::config_show(output_mode).await,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -356,6 +356,9 @@ pub enum Command {
         /// Automatically install shell integration into shell config file
         #[arg(long)]
         install: bool,
+        /// Skip confirmation prompt (for scripting)
+        #[arg(long, short)]
+        yes: bool,
     },
 
     /// Configure parsec
@@ -526,9 +529,13 @@ pub async fn run(cli: Cli) -> Result<()> {
             }
         }
         Command::Root => commands::root(&repo_path).await,
-        Command::Init { shell, install } => {
+        Command::Init {
+            shell,
+            install,
+            yes,
+        } => {
             if install {
-                commands::init_install(&shell).await
+                commands::init_install(&shell, yes).await
             } else {
                 commands::init_shell(&shell).await
             }


### PR DESCRIPTION
## feat: parsec init --install for automatic shell integration setup

**Ticket**: [115](https://github.com/erishforG/git-parsec/issues/115)

Shipped via `parsec ship 115`
