### PR TITLE
200: feat: validate ticket IDs to prevent path traversal and invalid branch names

### DIFF
--- a/src/cli/commands/workspace.rs
+++ b/src/cli/commands/workspace.rs
@@ -621,6 +621,8 @@ pub async fn clean(
 }
 
 pub async fn rename(repo: &Path, old_ticket: &str, new_ticket: &str, mode: Mode) -> Result<()> {
+    crate::worktree::validate_ticket_id(new_ticket)?;
+
     let config = ParsecConfig::load()?;
     let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
     let manager = WorktreeManager::new(repo, &config)?;

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -66,6 +66,8 @@ impl WorktreeManager {
         parent_ticket: Option<&str>,
         existing_branch: Option<&str>,
     ) -> Result<Workspace> {
+        super::validate_ticket_id(ticket)?;
+
         let base_branch = match base {
             Some(b) => b.to_owned(),
             None => {

--- a/src/worktree/mod.rs
+++ b/src/worktree/mod.rs
@@ -25,10 +25,7 @@ pub fn validate_ticket_id(ticket: &str) -> Result<()> {
 
     // Block path traversal
     if ticket.contains("..") || ticket.contains('/') || ticket.contains('\\') {
-        bail!(
-            "Ticket ID contains unsafe path characters: {}",
-            ticket
-        );
+        bail!("Ticket ID contains unsafe path characters: {}", ticket);
     }
 
     // Block null bytes and control characters
@@ -55,7 +52,9 @@ pub fn validate_ticket_id(ticket: &str) -> Result<()> {
     }
 
     // Block shell meta-characters
-    const SHELL_CHARS: &[char] = &['$', '`', '!', '&', '|', ';', '(', ')', '{', '}', '<', '>', '"', '\''];
+    const SHELL_CHARS: &[char] = &[
+        '$', '`', '!', '&', '|', ';', '(', ')', '{', '}', '<', '>', '"', '\'',
+    ];
     if let Some(c) = ticket.chars().find(|c| SHELL_CHARS.contains(c)) {
         bail!(
             "Ticket ID contains shell-unsafe character '{}': {}",

--- a/src/worktree/mod.rs
+++ b/src/worktree/mod.rs
@@ -3,3 +3,75 @@ mod manager;
 
 pub use lifecycle::{ParsecState, ShipResult, Workspace, WorkspaceStatus};
 pub use manager::WorktreeManager;
+
+use anyhow::{bail, Result};
+
+/// Validate a ticket identifier for safety.
+///
+/// Allowed formats:
+///   - Jira:   `[A-Z][A-Z0-9_]{1,19}-[1-9][0-9]*`  (e.g. PROJ-123, R2D2-1)
+///   - GitHub/GitLab: `#?[1-9][0-9]*`                (e.g. 42, #42)
+///   - Generic: alphanumeric with hyphens/underscores (e.g. my-ticket-1)
+///
+/// Rejects path traversal, shell meta-characters, and git ref-unsafe sequences.
+pub fn validate_ticket_id(ticket: &str) -> Result<()> {
+    if ticket.is_empty() {
+        bail!("Ticket ID cannot be empty.");
+    }
+
+    if ticket.len() > 100 {
+        bail!("Ticket ID too long (max 100 characters): {}", ticket);
+    }
+
+    // Block path traversal
+    if ticket.contains("..") || ticket.contains('/') || ticket.contains('\\') {
+        bail!(
+            "Ticket ID contains unsafe path characters: {}",
+            ticket
+        );
+    }
+
+    // Block null bytes and control characters
+    if ticket.chars().any(|c| c.is_control()) {
+        bail!("Ticket ID contains control characters: {}", ticket);
+    }
+
+    // Block whitespace
+    if ticket.chars().any(|c| c.is_whitespace()) {
+        bail!("Ticket ID contains whitespace: {}", ticket);
+    }
+
+    // Block git ref-unsafe characters: ~, ^, :, ?, *, [, @{
+    const UNSAFE_CHARS: &[char] = &['~', '^', ':', '?', '*', '[', ' '];
+    if let Some(c) = ticket.chars().find(|c| UNSAFE_CHARS.contains(c)) {
+        bail!(
+            "Ticket ID contains git-unsafe character '{}': {}",
+            c,
+            ticket
+        );
+    }
+    if ticket.contains("@{") {
+        bail!("Ticket ID contains git-unsafe sequence '@{{}}': {}", ticket);
+    }
+
+    // Block shell meta-characters
+    const SHELL_CHARS: &[char] = &['$', '`', '!', '&', '|', ';', '(', ')', '{', '}', '<', '>', '"', '\''];
+    if let Some(c) = ticket.chars().find(|c| SHELL_CHARS.contains(c)) {
+        bail!(
+            "Ticket ID contains shell-unsafe character '{}': {}",
+            c,
+            ticket
+        );
+    }
+
+    // Must start with alphanumeric or #
+    let first = ticket.chars().next().unwrap();
+    if !first.is_alphanumeric() && first != '#' {
+        bail!(
+            "Ticket ID must start with a letter, digit, or '#': {}",
+            ticket
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## feat: validate ticket IDs to prevent path traversal and invalid branch names

**Ticket**: [200](https://github.com/erishforG/git-parsec/issues/200)

Shipped via `parsec ship 200`
