### PR TITLE
152: refactor: Introduce GitHubClient struct to eliminate HTTP boilerplate

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -120,13 +120,14 @@ pub async fn create(
     let (ticket_id, ticket_url) = match config.tracker.provider {
         TrackerProvider::Github => {
             let remote_url = git::get_remote_url(&repo_root)?;
-            match github::create_issue(&remote_url, title, body, labels, &config).await? {
-                Some(result) => (format!("#{}", result.number), result.url),
-                None => anyhow::bail!(
+            let gh = github::GitHubClient::new(&remote_url, &config)?.ok_or_else(|| {
+                anyhow::anyhow!(
                     "GitHub token not configured. Set GITHUB_TOKEN or configure \
                      [github.\"github.com\"] in parsec config."
-                ),
-            }
+                )
+            })?;
+            let result = gh.create_issue(title, body, labels).await?;
+            (format!("#{}", result.number), result.url)
         }
         TrackerProvider::Jira => {
             let base_url = config
@@ -164,13 +165,14 @@ pub async fn create(
             // Auto-detect: try GitHub if remote points to github.com
             if let Ok(remote_url) = git::get_remote_url(&repo_root) {
                 if github::parse_github_remote(&remote_url).is_some() {
-                    match github::create_issue(&remote_url, title, body, labels, &config).await? {
-                        Some(result) => (format!("#{}", result.number), result.url),
-                        None => anyhow::bail!(
+                    let gh = github::GitHubClient::new(&remote_url, &config)?.ok_or_else(|| {
+                        anyhow::anyhow!(
                             "GitHub token not configured. Set GITHUB_TOKEN or configure \
                              [github.\"github.com\"] in parsec config."
-                        ),
-                    }
+                        )
+                    })?;
+                    let result = gh.create_issue(title, body, labels).await?;
+                    (format!("#{}", result.number), result.url)
                 } else {
                     anyhow::bail!(
                         "Tracker not configured (or not yet supported). \
@@ -251,28 +253,25 @@ pub async fn adopt(
 
     // Auto-detect existing PR for the adopted branch
     if let Ok(remote_url) = git::run_output(manager.repo_root(), &["remote", "get-url", "origin"]) {
-        if let Ok(Some(pr_number)) =
-            github::find_pr_by_branch(&remote_url, &workspace.branch, &config).await
-        {
-            // Record synthetic Ship entry so merge/pr-status can find the PR
-            let pr_url = if let Some(remote) = github::parse_github_remote(&remote_url) {
-                format!(
+        if let Ok(Some(gh)) = github::GitHubClient::new(&remote_url, &config) {
+            if let Ok(Some(pr_number)) = gh.find_pr_by_branch(&workspace.branch).await {
+                // Record synthetic Ship entry so merge/pr-status can find the PR
+                let remote = gh.remote();
+                let pr_url = format!(
                     "https://{}/{}/{}/pull/{}",
                     remote.host, remote.owner, remote.repo, pr_number
-                )
-            } else {
-                format!("pull/{}", pr_number)
-            };
-            if let Err(e) = crate::oplog::record(
-                manager.repo_root(),
-                crate::oplog::OpKind::Ship,
-                Some(ticket),
-                &format!("Adopted branch '{}' -> {}", workspace.branch, pr_url),
-                None,
-            ) {
-                eprintln!("warning: failed to record PR in oplog: {e}");
-            } else if mode != Mode::Quiet {
-                eprintln!("  Detected existing PR #{}", pr_number);
+                );
+                if let Err(e) = crate::oplog::record(
+                    manager.repo_root(),
+                    crate::oplog::OpKind::Ship,
+                    Some(ticket),
+                    &format!("Adopted branch '{}' -> {}", workspace.branch, pr_url),
+                    None,
+                ) {
+                    eprintln!("warning: failed to record PR in oplog: {e}");
+                } else if mode != Mode::Quiet {
+                    eprintln!("  Detected existing PR #{}", pr_number);
+                }
             }
         }
     }
@@ -307,11 +306,11 @@ pub async fn list(repo: &Path, no_pr: bool, full: bool, mode: Mode) -> Result<()
 
             // Fetch live PR status from GitHub
             if let Some(ref remote_url) = remote_url {
-                for (_ticket, (pr_num, state)) in pr_map.iter_mut() {
-                    if let Ok(Some(status)) =
-                        github::get_pr_status(remote_url, *pr_num, &config).await
-                    {
-                        *state = status.state;
+                if let Ok(Some(gh)) = github::GitHubClient::new(remote_url, &config) {
+                    for (_ticket, (pr_num, state)) in pr_map.iter_mut() {
+                        if let Ok(status) = gh.get_pr_status(*pr_num).await {
+                            *state = status.state;
+                        }
                     }
                 }
             }
@@ -472,7 +471,13 @@ pub async fn ship(
                     .filter(|entry| matches!(entry.op, crate::oplog::OpKind::Ship))
                     .find_map(|entry| entry.undo_info.as_ref().and_then(|u| u.branch.clone()));
                 if let Some(ref br) = branch {
-                    if let Ok(Some(_)) = github::find_pr_by_branch(&remote_url, br, &config).await {
+                    let already_shipped =
+                        if let Ok(Some(gh)) = github::GitHubClient::new(&remote_url, &config) {
+                            matches!(gh.find_pr_by_branch(br).await, Ok(Some(_)))
+                        } else {
+                            false
+                        };
+                    if already_shipped {
                         if mode == Mode::Human {
                             eprintln!("note: ticket {} already shipped. Nothing to do.", ticket);
                         }
@@ -512,39 +517,18 @@ pub async fn ship(
 
         let remote_url = git::get_remote_url(manager.repo_root());
         if let Ok(ref remote_url) = remote_url {
-            // Check if a PR already exists for this branch (#98)
-            if let Ok(Some(existing_pr)) =
-                github::find_pr_by_branch(remote_url, &result.branch, &config).await
-            {
-                let remote = github::parse_github_remote(remote_url);
-                let pr_url = if let Some(r) = remote {
-                    format!(
+            if let Some(gh) = github::GitHubClient::new(remote_url, &config)? {
+                // Check if a PR already exists for this branch (#98)
+                if let Ok(Some(existing_pr)) = gh.find_pr_by_branch(&result.branch).await {
+                    let r = gh.remote();
+                    let pr_url = format!(
                         "https://{}/{}/{}/pull/{}",
                         r.host, r.owner, r.repo, existing_pr
-                    )
+                    );
+                    result.pr_url = Some(pr_url);
                 } else {
-                    format!("PR #{}", existing_pr)
-                };
-                result.pr_url = Some(pr_url);
-            } else {
-                match github::create_pr(
-                    remote_url,
-                    &result.branch,
-                    &result.base_branch,
-                    &pr_title,
-                    &pr_body,
-                    draft || config.ship.draft,
-                    &config,
-                )
-                .await
-                {
-                    Ok(Some(pr)) => {
-                        result.pr_url = Some(pr.url);
-                    }
-                    Ok(None) => {
-                        // GitHub had no token — try GitLab
-                        match gitlab::create_mr(
-                            remote_url,
+                    match gh
+                        .create_pr(
                             &result.branch,
                             &result.base_branch,
                             &pr_title,
@@ -552,25 +536,40 @@ pub async fn ship(
                             draft || config.ship.draft,
                         )
                         .await
-                        {
-                            Ok(Some(mr)) => {
-                                result.pr_url = Some(mr.url);
-                            }
-                            Ok(None) => {
-                                eprintln!(
-                                    "note: PR/MR creation skipped — no token found.\n      \
-                                     Set PARSEC_GITHUB_TOKEN or PARSEC_GITLAB_TOKEN to enable."
-                                );
-                                pr_failed = true;
-                            }
-                            Err(e) => {
-                                eprintln!("error: GitLab MR creation failed: {e}");
-                                pr_failed = true;
-                            }
+                    {
+                        Ok(pr) => {
+                            result.pr_url = Some(pr.url);
+                        }
+                        Err(e) => {
+                            eprintln!("error: PR creation failed: {e}");
+                            pr_failed = true;
                         }
                     }
+                }
+            } else {
+                // No GitHub token — try GitLab
+                match gitlab::create_mr(
+                    remote_url,
+                    &result.branch,
+                    &result.base_branch,
+                    &pr_title,
+                    &pr_body,
+                    draft || config.ship.draft,
+                )
+                .await
+                {
+                    Ok(Some(mr)) => {
+                        result.pr_url = Some(mr.url);
+                    }
+                    Ok(None) => {
+                        eprintln!(
+                            "note: PR/MR creation skipped — no token found.\n      \
+                             Set PARSEC_GITHUB_TOKEN or PARSEC_GITLAB_TOKEN to enable."
+                        );
+                        pr_failed = true;
+                    }
                     Err(e) => {
-                        eprintln!("error: PR creation failed: {e}");
+                        eprintln!("error: GitLab MR creation failed: {e}");
                         pr_failed = true;
                     }
                 }
@@ -876,11 +875,11 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
             None => manager.list()?,
         };
 
-        for ws in &workspaces {
-            if let Ok(Some(pr_number)) =
-                github::find_pr_by_branch(&remote_url, &ws.branch, &config).await
-            {
-                all_entries.push((ws.ticket.clone(), pr_number, String::new()));
+        if let Some(gh) = github::GitHubClient::new(&remote_url, &config)? {
+            for ws in &workspaces {
+                if let Ok(Some(pr_number)) = gh.find_pr_by_branch(&ws.branch).await {
+                    all_entries.push((ws.ticket.clone(), pr_number, String::new()));
+                }
             }
         }
 
@@ -893,14 +892,12 @@ pub async fn pr_status(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<
         }
     }
 
+    let gh = github::GitHubClient::new(&remote_url, &config)?
+        .ok_or_else(|| anyhow::anyhow!("no GitHub token found. Set PARSEC_GITHUB_TOKEN."))?;
     let mut statuses = Vec::new();
     for (ticket_id, pr_number, _url) in &all_entries {
-        match crate::github::get_pr_status(&remote_url, *pr_number, &config).await? {
-            Some(status) => statuses.push((ticket_id.clone(), status)),
-            None => {
-                anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
-            }
-        }
+        let status = gh.get_pr_status(*pr_number).await?;
+        statuses.push((ticket_id.clone(), status));
     }
 
     output::print_pr_status(&statuses, mode);
@@ -918,6 +915,8 @@ pub async fn merge(
     let config = ParsecConfig::load()?;
     let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
     let remote_url = git::run_output(repo, &["remote", "get-url", "origin"])?;
+    let gh = github::GitHubClient::new(&remote_url, &config)?
+        .ok_or_else(|| anyhow::anyhow!("no GitHub token found. Set PARSEC_GITHUB_TOKEN."))?;
     let oplog = crate::oplog::OpLog::load(&repo_root)?;
     let manager = WorktreeManager::new(repo, &config)?;
 
@@ -952,7 +951,7 @@ pub async fn merge(
             let ws = manager.get(&ticket_id).with_context(|| {
                 format!("ticket {ticket_id} not found in active workspaces or oplog")
             })?;
-            github::find_pr_by_branch(&remote_url, &ws.branch, &config)
+            gh.find_pr_by_branch(&ws.branch)
                 .await?
                 .ok_or_else(|| {
                     anyhow::anyhow!(
@@ -964,7 +963,7 @@ pub async fn merge(
     };
 
     // Idempotency: check if PR is already merged/closed
-    if let Ok(Some(status)) = github::get_pr_status(&remote_url, pr_number, &config).await {
+    if let Ok(status) = gh.get_pr_status(pr_number).await {
         if status.state == "closed" {
             if mode == Mode::Human {
                 eprintln!(
@@ -995,29 +994,23 @@ pub async fn merge(
             eprint!("Waiting for CI to pass...");
         }
         loop {
-            match github::get_check_runs(&remote_url, pr_number, &config).await? {
-                Some(ci) => {
-                    if ci.overall == "passing" {
-                        if mode == Mode::Human {
-                            eprintln!(" {}", "✓".green());
-                        }
-                        break;
-                    } else if ci.overall == "failing" {
-                        if mode == Mode::Human {
-                            eprintln!(" {}", "✗".red());
-                        }
-                        anyhow::bail!(
-                            "CI is failing for PR #{}. Fix CI or use --no-wait to merge anyway.",
-                            pr_number
-                        );
-                    }
-                    // Still pending — wait and retry
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            let ci = gh.get_check_runs(pr_number).await?;
+            if ci.overall == "passing" {
+                if mode == Mode::Human {
+                    eprintln!(" {}", "✓".green());
                 }
-                None => {
-                    anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
+                break;
+            } else if ci.overall == "failing" {
+                if mode == Mode::Human {
+                    eprintln!(" {}", "✗".red());
                 }
+                anyhow::bail!(
+                    "CI is failing for PR #{}. Fix CI or use --no-wait to merge anyway.",
+                    pr_number
+                );
             }
+            // Still pending — wait and retry
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         }
     }
 
@@ -1026,47 +1019,33 @@ pub async fn merge(
     let delete_branch = !no_delete_branch;
 
     // Try merging, auto-update branch if not mergeable
-    let result = match github::merge_pr(&remote_url, pr_number, method, delete_branch, &config)
-        .await
-    {
-        Ok(Some(result)) => result,
-        Ok(None) => {
-            anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
-        }
+    let result = match gh.merge_pr(pr_number, method, delete_branch).await {
+        Ok(result) => result,
         Err(e) if e.to_string().starts_with("not mergeable") => {
             // PR is behind base branch — try updating
             if mode == Mode::Human {
                 eprintln!("PR #{} is not mergeable. Updating branch...", pr_number);
             }
-            match github::update_pr_branch(&remote_url, pr_number, &config).await? {
+            match gh.update_pr_branch(pr_number).await? {
                 true => {
                     if mode == Mode::Human {
                         eprintln!("Branch updated. Waiting for CI...");
                     }
                     // Wait for CI to pass again after update
                     loop {
-                        match github::get_check_runs(&remote_url, pr_number, &config).await? {
-                            Some(ci) => {
-                                if ci.overall == "passing" {
-                                    break;
-                                } else if ci.overall == "failing" {
-                                    anyhow::bail!(
-                                        "CI is failing after branch update for PR #{}.",
-                                        pr_number
-                                    );
-                                }
-                                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                            }
-                            None => anyhow::bail!("no GitHub token found."),
+                        let ci = gh.get_check_runs(pr_number).await?;
+                        if ci.overall == "passing" {
+                            break;
+                        } else if ci.overall == "failing" {
+                            anyhow::bail!(
+                                "CI is failing after branch update for PR #{}.",
+                                pr_number
+                            );
                         }
+                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     }
                     // Retry merge
-                    match github::merge_pr(&remote_url, pr_number, method, delete_branch, &config)
-                        .await?
-                    {
-                        Some(result) => result,
-                        None => anyhow::bail!("no GitHub token found."),
-                    }
+                    gh.merge_pr(pr_number, method, delete_branch).await?
                 }
                 false => {
                     anyhow::bail!(
@@ -1103,7 +1082,7 @@ pub async fn merge(
         .ok();
 
     if let Some(issue_num) = issue_number {
-        match github::close_issue(&remote_url, issue_num, &config).await {
+        match gh.close_issue(issue_num).await {
             Ok(true) => {
                 if mode == Mode::Human {
                     println!("  Closed issue #{}", issue_num);
@@ -1227,6 +1206,8 @@ pub async fn ci(repo: &Path, tickets: &[&str], watch: bool, all: bool, mode: Mod
     let config = ParsecConfig::load()?;
     let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
     let remote_url = git::run_output(repo, &["remote", "get-url", "origin"])?;
+    let gh = github::GitHubClient::new(&remote_url, &config)?
+        .ok_or_else(|| anyhow::anyhow!("no GitHub token found. Set PARSEC_GITHUB_TOKEN."))?;
     let oplog = crate::oplog::OpLog::load(&repo_root)?;
     let manager = WorktreeManager::new(repo, &config)?;
 
@@ -1271,7 +1252,7 @@ pub async fn ci(repo: &Path, tickets: &[&str], watch: bool, all: bool, mode: Mod
                 let ws = manager.get(&ticket_id).with_context(|| {
                     format!("ticket {ticket_id} not found in active workspaces or oplog")
                 })?;
-                match github::find_pr_by_branch(&remote_url, &ws.branch, &config).await? {
+                match gh.find_pr_by_branch(&ws.branch).await? {
                     Some(pr_number) => targets.push((ticket_id, pr_number)),
                     None => {
                         anyhow::bail!(
@@ -1311,7 +1292,7 @@ pub async fn ci(repo: &Path, tickets: &[&str], watch: bool, all: bool, mode: Mod
             let ws = manager.get(&ticket_id).with_context(|| {
                 format!("ticket {ticket_id} not found in active workspaces or oplog")
             })?;
-            match github::find_pr_by_branch(&remote_url, &ws.branch, &config).await? {
+            match gh.find_pr_by_branch(&ws.branch).await? {
                 Some(pr_number) => targets.push((ticket_id, pr_number)),
                 None => {
                     anyhow::bail!(
@@ -1326,12 +1307,8 @@ pub async fn ci(repo: &Path, tickets: &[&str], watch: bool, all: bool, mode: Mod
         let mut statuses: Vec<(String, crate::github::CiStatus)> = Vec::new();
 
         for (ticket_id, pr_number) in &targets {
-            match github::get_check_runs(&remote_url, *pr_number, &config).await? {
-                Some(ci) => statuses.push((ticket_id.clone(), ci)),
-                None => {
-                    anyhow::bail!("no GitHub token found. Set PARSEC_GITHUB_TOKEN.");
-                }
-            }
+            let ci = gh.get_check_runs(*pr_number).await?;
+            statuses.push((ticket_id.clone(), ci));
         }
 
         // In watch + human mode, clear screen before redraw
@@ -1557,7 +1534,10 @@ pub async fn switch(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<()>
         let remote_url = git::get_remote_url(&repo_root)?;
 
         // Fetch PR info from GitHub to get head branch
-        let pr_info = github::get_pr_info(&remote_url, pr_number, &config)
+        let gh = github::GitHubClient::new(&remote_url, &config)?
+            .ok_or_else(|| anyhow::anyhow!("no GitHub token found. Set PARSEC_GITHUB_TOKEN."))?;
+        let pr_info = gh
+            .get_pr_info(pr_number)
             .await?
             .ok_or_else(|| anyhow::anyhow!("PR #{} not found", pr_number))?;
 
@@ -2964,16 +2944,19 @@ pub async fn release(
                 step(&format!("Creating GitHub Release '{}'...", release_name));
 
                 if !dry_run {
-                    match github::create_release(remote, &tag, &release_name, &changelog, &config)
-                        .await?
-                    {
-                        Some(url) => Some(url),
-                        None => {
-                            eprintln!(
-                                "warning: no GitHub token found, skipping GitHub Release creation."
-                            );
-                            None
+                    if let Some(gh) = github::GitHubClient::new(remote, &config)? {
+                        match gh.create_release(&tag, &release_name, &changelog).await {
+                            Ok(url) => Some(url),
+                            Err(e) => {
+                                eprintln!("warning: GitHub Release creation failed: {e}");
+                                None
+                            }
                         }
+                    } else {
+                        eprintln!(
+                            "warning: no GitHub token found, skipping GitHub Release creation."
+                        );
+                        None
                     }
                 } else {
                     None

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::ParsecConfig;
 
+// ---------------------------------------------------------------------------
+// HTTP helpers (private)
+// ---------------------------------------------------------------------------
+
 /// Create a configured HTTP client with timeout.
 fn http_client() -> Result<Client> {
     Client::builder()
@@ -50,6 +54,10 @@ async fn send_with_retry(request_builder: reqwest::RequestBuilder) -> Result<Res
     }
 }
 
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
 /// Result of PR creation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrResult {
@@ -86,6 +94,64 @@ impl GitHubRemote {
         )
     }
 }
+
+/// PR status information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrStatus {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub mergeable: Option<bool>,
+    pub ci_status: String,
+    pub review_status: String,
+    pub url: String,
+}
+
+/// A single CI check run
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckRun {
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub html_url: Option<String>,
+}
+
+/// Aggregated CI status for a PR
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CiStatus {
+    pub pr_number: u64,
+    pub head_sha: String,
+    pub overall: String,
+    pub checks: Vec<CheckRun>,
+}
+
+/// Result of merging a PR
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeResult {
+    pub sha: String,
+    pub message: String,
+    pub merged: bool,
+}
+
+/// Basic PR info for checkout/review workflows.
+#[derive(Debug, Clone)]
+pub struct PrInfo {
+    pub title: String,
+    pub head_branch: String,
+}
+
+/// Result of issue creation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueResult {
+    pub number: u64,
+    pub url: String,
+}
+
+// ---------------------------------------------------------------------------
+// Free functions (parsing, token resolution)
+// ---------------------------------------------------------------------------
 
 /// Parse any GitHub remote URL (github.com or Enterprise) into GitHubRemote.
 ///
@@ -148,756 +214,515 @@ pub fn resolve_github_token(host: &str, config: &ParsecConfig) -> Option<String>
     None
 }
 
-/// PR status information
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PrStatus {
-    pub number: u64,
-    pub title: String,
-    pub state: String,
-    pub mergeable: Option<bool>,
-    pub ci_status: String,
-    pub review_status: String,
-    pub url: String,
+// ---------------------------------------------------------------------------
+// GitHubClient
+// ---------------------------------------------------------------------------
+
+/// Authenticated GitHub API client that eliminates per-call boilerplate.
+///
+/// Encapsulates remote parsing, token resolution, HTTP client creation,
+/// and standard header injection. Construct via `GitHubClient::new()` which
+/// returns `Ok(None)` when no token is available.
+pub struct GitHubClient {
+    client: Client,
+    remote: GitHubRemote,
+    token: String,
+    api_base: String,
 }
 
-/// Fetch the status of a GitHub PR by number.
-pub async fn get_pr_status(
-    remote_url: &str,
-    pr_number: u64,
-    config: &ParsecConfig,
-) -> Result<Option<PrStatus>> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
+impl GitHubClient {
+    /// Create a new client for the given remote URL.
+    /// Returns `Ok(None)` when no GitHub token is available.
+    pub fn new(remote_url: &str, config: &ParsecConfig) -> Result<Option<Self>> {
+        let remote = parse_github_remote(remote_url).ok_or_else(|| {
+            anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
+        })?;
 
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
+        let token = match resolve_github_token(&remote.host, config) {
+            Some(t) => t,
+            None => return Ok(None),
+        };
 
-    let api_base = remote.api_base();
-    let client = http_client()?;
+        let api_base = remote.api_base();
+        let client = http_client()?;
 
-    // Fetch PR details
-    let pr_url = format!(
-        "{}/repos/{}/{}/pulls/{}",
-        api_base, remote.owner, remote.repo, pr_number
-    );
-    let pr_resp: serde_json::Value = send_with_retry(
-        client
-            .get(&pr_url)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .bearer_auth(&token),
-    )
-    .await?
-    .json()
-    .await?;
-
-    let title = pr_resp["title"].as_str().unwrap_or("").to_string();
-    let state = pr_resp["state"].as_str().unwrap_or("unknown").to_string();
-    let mergeable = pr_resp["mergeable"].as_bool();
-    let html_url = pr_resp["html_url"].as_str().unwrap_or("").to_string();
-    let head_sha = pr_resp["head"]["sha"].as_str().unwrap_or("");
-
-    // Fetch combined commit status
-    let ci_status = if !head_sha.is_empty() {
-        let status_url = format!(
-            "{}/repos/{}/{}/commits/{}/status",
-            api_base, remote.owner, remote.repo, head_sha
-        );
-        let status_resp: serde_json::Value = send_with_retry(
-            client
-                .get(&status_url)
-                .header("Accept", "application/vnd.github+json")
-                .header("X-GitHub-Api-Version", "2022-11-28")
-                .bearer_auth(&token),
-        )
-        .await?
-        .json()
-        .await?;
-        status_resp["state"]
-            .as_str()
-            .unwrap_or("unknown")
-            .to_string()
-    } else {
-        "unknown".to_string()
-    };
-
-    // Fetch reviews
-    let reviews_url = format!(
-        "{}/repos/{}/{}/pulls/{}/reviews",
-        api_base, remote.owner, remote.repo, pr_number
-    );
-    let reviews_resp: Vec<serde_json::Value> = send_with_retry(
-        client
-            .get(&reviews_url)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .bearer_auth(&token),
-    )
-    .await?
-    .json()
-    .await?;
-
-    let review_status = if reviews_resp.iter().any(|r| {
-        r["state"]
-            .as_str()
-            .is_some_and(|s| s == "CHANGES_REQUESTED")
-    }) {
-        "changes_requested".to_string()
-    } else if reviews_resp
-        .iter()
-        .any(|r| r["state"].as_str().is_some_and(|s| s == "APPROVED"))
-    {
-        "approved".to_string()
-    } else if reviews_resp.is_empty() {
-        "no reviews".to_string()
-    } else {
-        "pending".to_string()
-    };
-
-    Ok(Some(PrStatus {
-        number: pr_number,
-        title,
-        state,
-        mergeable,
-        ci_status,
-        review_status,
-        url: html_url,
-    }))
-}
-
-/// A single CI check run
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CheckRun {
-    pub name: String,
-    pub status: String,
-    pub conclusion: Option<String>,
-    pub started_at: Option<String>,
-    pub completed_at: Option<String>,
-    pub html_url: Option<String>,
-}
-
-/// Aggregated CI status for a PR
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CiStatus {
-    pub pr_number: u64,
-    pub head_sha: String,
-    pub overall: String,
-    pub checks: Vec<CheckRun>,
-}
-
-/// Fetch check runs for a PR by number.
-/// Returns None if no GitHub token is available.
-pub async fn get_check_runs(
-    remote_url: &str,
-    pr_number: u64,
-    config: &ParsecConfig,
-) -> Result<Option<CiStatus>> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
-
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
-    let api_base = remote.api_base();
-    let client = http_client()?;
-
-    // Fetch PR to get head SHA
-    let pr_url = format!(
-        "{}/repos/{}/{}/pulls/{}",
-        api_base, remote.owner, remote.repo, pr_number
-    );
-    let pr_resp: serde_json::Value = send_with_retry(
-        client
-            .get(&pr_url)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .bearer_auth(&token),
-    )
-    .await?
-    .json()
-    .await?;
-
-    let head_sha = pr_resp["head"]["sha"].as_str().unwrap_or("").to_string();
-
-    if head_sha.is_empty() {
-        bail!("could not determine head SHA for PR #{}", pr_number);
+        Ok(Some(Self {
+            client,
+            remote,
+            token,
+            api_base,
+        }))
     }
 
-    // Fetch check runs for the head SHA
-    let checks_url = format!(
-        "{}/repos/{}/{}/commits/{}/check-runs",
-        api_base, remote.owner, remote.repo, head_sha
-    );
-    let checks_resp: serde_json::Value = send_with_retry(
-        client
-            .get(&checks_url)
+    /// Access the parsed remote info.
+    pub fn remote(&self) -> &GitHubRemote {
+        &self.remote
+    }
+
+    /// `/repos/{owner}/{repo}` path prefix.
+    fn repo_path(&self) -> String {
+        format!("/repos/{}/{}", self.remote.owner, self.remote.repo)
+    }
+
+    // -- HTTP verb helpers with standard GitHub headers ----------------------
+
+    fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .get(format!("{}{}", self.api_base, path))
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
-            .bearer_auth(&token),
-    )
-    .await?
-    .json()
-    .await?;
+            .bearer_auth(&self.token)
+    }
 
-    let checks: Vec<CheckRun> = checks_resp["check_runs"]
-        .as_array()
-        .unwrap_or(&vec![])
-        .iter()
-        .map(|c| CheckRun {
-            name: c["name"].as_str().unwrap_or("").to_string(),
-            status: c["status"].as_str().unwrap_or("").to_string(),
-            conclusion: c["conclusion"].as_str().map(|s| s.to_string()),
-            started_at: c["started_at"].as_str().map(|s| s.to_string()),
-            completed_at: c["completed_at"].as_str().map(|s| s.to_string()),
-            html_url: c["html_url"].as_str().map(|s| s.to_string()),
+    fn post(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .post(format!("{}{}", self.api_base, path))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(&self.token)
+    }
+
+    fn put(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .put(format!("{}{}", self.api_base, path))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(&self.token)
+    }
+
+    fn patch(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .patch(format!("{}{}", self.api_base, path))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(&self.token)
+    }
+
+    fn delete_req(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .delete(format!("{}{}", self.api_base, path))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(&self.token)
+    }
+
+    // -- API methods ---------------------------------------------------------
+
+    /// Fetch the status of a GitHub PR by number.
+    pub async fn get_pr_status(&self, pr_number: u64) -> Result<PrStatus> {
+        let rp = self.repo_path();
+
+        // Fetch PR details
+        let pr_resp: serde_json::Value =
+            send_with_retry(self.get(&format!("{}/pulls/{}", rp, pr_number)))
+                .await?
+                .json()
+                .await?;
+
+        let title = pr_resp["title"].as_str().unwrap_or("").to_string();
+        let state = pr_resp["state"].as_str().unwrap_or("unknown").to_string();
+        let mergeable = pr_resp["mergeable"].as_bool();
+        let html_url = pr_resp["html_url"].as_str().unwrap_or("").to_string();
+        let head_sha = pr_resp["head"]["sha"].as_str().unwrap_or("");
+
+        // Fetch combined commit status
+        let ci_status = if !head_sha.is_empty() {
+            let status_resp: serde_json::Value =
+                send_with_retry(self.get(&format!("{}/commits/{}/status", rp, head_sha)))
+                    .await?
+                    .json()
+                    .await?;
+            status_resp["state"]
+                .as_str()
+                .unwrap_or("unknown")
+                .to_string()
+        } else {
+            "unknown".to_string()
+        };
+
+        // Fetch reviews
+        let reviews_resp: Vec<serde_json::Value> =
+            send_with_retry(self.get(&format!("{}/pulls/{}/reviews", rp, pr_number)))
+                .await?
+                .json()
+                .await?;
+
+        let review_status = if reviews_resp.iter().any(|r| {
+            r["state"]
+                .as_str()
+                .is_some_and(|s| s == "CHANGES_REQUESTED")
+        }) {
+            "changes_requested".to_string()
+        } else if reviews_resp
+            .iter()
+            .any(|r| r["state"].as_str().is_some_and(|s| s == "APPROVED"))
+        {
+            "approved".to_string()
+        } else if reviews_resp.is_empty() {
+            "no reviews".to_string()
+        } else {
+            "pending".to_string()
+        };
+
+        Ok(PrStatus {
+            number: pr_number,
+            title,
+            state,
+            mergeable,
+            ci_status,
+            review_status,
+            url: html_url,
         })
-        .collect();
-
-    // Derive overall status
-    let overall = if checks.is_empty() {
-        "no checks".to_string()
-    } else if checks
-        .iter()
-        .any(|c| c.conclusion.as_deref() == Some("failure"))
-    {
-        "failing".to_string()
-    } else if checks.iter().all(|c| {
-        c.conclusion.as_deref() == Some("success") || c.conclusion.as_deref() == Some("skipped")
-    }) {
-        "passing".to_string()
-    } else {
-        "pending".to_string()
-    };
-
-    Ok(Some(CiStatus {
-        pr_number,
-        head_sha,
-        overall,
-        checks,
-    }))
-}
-
-/// Find an open PR by branch name.
-/// Returns the PR number if found, None if no token or no matching PR.
-pub async fn find_pr_by_branch(
-    remote_url: &str,
-    branch: &str,
-    config: &ParsecConfig,
-) -> Result<Option<u64>> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
-
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
-    let api_base = remote.api_base();
-    let client = http_client()?;
-
-    let url = format!(
-        "{}/repos/{}/{}/pulls?head={}:{}&state=open",
-        api_base, remote.owner, remote.repo, remote.owner, branch
-    );
-    let resp: Vec<serde_json::Value> = send_with_retry(
-        client
-            .get(&url)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .bearer_auth(&token),
-    )
-    .await?
-    .json()
-    .await?;
-
-    Ok(resp.first().and_then(|pr| pr["number"].as_u64()))
-}
-
-/// Result of merging a PR
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MergeResult {
-    pub sha: String,
-    pub message: String,
-    pub merged: bool,
-}
-
-/// Merge a GitHub PR.
-/// `method` should be "squash", "rebase", or "merge".
-/// Returns None if no token, Some(MergeResult) on success.
-pub async fn merge_pr(
-    remote_url: &str,
-    pr_number: u64,
-    method: &str,
-    delete_branch: bool,
-    config: &ParsecConfig,
-) -> Result<Option<MergeResult>> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
-
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
-    let api_base = remote.api_base();
-    let client = http_client()?;
-
-    // Merge the PR
-    let url = format!(
-        "{}/repos/{}/{}/pulls/{}/merge",
-        api_base, remote.owner, remote.repo, pr_number
-    );
-    let payload = serde_json::json!({
-        "merge_method": method,
-    });
-
-    let response = client
-        .put(&url)
-        .header("Accept", "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28")
-        .bearer_auth(&token)
-        .json(&payload)
-        .send()
-        .await
-        .context("Failed to send merge request to GitHub")?;
-
-    if !response.status().is_success() {
-        let status_code = response.status().as_u16();
-        let body = response.text().await.unwrap_or_default();
-        if status_code == 405 || status_code == 409 {
-            bail!("not mergeable: {}", body);
-        }
-        bail!("GitHub merge API returned {}: {}", status_code, body);
     }
 
-    let resp: serde_json::Value = response.json().await?;
-    let sha = resp["sha"].as_str().unwrap_or("").to_string();
-    let message = resp["message"].as_str().unwrap_or("").to_string();
+    /// Fetch check runs for a PR by number.
+    pub async fn get_check_runs(&self, pr_number: u64) -> Result<CiStatus> {
+        let rp = self.repo_path();
 
-    // Delete remote branch if requested
-    if delete_branch {
-        let branch_url = format!(
-            "{}/repos/{}/{}/pulls/{}",
-            api_base, remote.owner, remote.repo, pr_number
+        // Fetch PR to get head SHA
+        let pr_resp: serde_json::Value =
+            send_with_retry(self.get(&format!("{}/pulls/{}", rp, pr_number)))
+                .await?
+                .json()
+                .await?;
+
+        let head_sha = pr_resp["head"]["sha"].as_str().unwrap_or("").to_string();
+        if head_sha.is_empty() {
+            bail!("could not determine head SHA for PR #{}", pr_number);
+        }
+
+        // Fetch check runs for the head SHA
+        let checks_resp: serde_json::Value =
+            send_with_retry(self.get(&format!("{}/commits/{}/check-runs", rp, head_sha)))
+                .await?
+                .json()
+                .await?;
+
+        let checks: Vec<CheckRun> = checks_resp["check_runs"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|c| CheckRun {
+                name: c["name"].as_str().unwrap_or("").to_string(),
+                status: c["status"].as_str().unwrap_or("").to_string(),
+                conclusion: c["conclusion"].as_str().map(|s| s.to_string()),
+                started_at: c["started_at"].as_str().map(|s| s.to_string()),
+                completed_at: c["completed_at"].as_str().map(|s| s.to_string()),
+                html_url: c["html_url"].as_str().map(|s| s.to_string()),
+            })
+            .collect();
+
+        // Derive overall status
+        let overall = if checks.is_empty() {
+            "no checks".to_string()
+        } else if checks
+            .iter()
+            .any(|c| c.conclusion.as_deref() == Some("failure"))
+        {
+            "failing".to_string()
+        } else if checks.iter().all(|c| {
+            c.conclusion.as_deref() == Some("success") || c.conclusion.as_deref() == Some("skipped")
+        }) {
+            "passing".to_string()
+        } else {
+            "pending".to_string()
+        };
+
+        Ok(CiStatus {
+            pr_number,
+            head_sha,
+            overall,
+            checks,
+        })
+    }
+
+    /// Find an open PR by branch name.
+    /// Returns the PR number if found.
+    pub async fn find_pr_by_branch(&self, branch: &str) -> Result<Option<u64>> {
+        let url = format!(
+            "{}/pulls?head={}:{}&state=open",
+            self.repo_path(),
+            self.remote.owner,
+            branch
         );
-        let pr_resp: serde_json::Value = send_with_retry(
-            client
-                .get(&branch_url)
-                .header("Accept", "application/vnd.github+json")
-                .header("X-GitHub-Api-Version", "2022-11-28")
-                .bearer_auth(&token),
-        )
-        .await?
-        .json()
-        .await?;
+        let resp: Vec<serde_json::Value> = send_with_retry(self.get(&url)).await?.json().await?;
 
-        if let Some(branch_name) = pr_resp["head"]["ref"].as_str() {
-            let del_url = format!(
-                "{}/repos/{}/{}/git/refs/heads/{}",
-                api_base, remote.owner, remote.repo, branch_name
-            );
-            match client
-                .delete(&del_url)
-                .header("Accept", "application/vnd.github+json")
-                .header("X-GitHub-Api-Version", "2022-11-28")
-                .bearer_auth(&token)
-                .send()
-                .await
-            {
-                Ok(resp) if !resp.status().is_success() => {
-                    let status = resp.status();
-                    let body = resp.text().await.unwrap_or_default();
-                    eprintln!(
-                        "warning: failed to delete remote branch '{}': {} {}",
-                        branch_name, status, body
-                    );
+        Ok(resp.first().and_then(|pr| pr["number"].as_u64()))
+    }
+
+    /// Merge a GitHub PR.
+    /// `method` should be "squash", "rebase", or "merge".
+    pub async fn merge_pr(
+        &self,
+        pr_number: u64,
+        method: &str,
+        delete_branch: bool,
+    ) -> Result<MergeResult> {
+        let rp = self.repo_path();
+
+        let payload = serde_json::json!({ "merge_method": method });
+
+        let response = self
+            .put(&format!("{}/pulls/{}/merge", rp, pr_number))
+            .json(&payload)
+            .send()
+            .await
+            .context("Failed to send merge request to GitHub")?;
+
+        if !response.status().is_success() {
+            let status_code = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            if status_code == 405 || status_code == 409 {
+                bail!("not mergeable: {}", body);
+            }
+            bail!("GitHub merge API returned {}: {}", status_code, body);
+        }
+
+        let resp: serde_json::Value = response.json().await?;
+        let sha = resp["sha"].as_str().unwrap_or("").to_string();
+        let message = resp["message"].as_str().unwrap_or("").to_string();
+
+        // Delete remote branch if requested
+        if delete_branch {
+            let pr_resp: serde_json::Value =
+                send_with_retry(self.get(&format!("{}/pulls/{}", rp, pr_number)))
+                    .await?
+                    .json()
+                    .await?;
+
+            if let Some(branch_name) = pr_resp["head"]["ref"].as_str() {
+                let del_url = format!("{}/git/refs/heads/{}", rp, branch_name);
+                match self.delete_req(&del_url).send().await {
+                    Ok(resp) if !resp.status().is_success() => {
+                        let status = resp.status();
+                        let body = resp.text().await.unwrap_or_default();
+                        eprintln!(
+                            "warning: failed to delete remote branch '{}': {} {}",
+                            branch_name, status, body
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "warning: failed to delete remote branch '{}': {}",
+                            branch_name, e
+                        );
+                    }
+                    _ => {} // success
                 }
-                Err(e) => {
-                    eprintln!(
-                        "warning: failed to delete remote branch '{}': {}",
-                        branch_name, e
-                    );
-                }
-                _ => {} // success
             }
         }
+
+        Ok(MergeResult {
+            sha,
+            message,
+            merged: true,
+        })
     }
 
-    Ok(Some(MergeResult {
-        sha,
-        message,
-        merged: true,
-    }))
-}
+    /// Update a PR branch with the base branch (to make it mergeable).
+    /// Returns Ok(true) on success, Ok(false) if conflicts prevent update.
+    pub async fn update_pr_branch(&self, pr_number: u64) -> Result<bool> {
+        let url = format!("{}/pulls/{}/update-branch", self.repo_path(), pr_number);
 
-/// Update a PR branch with the base branch (to make it mergeable).
-/// Uses GitHub's "Update a pull request branch" API.
-/// Returns Ok(true) on success, Ok(false) if conflicts prevent update.
-pub async fn update_pr_branch(
-    remote_url: &str,
-    pr_number: u64,
-    config: &ParsecConfig,
-) -> Result<bool> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
+        let response = self
+            .put(&url)
+            .send()
+            .await
+            .context("Failed to send update-branch request to GitHub")?;
 
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => bail!("no GitHub token found"),
-    };
+        if response.status().is_success() {
+            Ok(true)
+        } else if response.status().as_u16() == 422 {
+            // 422 = conflicts, cannot auto-update
+            Ok(false)
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("GitHub update-branch API returned {}: {}", status, body);
+        }
+    }
 
-    let api_base = remote.api_base();
-    let client = http_client()?;
+    /// Fetch basic info about a GitHub PR by number.
+    pub async fn get_pr_info(&self, pr_number: u64) -> Result<Option<PrInfo>> {
+        let pr_resp: serde_json::Value =
+            send_with_retry(self.get(&format!("{}/pulls/{}", self.repo_path(), pr_number)))
+                .await?
+                .json()
+                .await?;
 
-    let url = format!(
-        "{}/repos/{}/{}/pulls/{}/update-branch",
-        api_base, remote.owner, remote.repo, pr_number
-    );
+        // GitHub returns a JSON object with a "message" field (not an array) when not found
+        if pr_resp.get("message").is_some() && pr_resp.get("number").is_none() {
+            return Ok(None);
+        }
 
-    let response = client
-        .put(&url)
-        .header("Accept", "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28")
-        .bearer_auth(&token)
-        .send()
-        .await
-        .context("Failed to send update-branch request to GitHub")?;
+        if pr_resp["number"].as_u64().is_none() {
+            return Ok(None);
+        }
+        let title = pr_resp["title"].as_str().unwrap_or("").to_string();
+        let head_branch = pr_resp["head"]["ref"].as_str().unwrap_or("").to_string();
 
-    if response.status().is_success() {
+        if head_branch.is_empty() {
+            anyhow::bail!("PR #{} response missing head.ref field", pr_number);
+        }
+
+        Ok(Some(PrInfo { title, head_branch }))
+    }
+
+    /// Create a GitHub Release.
+    /// Returns the html_url of the created release.
+    pub async fn create_release(&self, tag: &str, name: &str, body: &str) -> Result<String> {
+        let payload = serde_json::json!({
+            "tag_name": tag,
+            "name": name,
+            "body": body,
+            "draft": false,
+            "prerelease": false,
+        });
+
+        let response = self
+            .post(&format!("{}/releases", self.repo_path()))
+            .json(&payload)
+            .send()
+            .await
+            .context("Failed to send release creation request to GitHub")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body_text = response.text().await.unwrap_or_default();
+            bail!("GitHub API returned {}: {}", status, body_text);
+        }
+
+        let resp: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse GitHub API response")?;
+
+        resp["html_url"]
+            .as_str()
+            .map(|s| s.to_owned())
+            .ok_or_else(|| anyhow::anyhow!("GitHub response missing html_url"))
+    }
+
+    /// Create a GitHub issue.
+    pub async fn create_issue(
+        &self,
+        title: &str,
+        body: Option<&str>,
+        labels: &[String],
+    ) -> Result<IssueResult> {
+        let mut payload = serde_json::json!({ "title": title });
+        if let Some(b) = body {
+            payload["body"] = serde_json::json!(b);
+        }
+        if !labels.is_empty() {
+            payload["labels"] = serde_json::json!(labels);
+        }
+
+        let response = self
+            .post(&format!("{}/issues", self.repo_path()))
+            .json(&payload)
+            .send()
+            .await
+            .context("Failed to send issue creation request to GitHub")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("GitHub API returned {}: {}", status, body);
+        }
+
+        let resp: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse GitHub API response")?;
+
+        let html_url = resp["html_url"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("GitHub response missing html_url"))?
+            .to_owned();
+
+        let number = resp["number"]
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("GitHub response missing number"))?;
+
+        Ok(IssueResult {
+            number,
+            url: html_url,
+        })
+    }
+
+    /// Close a GitHub issue by number.
+    pub async fn close_issue(&self, issue_number: u64) -> Result<bool> {
+        let payload = serde_json::json!({
+            "state": "closed",
+            "state_reason": "completed",
+        });
+
+        let response = self
+            .patch(&format!("{}/issues/{}", self.repo_path(), issue_number))
+            .json(&payload)
+            .send()
+            .await
+            .context("Failed to send close issue request to GitHub")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            eprintln!(
+                "warning: failed to close issue #{}: {} {}",
+                issue_number, status, body
+            );
+            return Ok(false);
+        }
+
         Ok(true)
-    } else if response.status().as_u16() == 422 {
-        // 422 = conflicts, cannot auto-update
-        Ok(false)
-    } else {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        bail!("GitHub update-branch API returned {}: {}", status, body);
-    }
-}
-
-/// Basic PR info for checkout/review workflows.
-#[derive(Debug, Clone)]
-pub struct PrInfo {
-    pub title: String,
-    pub head_branch: String,
-}
-
-/// Fetch basic info about a GitHub PR by number.
-/// Returns None if no GitHub token is available.
-pub async fn get_pr_info(
-    remote_url: &str,
-    pr_number: u64,
-    config: &ParsecConfig,
-) -> Result<Option<PrInfo>> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
-
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
-    let api_base = remote.api_base();
-    let client = http_client()?;
-
-    let pr_url = format!(
-        "{}/repos/{}/{}/pulls/{}",
-        api_base, remote.owner, remote.repo, pr_number
-    );
-    let pr_resp: serde_json::Value = send_with_retry(
-        client
-            .get(&pr_url)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .bearer_auth(&token),
-    )
-    .await?
-    .json()
-    .await?;
-
-    // GitHub returns a JSON object with a "message" field (not an array) when not found
-    if pr_resp.get("message").is_some() && pr_resp.get("number").is_none() {
-        return Ok(None);
     }
 
-    if pr_resp["number"].as_u64().is_none() {
-        return Ok(None);
+    /// Create a GitHub pull request.
+    pub async fn create_pr(
+        &self,
+        branch: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+        draft: bool,
+    ) -> Result<PrResult> {
+        let payload = serde_json::json!({
+            "title": title,
+            "head": branch,
+            "base": base,
+            "body": body,
+            "draft": draft,
+        });
+
+        let response = self
+            .post(&format!("{}/pulls", self.repo_path()))
+            .json(&payload)
+            .send()
+            .await
+            .context("Failed to send PR creation request to GitHub")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("GitHub API returned {}: {}", status, body);
+        }
+
+        let resp: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse GitHub API response")?;
+
+        let html_url = resp["html_url"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("GitHub response missing html_url"))?
+            .to_owned();
+
+        let number = resp["number"].as_u64().unwrap_or(0);
+
+        Ok(PrResult {
+            url: html_url,
+            number,
+        })
     }
-    let title = pr_resp["title"].as_str().unwrap_or("").to_string();
-    let head_branch = pr_resp["head"]["ref"].as_str().unwrap_or("").to_string();
-
-    if head_branch.is_empty() {
-        anyhow::bail!("PR #{} response missing head.ref field", pr_number);
-    }
-
-    Ok(Some(PrInfo { title, head_branch }))
-}
-
-/// Create a GitHub Release.
-/// Returns the html_url of the created release, or None if no token is available.
-pub async fn create_release(
-    remote_url: &str,
-    tag: &str,
-    name: &str,
-    body: &str,
-    config: &ParsecConfig,
-) -> Result<Option<String>> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
-
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
-    let api_url = format!(
-        "{}/repos/{}/{}/releases",
-        remote.api_base(),
-        remote.owner,
-        remote.repo
-    );
-
-    let payload = serde_json::json!({
-        "tag_name": tag,
-        "name": name,
-        "body": body,
-        "draft": false,
-        "prerelease": false,
-    });
-
-    let client = http_client()?;
-    let response = client
-        .post(&api_url)
-        .header("Accept", "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28")
-        .bearer_auth(&token)
-        .json(&payload)
-        .send()
-        .await
-        .context("Failed to send release creation request to GitHub")?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let body_text = response.text().await.unwrap_or_default();
-        bail!("GitHub API returned {}: {}", status, body_text);
-    }
-
-    let resp: serde_json::Value = response
-        .json()
-        .await
-        .context("Failed to parse GitHub API response")?;
-
-    let html_url = resp["html_url"].as_str().map(|s| s.to_owned());
-    Ok(html_url)
-}
-
-/// Result of issue creation
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IssueResult {
-    pub number: u64,
-    pub url: String,
-}
-
-/// Create a GitHub issue.
-/// Returns None if no GitHub token is available.
-pub async fn create_issue(
-    remote_url: &str,
-    title: &str,
-    body: Option<&str>,
-    labels: &[String],
-    config: &ParsecConfig,
-) -> Result<Option<IssueResult>> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
-
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
-    let api_url = format!(
-        "{}/repos/{}/{}/issues",
-        remote.api_base(),
-        remote.owner,
-        remote.repo
-    );
-
-    let mut payload = serde_json::json!({ "title": title });
-    if let Some(b) = body {
-        payload["body"] = serde_json::json!(b);
-    }
-    if !labels.is_empty() {
-        payload["labels"] = serde_json::json!(labels);
-    }
-
-    let client = http_client()?;
-    let response = client
-        .post(&api_url)
-        .header("Accept", "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28")
-        .bearer_auth(&token)
-        .json(&payload)
-        .send()
-        .await
-        .context("Failed to send issue creation request to GitHub")?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        bail!("GitHub API returned {}: {}", status, body);
-    }
-
-    let resp: serde_json::Value = response
-        .json()
-        .await
-        .context("Failed to parse GitHub API response")?;
-
-    let html_url = resp["html_url"]
-        .as_str()
-        .ok_or_else(|| anyhow::anyhow!("GitHub response missing html_url"))?
-        .to_owned();
-
-    let number = resp["number"]
-        .as_u64()
-        .ok_or_else(|| anyhow::anyhow!("GitHub response missing number"))?;
-
-    Ok(Some(IssueResult {
-        number,
-        url: html_url,
-    }))
-}
-
-/// Close a GitHub issue by number.
-/// Returns Ok(true) on success, Ok(false) if no token available.
-pub async fn close_issue(
-    remote_url: &str,
-    issue_number: u64,
-    config: &ParsecConfig,
-) -> Result<bool> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
-
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => return Ok(false),
-    };
-
-    let api_url = format!(
-        "{}/repos/{}/{}/issues/{}",
-        remote.api_base(),
-        remote.owner,
-        remote.repo,
-        issue_number
-    );
-
-    let payload = serde_json::json!({
-        "state": "closed",
-        "state_reason": "completed",
-    });
-
-    let client = http_client()?;
-    let response = client
-        .patch(&api_url)
-        .header("Accept", "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28")
-        .bearer_auth(&token)
-        .json(&payload)
-        .send()
-        .await
-        .context("Failed to send close issue request to GitHub")?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        eprintln!(
-            "warning: failed to close issue #{}: {} {}",
-            issue_number, status, body
-        );
-        return Ok(false);
-    }
-
-    Ok(true)
-}
-
-/// Create a GitHub pull request.
-/// Returns None if no GitHub token is available.
-pub async fn create_pr(
-    remote_url: &str,
-    branch: &str,
-    base: &str,
-    title: &str,
-    body: &str,
-    draft: bool,
-    config: &ParsecConfig,
-) -> Result<Option<PrResult>> {
-    let remote = parse_github_remote(remote_url).ok_or_else(|| {
-        anyhow::anyhow!("could not parse owner/repo from remote URL: {}", remote_url)
-    })?;
-
-    let token = match resolve_github_token(&remote.host, config) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
-
-    let api_url = format!(
-        "{}/repos/{}/{}/pulls",
-        remote.api_base(),
-        remote.owner,
-        remote.repo
-    );
-
-    let payload = serde_json::json!({
-        "title": title,
-        "head": branch,
-        "base": base,
-        "body": body,
-        "draft": draft,
-    });
-
-    let client = http_client()?;
-    let response = client
-        .post(&api_url)
-        .header("Accept", "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28")
-        .bearer_auth(&token)
-        .json(&payload)
-        .send()
-        .await
-        .context("Failed to send PR creation request to GitHub")?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        bail!("GitHub API returned {}: {}", status, body);
-    }
-
-    let resp: serde_json::Value = response
-        .json()
-        .await
-        .context("Failed to parse GitHub API response")?;
-
-    let html_url = resp["html_url"]
-        .as_str()
-        .ok_or_else(|| anyhow::anyhow!("GitHub response missing html_url"))?
-        .to_owned();
-
-    let number = resp["number"].as_u64().unwrap_or(0);
-
-    Ok(Some(PrResult {
-        url: html_url,
-        number,
-    }))
 }


### PR DESCRIPTION
## refactor: Introduce GitHubClient struct to eliminate HTTP boilerplate

**Ticket**: [152](https://github.com/erishforG/git-parsec/issues/152)

Shipped via `parsec ship 152`
