### PR TITLE
197: fix: remove unwrap() panic paths in tracker and stack sync

### DIFF
--- a/src/cli/commands/stack.rs
+++ b/src/cli/commands/stack.rs
@@ -89,10 +89,16 @@ pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
                 .filter(|w| w.parent_ticket.as_deref() == Some(parent_ticket))
                 .collect();
             for child in &children {
-                let parent_ws = workspaces
-                    .iter()
-                    .find(|w| w.ticket == parent_ticket)
-                    .unwrap();
+                let parent_ws = match workspaces.iter().find(|w| w.ticket == parent_ticket) {
+                    Some(ws) => ws,
+                    None => {
+                        failed.push((
+                            child.ticket.clone(),
+                            format!("parent workspace '{}' not found", parent_ticket),
+                        ));
+                        continue;
+                    }
+                };
                 if let Err(e) = git::run(&child.path, &["rebase", &parent_ws.branch]) {
                     let _ = git::run(&child.path, &["rebase", "--abort"]);
                     failed.push((

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -205,7 +205,7 @@ pub async fn post_comment(
                     .as_ref()
                     .map(|j| j.base_url.clone())
                     .or_else(|| std::env::var(crate::env::JIRA_BASE_URL).ok())
-                    .unwrap();
+                    .ok_or_else(|| anyhow::anyhow!("Jira base URL not configured"))?;
                 let email = config.tracker.jira.as_ref().and_then(|j| j.email.clone());
                 let config_token = config
                     .tracker


### PR DESCRIPTION
## fix: remove unwrap() panic paths in tracker and stack sync

**Ticket**: [197](https://github.com/erishforG/git-parsec/issues/197)

Shipped via `parsec ship 197`
