### PR TITLE
release: v0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager — ticket to PR in one command. Parallel AI agent workflows with Jira & GitHub Issues integration."


### PR DESCRIPTION
## Summary
- Release v0.3.2 with Windows CI fix
- Includes `shell: bash` for release upload step to fix PowerShell `--clobber` parsing error

## Changes since v0.3.1
- fix: use bash shell for release upload step on Windows (#190)

🤖 Generated with [Claude Code](https://claude.com/claude-code)