### PR TITLE
199: chore: major dependency upgrades (reqwest, colored, indicatif, tabled, toml)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,18 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive", "color"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.8"
+toml = "1"
 anyhow = "1"
 thiserror = "2"
-colored = "2"
+colored = "3"
 dirs = "6"
 chrono = { version = "0.4", features = ["serde"] }
-tabled = { version = "0.17", features = ["ansi"] }
-indicatif = "0.17"
-dialoguer = "0.11"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+tabled = { version = "0.20", features = ["ansi"] }
+indicatif = "0.18"
+dialoguer = "0.12"
+reqwest = { version = "0.13", features = ["json", "query", "rustls-native-certs"], default-features = false }
 tokio = { version = "1", features = ["full"] }
-clap_mangen = "0.2"
+clap_mangen = "0.3"
 clap_complete = "4"
 
 [dev-dependencies]


### PR DESCRIPTION
## chore: major dependency upgrades (reqwest, colored, indicatif, tabled, toml)

**Ticket**: [199](https://github.com/erishforG/git-parsec/issues/199)

Shipped via `parsec ship 199`
