### PR TITLE
feat: improve PR title format and add --title flag to ship

### DIFF
--- a/src/cli/commands/ship.rs
+++ b/src/cli/commands/ship.rs
@@ -10,12 +10,14 @@ use crate::output::{self, Mode};
 use crate::tracker;
 use crate::worktree::WorktreeManager;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn ship(
     repo: &Path,
     ticket: &str,
     draft: bool,
     no_pr: bool,
     base_override: Option<String>,
+    title_override: Option<String>,
     skip_hooks: bool,
     mode: Mode,
 ) -> Result<()> {
@@ -110,12 +112,16 @@ pub async fn ship(
                 _ => (None, None),
             };
 
-        // Prefer freshly fetched title over stored one
+        // Priority: --title flag > fresh tracker fetch > stored workspace title
         let effective_title = ticket_title.as_deref().or(result.ticket_title.as_deref());
 
-        let pr_title = effective_title
-            .map(|t| format!("{}: {}", result.ticket, t))
-            .unwrap_or_else(|| result.ticket.clone());
+        let pr_title = if let Some(ref t) = title_override {
+            t.clone()
+        } else {
+            effective_title
+                .map(|t| format!("[{}] {}", result.ticket, t))
+                .unwrap_or_else(|| result.ticket.clone())
+        };
 
         let pr_body = build_pr_body(&result.ticket, effective_title, ticket_url.as_deref());
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -121,6 +121,10 @@ pub enum Command {
         #[arg(long)]
         base: Option<String>,
 
+        /// Override PR title (default: [TICKET] tracker title)
+        #[arg(long, short)]
+        title: Option<String>,
+
         /// Skip pre-ship hooks
         #[arg(long)]
         skip_hooks: bool,
@@ -534,6 +538,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             draft,
             no_pr,
             base,
+            title,
             skip_hooks,
         } => {
             commands::ship(
@@ -542,6 +547,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 draft,
                 no_pr,
                 base,
+                title,
                 skip_hooks,
                 output_mode,
             )


### PR DESCRIPTION
## Summary
- Change PR title format from `TICKET: title` to `[TICKET] title` for better readability
- Add `--title`/`-t` option to `parsec ship` for user override
- Title priority: `--title` flag > fresh tracker fetch > stored workspace title > ticket ID only

## Example
- Before: `CL-2322: ClaimSearchHttpRequest listType @NotNull 검증 추가`
- After: `[CL-2322] ClaimSearchHttpRequest listType @NotNull 검증 추가`
- Override: `parsec ship CL-2322 --title "custom title"`

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)