### PR TITLE
119: feat: parsec start --hook for post-create automation

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -14,6 +14,7 @@ use crate::tracker;
 use crate::tracker::jira::JiraTracker;
 use crate::worktree::WorktreeManager;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start(
     repo: &Path,
     ticket: &str,
@@ -21,6 +22,7 @@ pub async fn start(
     title: Option<String>,
     on: Option<&str>,
     existing_branch: Option<&str>,
+    hook: Option<String>,
     mode: Mode,
 ) -> Result<()> {
     let mut config = ParsecConfig::load()?;
@@ -66,6 +68,20 @@ pub async fn start(
         }),
     ) {
         eprintln!("warning: failed to write oplog: {e}");
+    }
+
+    // Run one-off hook if provided (runs after config-based hooks in manager.create)
+    if let Some(hook_cmd) = hook {
+        eprintln!("Running post-create hook: {}", hook_cmd);
+        let status = std::process::Command::new("sh")
+            .args(["-c", &hook_cmd])
+            .current_dir(&workspace.path)
+            .status();
+        match status {
+            Ok(s) if s.success() => {}
+            Ok(s) => eprintln!("warning: hook '{}' exited with {}", hook_cmd, s),
+            Err(e) => eprintln!("warning: failed to run hook '{}': {}", hook_cmd, e),
+        }
     }
 
     Ok(())
@@ -1480,6 +1496,7 @@ pub async fn inbox(repo: &Path, pick: bool, mode: Mode) -> Result<()> {
             &chosen.key,
             None,
             Some(chosen.summary.clone()),
+            None,
             None,
             None,
             mode,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -57,6 +57,10 @@ pub enum Command {
         /// Use an existing branch instead of creating a new one
         #[arg(long = "branch")]
         existing_branch: Option<String>,
+
+        /// Run a command after worktree creation (one-off hook)
+        #[arg(long)]
+        hook: Option<String>,
     },
 
     /// List all active worktrees
@@ -434,6 +438,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             title,
             on,
             existing_branch,
+            hook,
         } => {
             commands::start(
                 &repo_path,
@@ -442,6 +447,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 title,
                 on.as_deref(),
                 existing_branch.as_deref(),
+                hook,
                 output_mode,
             )
             .await


### PR DESCRIPTION
## feat: parsec start --hook for post-create automation

**Ticket**: [119](https://github.com/erishforG/git-parsec/issues/119)

Shipped via `parsec ship 119`
