### PR TITLE
196: security: patch rustls-webpki vulnerabilities (RUSTSEC-2026-0098/0099/0104)

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -312,7 +312,12 @@ pub struct ParsecConfig {
 
 impl ParsecConfig {
     /// Return the canonical path to the config file.
+    ///
+    /// Respects `PARSEC_CONFIG_DIR` env var for testing and CI isolation.
     pub fn config_path() -> PathBuf {
+        if let Ok(dir) = std::env::var("PARSEC_CONFIG_DIR") {
+            return PathBuf::from(dir).join("config.toml");
+        }
         dirs::config_dir()
             .unwrap_or_else(|| {
                 dirs::home_dir()

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -111,7 +111,10 @@ fn setup_repo_with_remote() -> (TempDir, TempDir) {
 }
 
 fn parsec() -> Command {
-    Command::cargo_bin("parsec").unwrap()
+    let mut cmd = Command::cargo_bin("parsec").unwrap();
+    // Isolate tests from user's global config (e.g. default_base = "develop")
+    cmd.env("PARSEC_CONFIG_DIR", "/tmp/parsec-test-nonexistent");
+    cmd
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## security: patch rustls-webpki vulnerabilities (RUSTSEC-2026-0098/0099/0104)

**Ticket**: [196](https://github.com/erishforG/git-parsec/issues/196)

Shipped via `parsec ship 196`
