### PR TITLE
fix: use bash shell for Windows release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
           Compress-Archive -Path "target/${{ matrix.target }}/release/parsec.exe" -DestinationPath "parsec-${{ needs.release.outputs.version }}-${{ matrix.target }}.zip"
 
       - name: Upload to GitHub Release
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary
- Fix Windows binary upload failure in release workflow
- PowerShell interprets `--clobber` flag as a unary operator (`--`), causing `gh release upload` to fail
- Adding `shell: bash` to the upload step ensures consistent behavior across all platforms

## Context
- v0.3.1 release: 3/4 platform binaries uploaded successfully (Linux, macOS x86, macOS ARM)
- Windows upload failed: https://github.com/erishforG/git-parsec/actions/runs/24707308390/job/72263480614

## Test plan
- [ ] Merge and manually re-run the Windows binary build for v0.3.1
- [ ] Verify Windows zip appears in the release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)