### PR TITLE
chore: merge develop into main (v0.3.1 + Windows CI fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
           Compress-Archive -Path "target/${{ matrix.target }}/release/parsec.exe" -DestinationPath "parsec-${{ needs.release.outputs.version }}-${{ matrix.target }}.zip"
 
       - name: Upload to GitHub Release
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary
- Merge develop into main to include all recent changes
- Includes fix for Windows binary upload failure in release workflow (#190)
- This will trigger a new release cycle for the next version bump

## Changes since last main merge
- fix: use bash shell for release upload step on Windows (#190)
- feat: Jira config token support + HTML error sanitization + status tracker info (#187)
- refactor: split commands.rs into sub-modules (#185)
- feat: typed GitHub API response structs (#184)
- refactor: introduce GitHubClient struct (#178)

🤖 Generated with [Claude Code](https://claude.com/claude-code)