### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager — ticket to PR in one command. Parallel AI agent workflows with Jira & GitHub Issues integration."


### PR DESCRIPTION
## Summary
- Bump version to 0.3.2 for patch release
- Includes Windows CI fix from #190 that wasn't in v0.3.1 binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)