### PR TITLE
72: feat: `parsec create` — create ticket and worktree in one step

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -87,6 +87,116 @@ pub async fn start(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+pub async fn create(
+    repo: &Path,
+    title: &str,
+    body: Option<String>,
+    label: Option<String>,
+    project: Option<String>,
+    start_worktree: bool,
+    mode: Mode,
+) -> Result<()> {
+    let mut config = ParsecConfig::load()?;
+    let repo_root = git::get_repo_root(repo)?;
+    config.resolve_for_repo(&repo_root);
+
+    let labels: Vec<String> = label
+        .as_deref()
+        .map(|l| l.split(',').map(|s| s.trim().to_string()).collect())
+        .unwrap_or_default();
+
+    let (ticket_id, ticket_url) = match config.tracker.provider {
+        crate::config::TrackerProvider::Github => {
+            let remote_url = git::get_remote_url(&repo_root)?;
+            match github::create_issue(&remote_url, title, body.as_deref(), labels, &config).await?
+            {
+                Some((number, url)) => (format!("#{}", number), url),
+                None => anyhow::bail!(
+                    "GitHub token not configured. Set GITHUB_TOKEN or configure \
+                     [github.\"github.com\"] in parsec config."
+                ),
+            }
+        }
+        crate::config::TrackerProvider::Jira => {
+            crate::tracker::load_atlassian_env();
+
+            let base_url = config
+                .tracker
+                .jira
+                .as_ref()
+                .map(|j| j.base_url.clone())
+                .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Jira base URL not found. Set it in config or {} env var.",
+                        crate::env::JIRA_BASE_URL,
+                    )
+                })?;
+
+            let project_key = project
+                .or_else(|| config.tracker.jira.as_ref().and_then(|j| j.project.clone()))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Jira project key required. Pass --project PROJ or set \
+                         tracker.jira.project in config."
+                    )
+                })?;
+
+            let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());
+            let jira = crate::tracker::jira::JiraTracker::new(&base_url, email.as_deref());
+            let (key, url) = jira
+                .create_issue(&project_key, title, body.as_deref())
+                .await?;
+            (key, url)
+        }
+        crate::config::TrackerProvider::Gitlab | crate::config::TrackerProvider::None => {
+            // Auto-detect: try GitHub if remote points to github.com
+            if let Ok(remote_url) = git::get_remote_url(&repo_root) {
+                if github::parse_github_remote(&remote_url).is_some() {
+                    match github::create_issue(&remote_url, title, body.as_deref(), labels, &config)
+                        .await?
+                    {
+                        Some((number, url)) => (format!("#{}", number), url),
+                        None => anyhow::bail!(
+                            "GitHub token not configured. Set GITHUB_TOKEN or configure \
+                             [github.\"github.com\"] in parsec config."
+                        ),
+                    }
+                } else {
+                    anyhow::bail!(
+                        "Tracker not configured (or not yet supported). \
+                         Set tracker.provider = \"github\" or \"jira\" in parsec config."
+                    )
+                }
+            } else {
+                anyhow::bail!(
+                    "Tracker not configured (or not yet supported). \
+                     Set tracker.provider = \"github\" or \"jira\" in parsec config."
+                )
+            }
+        }
+    };
+
+    output::print_create(&ticket_id, title, &ticket_url, mode);
+
+    if start_worktree {
+        start(
+            repo,
+            &ticket_id,
+            None,
+            Some(title.to_string()),
+            None,
+            None,
+            None,
+            mode,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
 pub async fn adopt(
     repo: &Path,
     ticket: &str,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -402,6 +402,33 @@ pub enum Command {
         #[arg(long)]
         dry_run: bool,
     },
+
+    /// Create a new issue on the tracker
+    ///
+    /// Creates a new ticket on GitHub Issues (or Jira) and optionally
+    /// starts a worktree for it immediately. Use --start to chain into
+    /// parsec start after creation.
+    Create {
+        /// Issue title
+        #[arg(long)]
+        title: String,
+
+        /// Issue body/description
+        #[arg(long)]
+        body: Option<String>,
+
+        /// Labels to add (comma-separated)
+        #[arg(long)]
+        label: Option<String>,
+
+        /// Jira project key (e.g. PROJ). Auto-detected from config if omitted
+        #[arg(long, short)]
+        project: Option<String>,
+
+        /// Start a worktree after creation
+        #[arg(long)]
+        start: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -604,5 +631,12 @@ pub async fn run(cli: Cli) -> Result<()> {
             )
             .await
         }
+        Command::Create {
+            title,
+            body,
+            label,
+            project,
+            start,
+        } => commands::create(&repo_path, &title, body, label, project, start, output_mode).await,
     }
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -610,6 +610,74 @@ pub async fn create_release(
     Ok(html_url)
 }
 
+/// Create a GitHub issue.
+/// Returns `(number, html_url)` on success, or `None` if no token is available.
+pub async fn create_issue(
+    remote_url: &str,
+    title: &str,
+    body: Option<&str>,
+    labels: Vec<String>,
+    config: &ParsecConfig,
+) -> Result<Option<(u64, String)>> {
+    let remote = parse_github_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+    })?;
+
+    let token = match resolve_github_token(&remote.host, config) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let api_url = format!(
+        "{}/repos/{}/{}/issues",
+        remote.api_base(),
+        remote.owner,
+        remote.repo
+    );
+
+    let mut payload = serde_json::json!({ "title": title });
+    if let Some(b) = body {
+        payload["body"] = serde_json::json!(b);
+    }
+    if !labels.is_empty() {
+        payload["labels"] = serde_json::json!(labels);
+    }
+
+    let client = Client::new();
+    let response = client
+        .post(&api_url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .json(&payload)
+        .send()
+        .await
+        .context("Failed to send issue creation request to GitHub")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        bail!("GitHub API returned {}: {}", status, body);
+    }
+
+    let resp: serde_json::Value = response
+        .json()
+        .await
+        .context("Failed to parse GitHub API response")?;
+
+    let html_url = resp["html_url"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("GitHub response missing html_url"))?
+        .to_owned();
+
+    let number = resp["number"]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("GitHub response missing number"))?;
+
+    Ok(Some((number, html_url)))
+}
+
 /// Create a GitHub pull request.
 /// Returns None if no GitHub token is available.
 pub async fn create_pr(

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -961,3 +961,11 @@ pub fn print_config_show(config: &ParsecConfig) {
         }
     }
 }
+
+pub fn print_create(ticket_id: &str, title: &str, url: &str) {
+    println!(
+        "{}",
+        format!("Created issue {} - {}", ticket_id.bold(), title).green()
+    );
+    println!("  {}", url.dimmed());
+}

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -311,3 +311,13 @@ pub fn print_board(sprint: Option<&SprintInfo>, columns: &[(String, Vec<BoardTic
     });
     println!("{}", value);
 }
+
+pub fn print_create(ticket_id: &str, title: &str, url: &str) {
+    let value = json!({
+        "action": "create",
+        "id": ticket_id,
+        "title": title,
+        "url": url,
+    });
+    println!("{}", value);
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -272,3 +272,11 @@ pub fn print_list_full(
         Mode::Human => human::print_list_full(infos, pr_map),
     }
 }
+
+pub fn print_create(ticket_id: &str, title: &str, url: &str, mode: Mode) {
+    match mode {
+        Mode::Quiet => {}
+        Mode::Json => json::print_create(ticket_id, title, url),
+        Mode::Human => human::print_create(ticket_id, title, url),
+    }
+}

--- a/src/tracker/jira.rs
+++ b/src/tracker/jira.rs
@@ -427,6 +427,67 @@ impl JiraTracker {
         Ok(issues)
     }
 
+    /// Create a new Jira issue.
+    /// Endpoint: POST /rest/api/2/issue
+    /// Returns the issue key (e.g. "PROJ-42") and browse URL on success.
+    pub async fn create_issue(
+        &self,
+        project_key: &str,
+        summary: &str,
+        description: Option<&str>,
+    ) -> Result<(String, String)> {
+        let token = Self::resolve_token()?;
+        let url = format!("{}/rest/api/2/issue", self.base_url);
+
+        let mut fields = serde_json::json!({
+            "project": { "key": project_key },
+            "summary": summary,
+            "issuetype": { "name": "Task" }
+        });
+        if let Some(desc) = description {
+            fields["description"] = serde_json::json!(desc);
+        }
+
+        let payload = serde_json::json!({ "fields": fields });
+
+        let mut request = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&payload);
+
+        if let Some(ref email) = self.email {
+            request = request.basic_auth(email, Some(&token));
+        } else {
+            request = request.bearer_auth(&token);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Failed to send issue creation request to Jira")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Jira API returned {} when creating issue: {}", status, body);
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse Jira create issue response")?;
+
+        let key = body["key"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Jira response missing 'key' field"))?
+            .to_string();
+
+        let browse_url = format!("{}/browse/{}", self.base_url, key);
+
+        Ok((key, browse_url))
+    }
+
     /// Search for issues assigned to the current user via JQL.
     /// Endpoint: GET /rest/api/2/search?jql=...&fields=summary,status,priority,assignee
     pub async fn search_assigned_issues(&self, jql: &str) -> Result<Vec<InboxTicket>> {


### PR DESCRIPTION
## feat: `parsec create` — create ticket and worktree in one step

**Ticket**: [72](https://github.com/erishforG/git-parsec/issues/72)

Shipped via `parsec ship 72`
