### PR TITLE
156: fix: Replace std::process::exit(1) with proper error propagation in CI

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1282,7 +1282,13 @@ pub async fn ci(repo: &Path, tickets: &[&str], watch: bool, all: bool, mode: Mod
             // Determine exit code based on overall status
             let has_failure = statuses.iter().any(|(_t, ci)| ci.overall == "failing");
             if has_failure {
-                std::process::exit(1);
+                anyhow::bail!(
+                    "CI checks failing for {} ticket(s)",
+                    statuses
+                        .iter()
+                        .filter(|(_t, ci)| ci.overall == "failing")
+                        .count()
+                );
             }
             return Ok(());
         }
@@ -1295,7 +1301,13 @@ pub async fn ci(repo: &Path, tickets: &[&str], watch: bool, all: bool, mode: Mod
         if all_completed {
             let has_failure = statuses.iter().any(|(_t, ci)| ci.overall == "failing");
             if has_failure {
-                std::process::exit(1);
+                anyhow::bail!(
+                    "CI checks failing for {} ticket(s)",
+                    statuses
+                        .iter()
+                        .filter(|(_t, ci)| ci.overall == "failing")
+                        .count()
+                );
             }
             return Ok(());
         }


### PR DESCRIPTION
## fix: Replace std::process::exit(1) with proper error propagation in CI

**Ticket**: [156](https://github.com/erishforG/git-parsec/issues/156)

Shipped via `parsec ship 156`
