### PR TITLE
114: feat: add parsec release command for automated release workflow

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2370,6 +2370,220 @@ pub async fn doctor(repo: &Path, mode: Mode) -> Result<()> {
     Ok(())
 }
 
+pub async fn release(
+    repo: &Path,
+    version: &str,
+    from: Option<&str>,
+    no_github_release: bool,
+    dry_run: bool,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let repo_root = git::get_repo_root(repo)?;
+
+    // Resolve source branch: --from > "develop" > git default branch
+    let source_branch = if let Some(f) = from {
+        f.to_string()
+    } else {
+        // Try "develop" first, fall back to default branch
+        let has_develop =
+            git::run_output(&repo_root, &["rev-parse", "--verify", "refs/heads/develop"]).is_ok();
+        if has_develop {
+            "develop".to_string()
+        } else {
+            git::get_default_branch(&repo_root)?
+        }
+    };
+
+    // Resolve target branch from config (default: "main")
+    let target_branch = config.release.branch.clone();
+    let tag_prefix = config.release.tag_prefix.clone();
+    let tag = format!("{}{}", tag_prefix, version);
+
+    let step = |msg: &str| {
+        if mode != Mode::Quiet {
+            println!("  {}", msg);
+        }
+    };
+
+    if dry_run && mode != Mode::Quiet {
+        println!("Dry run — no changes will be made.\n");
+    }
+
+    // Step a: git fetch origin
+    step("Fetching from origin...");
+    if !dry_run {
+        git::run(&repo_root, &["fetch", "origin"])?;
+    }
+
+    // Step b: Verify source branch is up to date with origin
+    step(&format!(
+        "Verifying '{}' is up to date with origin...",
+        source_branch
+    ));
+    if !dry_run {
+        // Get local and remote SHAs
+        let local_sha = git::run_output(&repo_root, &["rev-parse", &source_branch])?;
+        let remote_ref = format!("origin/{}", source_branch);
+        let remote_sha =
+            git::run_output(&repo_root, &["rev-parse", &remote_ref]).unwrap_or_default();
+        if !remote_sha.is_empty() && local_sha != remote_sha {
+            // Check if local is behind remote
+            let behind = git::run_output(
+                &repo_root,
+                &[
+                    "rev-list",
+                    "--count",
+                    &format!("{}..{}", source_branch, remote_ref),
+                ],
+            )
+            .unwrap_or_default();
+            let behind_n: u32 = behind.trim().parse().unwrap_or(0);
+            if behind_n > 0 {
+                anyhow::bail!(
+                    "branch '{}' is {} commit(s) behind origin/{}. Pull first.",
+                    source_branch,
+                    behind_n,
+                    source_branch
+                );
+            }
+        }
+    }
+
+    // Step c: checkout target branch and pull
+    step(&format!("Checking out '{}' and pulling...", target_branch));
+    if !dry_run {
+        git::run(&repo_root, &["checkout", &target_branch])?;
+        git::run(&repo_root, &["pull", "origin", &target_branch])?;
+    }
+
+    // Step d: merge source branch with --no-ff
+    let merge_msg = format!("Release {}", version);
+    step(&format!(
+        "Merging '{}' into '{}' (no-ff)...",
+        source_branch, target_branch
+    ));
+    if !dry_run {
+        git::run(
+            &repo_root,
+            &["merge", &source_branch, "--no-ff", "-m", &merge_msg],
+        )?;
+    }
+
+    // Step e: create annotated tag
+    step(&format!("Creating tag '{}'...", tag));
+    if !dry_run {
+        git::run(&repo_root, &["tag", "-a", &tag, "-m", &merge_msg])?;
+    }
+
+    // Step f: push with tags
+    step(&format!("Pushing '{}' with tags...", target_branch));
+    if !dry_run {
+        git::run(
+            &repo_root,
+            &["push", "origin", &target_branch, "--follow-tags"],
+        )?;
+    }
+
+    // Step g: GitHub Release
+    let release_url = if !no_github_release {
+        // Check for GitHub remote
+        let remote_url = git::run_output(&repo_root, &["remote", "get-url", "origin"]).ok();
+
+        if let Some(ref remote) = remote_url {
+            if github::parse_github_remote(remote).is_some() {
+                // Generate changelog from git log between previous tag and new tag
+                let changelog = if config.release.changelog {
+                    // Find the previous tag
+                    let prev_tag = git::run_output(
+                        &repo_root,
+                        &["describe", "--tags", "--abbrev=0", &format!("{}^", tag)],
+                    )
+                    .ok();
+
+                    let range = if let Some(ref pt) = prev_tag {
+                        format!("{}..{}", pt, tag)
+                    } else {
+                        tag.clone()
+                    };
+
+                    let log = if dry_run {
+                        // In dry run, use HEAD instead of the new tag (not yet created)
+                        let dry_range = if let Some(ref pt) = prev_tag {
+                            format!("{}..HEAD", pt)
+                        } else {
+                            "HEAD".to_string()
+                        };
+                        git::run_output(
+                            &repo_root,
+                            &["log", &dry_range, "--pretty=format:- %s (%h)"],
+                        )
+                        .unwrap_or_default()
+                    } else {
+                        git::run_output(&repo_root, &["log", &range, "--pretty=format:- %s (%h)"])
+                            .unwrap_or_default()
+                    };
+                    log
+                } else {
+                    String::new()
+                };
+
+                let release_name = format!("{}{}", tag_prefix, version);
+                step(&format!("Creating GitHub Release '{}'...", release_name));
+
+                if !dry_run {
+                    match github::create_release(remote, &tag, &release_name, &changelog, &config)
+                        .await?
+                    {
+                        Some(url) => Some(url),
+                        None => {
+                            eprintln!(
+                                "warning: no GitHub token found, skipping GitHub Release creation."
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Step h: Print summary
+    if mode == Mode::Json {
+        let summary = serde_json::json!({
+            "version": version,
+            "tag": tag,
+            "source_branch": source_branch,
+            "target_branch": target_branch,
+            "dry_run": dry_run,
+            "github_release_url": release_url,
+        });
+        println!("{}", serde_json::to_string_pretty(&summary)?);
+    } else if mode == Mode::Human {
+        println!();
+        println!("{}", "Release complete!".green().bold());
+        println!("  Version : {}", version.bold());
+        println!("  Tag     : {}", tag.bold());
+        println!("  Branch  : {} -> {}", source_branch, target_branch);
+        if dry_run {
+            println!("  (dry run — no changes were made)");
+        }
+        if let Some(url) = &release_url {
+            println!("  Release : {}", url);
+        }
+    }
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -380,6 +380,24 @@ pub enum Command {
     /// shell integration, and remote access. Prints ✓/✗ for each check
     /// with actionable fix instructions.
     Doctor,
+
+    /// Create a release: merge to release branch, tag, and create GitHub Release
+    ///
+    /// Merges the current develop branch into the release branch (default: main),
+    /// creates a git tag, and creates a GitHub Release with auto-generated changelog.
+    Release {
+        /// Version string (e.g., "0.3.0")
+        version: String,
+        /// Source branch to release from (default: develop or default branch)
+        #[arg(long)]
+        from: Option<String>,
+        /// Skip creating GitHub Release
+        #[arg(long)]
+        no_github_release: bool,
+        /// Dry run — show what would happen without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -554,5 +572,21 @@ pub async fn run(cli: Cli) -> Result<()> {
             ConfigAction::Completions { shell } => commands::config_completions(shell).await,
         },
         Command::Doctor => commands::doctor(&repo_path, output_mode).await,
+        Command::Release {
+            version,
+            from,
+            no_github_release,
+            dry_run,
+        } => {
+            commands::release(
+                &repo_path,
+                &version,
+                from.as_deref(),
+                no_github_release,
+                dry_run,
+                output_mode,
+            )
+            .await
+        }
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -24,6 +24,14 @@ fn default_true() -> bool {
     true
 }
 
+fn default_release_branch() -> String {
+    "main".to_string()
+}
+
+fn default_tag_prefix() -> String {
+    "v".to_string()
+}
+
 // ---------------------------------------------------------------------------
 // TrackerProvider
 // ---------------------------------------------------------------------------
@@ -213,6 +221,33 @@ pub struct AutoTransitionConfig {
 }
 
 // ---------------------------------------------------------------------------
+// ReleaseConfig
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReleaseConfig {
+    /// Target branch for release (default: "main")
+    #[serde(default = "default_release_branch")]
+    pub branch: String,
+    /// Tag prefix (default: "v")
+    #[serde(default = "default_tag_prefix")]
+    pub tag_prefix: String,
+    /// Auto-generate changelog
+    #[serde(default = "default_true")]
+    pub changelog: bool,
+}
+
+impl Default for ReleaseConfig {
+    fn default() -> Self {
+        Self {
+            branch: default_release_branch(),
+            tag_prefix: default_tag_prefix(),
+            changelog: true,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // GithubHostConfig
 // ---------------------------------------------------------------------------
 
@@ -258,6 +293,8 @@ pub struct ParsecConfig {
     pub ship: ShipConfig,
     #[serde(default)]
     pub hooks: HooksConfig,
+    #[serde(default)]
+    pub release: ReleaseConfig,
     /// Per-host GitHub tokens. Keys are hostnames like "github.com" or
     /// "github.example.com". Serializes as `[github."hostname"]` in TOML.
     #[serde(default)]

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -550,6 +550,66 @@ pub async fn get_pr_info(
     Ok(Some(PrInfo { title, head_branch }))
 }
 
+/// Create a GitHub Release.
+/// Returns the html_url of the created release, or None if no token is available.
+pub async fn create_release(
+    remote_url: &str,
+    tag: &str,
+    name: &str,
+    body: &str,
+    config: &ParsecConfig,
+) -> Result<Option<String>> {
+    let remote = parse_github_remote(remote_url).ok_or_else(|| {
+        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+    })?;
+
+    let token = match resolve_github_token(&remote.host, config) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let api_url = format!(
+        "{}/repos/{}/{}/releases",
+        remote.api_base(),
+        remote.owner,
+        remote.repo
+    );
+
+    let payload = serde_json::json!({
+        "tag_name": tag,
+        "name": name,
+        "body": body,
+        "draft": false,
+        "prerelease": false,
+    });
+
+    let client = Client::new();
+    let response = client
+        .post(&api_url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "git-parsec")
+        .bearer_auth(&token)
+        .json(&payload)
+        .send()
+        .await
+        .context("Failed to send release creation request to GitHub")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body_text = response.text().await.unwrap_or_default();
+        bail!("GitHub API returned {}: {}", status, body_text);
+    }
+
+    let resp: serde_json::Value = response
+        .json()
+        .await
+        .context("Failed to parse GitHub API response")?;
+
+    let html_url = resp["html_url"].as_str().map(|s| s.to_owned());
+    Ok(html_url)
+}
+
 /// Create a GitHub pull request.
 /// Returns None if no GitHub token is available.
 pub async fn create_pr(


### PR DESCRIPTION
## feat: add parsec release command for automated release workflow

**Ticket**: [114](https://github.com/erishforG/git-parsec/issues/114)

Shipped via `parsec ship 114`
