### PR TITLE
221: fix: reqwest 0.13 missing rustls TLS backend feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 tabled = { version = "0.20", features = ["ansi"] }
 indicatif = "0.18"
 dialoguer = "0.12"
-reqwest = { version = "0.13", features = ["json", "query", "rustls-native-certs"], default-features = false }
+reqwest = { version = "0.13", features = ["json", "query", "rustls", "rustls-native-certs"], default-features = false }
 tokio = { version = "1", features = ["full"] }
 clap_mangen = "0.3"
 clap_complete = "4"


### PR DESCRIPTION
## fix: reqwest 0.13 missing rustls TLS backend feature

**Ticket**: [221](https://github.com/erishforG/git-parsec/issues/221)

Shipped via `parsec ship 221`
