### PR TITLE
v0.4 features: Windows CI, ship reviewers/labels, stack submit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,21 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test
 
+  test-cross-platform:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # Informational until Windows UNC path issues are resolved
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo test
+
   fmt:
     name: Format
     runs-on: ubuntu-latest
@@ -66,7 +81,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/src/cli/commands/ship.rs
+++ b/src/cli/commands/ship.rs
@@ -20,11 +20,25 @@ pub async fn ship(
     base_override: Option<String>,
     title_override: Option<String>,
     skip_hooks: bool,
+    reviewers: Vec<String>,
+    labels: Vec<String>,
     mode: Mode,
 ) -> Result<()> {
     let mut config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
     config.resolve_for_repo(manager.repo_root());
+
+    // Merge CLI args with config defaults (CLI overrides when non-empty)
+    let effective_reviewers = if reviewers.is_empty() {
+        config.ship.default_reviewers.clone()
+    } else {
+        reviewers
+    };
+    let effective_labels = if labels.is_empty() {
+        config.ship.default_labels.clone()
+    } else {
+        labels
+    };
 
     // Run pre-ship hooks before pushing
     if !skip_hooks && !config.hooks.pre_ship.is_empty() {
@@ -163,6 +177,20 @@ pub async fn ship(
                         .await
                     {
                         Ok(pr) => {
+                            // Request reviewers if specified
+                            if !effective_reviewers.is_empty() {
+                                if let Err(e) =
+                                    gh.request_reviewers(pr.number, &effective_reviewers).await
+                                {
+                                    eprintln!("warning: failed to request reviewers: {e}");
+                                }
+                            }
+                            // Add labels if specified
+                            if !effective_labels.is_empty() {
+                                if let Err(e) = gh.add_labels(pr.number, &effective_labels).await {
+                                    eprintln!("warning: failed to add labels: {e}");
+                                }
+                            }
                             result.pr_url = Some(pr.url);
                         }
                         Err(e) => {

--- a/src/cli/commands/ship.rs
+++ b/src/cli/commands/ship.rs
@@ -152,7 +152,15 @@ pub async fn ship(
                 .unwrap_or_else(|| result.ticket.clone())
         };
 
-        let pr_body = build_pr_body(&result.ticket, effective_title, ticket_url.as_deref());
+        // Gather stack context for PR body (#234)
+        let stack_info = gather_stack_info(&manager, ticket);
+
+        let pr_body = build_pr_body(
+            &result.ticket,
+            effective_title,
+            ticket_url.as_deref(),
+            stack_info.as_ref(),
+        );
 
         let remote_url = git::get_remote_url(manager.repo_root());
         if let Ok(ref remote_url) = remote_url {
@@ -306,7 +314,50 @@ pub async fn ship(
     Ok(())
 }
 
-fn build_pr_body(ticket: &str, title: Option<&str>, ticket_url: Option<&str>) -> String {
+/// Stack context for PR body navigation links.
+struct StackPrInfo {
+    parent_ticket: Option<String>,
+    parent_branch: Option<String>,
+    child_tickets: Vec<(String, String)>, // (ticket, branch)
+    current_branch: String,
+}
+
+/// Gather stack relationship info for a ticket, if it's part of a stack.
+fn gather_stack_info(manager: &WorktreeManager, ticket: &str) -> Option<StackPrInfo> {
+    let workspaces = manager.list().ok()?;
+    let current_ws = manager.get(ticket).ok()?;
+
+    let parent = current_ws
+        .parent_ticket
+        .as_ref()
+        .and_then(|pt| workspaces.iter().find(|w| w.ticket == *pt));
+
+    let children: Vec<_> = workspaces
+        .iter()
+        .filter(|w| w.parent_ticket.as_deref() == Some(ticket))
+        .collect();
+
+    if parent.is_none() && children.is_empty() {
+        return None;
+    }
+
+    Some(StackPrInfo {
+        parent_ticket: current_ws.parent_ticket.clone(),
+        parent_branch: parent.map(|p| p.branch.clone()),
+        child_tickets: children
+            .iter()
+            .map(|c| (c.ticket.clone(), c.branch.clone()))
+            .collect(),
+        current_branch: current_ws.branch.clone(),
+    })
+}
+
+fn build_pr_body(
+    ticket: &str,
+    title: Option<&str>,
+    ticket_url: Option<&str>,
+    stack_info: Option<&StackPrInfo>,
+) -> String {
     let mut body = String::new();
 
     if let Some(title) = title {
@@ -316,6 +367,28 @@ fn build_pr_body(ticket: &str, title: Option<&str>, ticket_url: Option<&str>) ->
     // Add ticket link if URL is available (works for any tracker)
     if let Some(url) = ticket_url {
         body.push_str(&format!("**Ticket**: [{ticket}]({url})\n\n"));
+    }
+
+    // Add stack navigation section (#234)
+    if let Some(stack) = stack_info {
+        body.push_str("### Stack\n\n");
+        body.push_str("| | Ticket | Branch |\n");
+        body.push_str("|---|--------|--------|\n");
+
+        if let (Some(ref pt), Some(ref pb)) = (&stack.parent_ticket, &stack.parent_branch) {
+            body.push_str(&format!("| \u{2b06} Parent | {} | `{}` |\n", pt, pb));
+        }
+
+        body.push_str(&format!(
+            "| **\u{27a1} Current** | **{}** | **`{}`** |\n",
+            ticket, stack.current_branch
+        ));
+
+        for (ct, cb) in &stack.child_tickets {
+            body.push_str(&format!("| \u{2b07} Child | {} | `{}` |\n", ct, cb));
+        }
+
+        body.push('\n');
     }
 
     body.push_str(&format!("Shipped via `parsec ship {ticket}`\n"));

--- a/src/cli/commands/stack.rs
+++ b/src/cli/commands/stack.rs
@@ -178,11 +178,15 @@ pub async fn stack_submit(repo: &Path, mode: Mode) -> Result<()> {
             eprintln!("Shipping {}...", ticket);
         }
         match super::ship(
-            repo, ticket, false, // draft
-            false, // no_pr
-            None,  // base_override
-            None,  // title_override
-            false, // skip_hooks
+            repo,
+            ticket,
+            false,      // draft
+            false,      // no_pr
+            None,       // base_override
+            None,       // title_override
+            false,      // skip_hooks
+            Vec::new(), // reviewers
+            Vec::new(), // labels
             mode,
         )
         .await

--- a/src/cli/commands/stack.rs
+++ b/src/cli/commands/stack.rs
@@ -116,3 +116,108 @@ pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
     output::print_sync(&synced, &failed, "rebase (stack)", mode);
     Ok(())
 }
+
+/// Ship the entire stack in topological order (#235).
+pub async fn stack_submit(repo: &Path, mode: Mode) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config)?;
+    let workspaces = manager.list()?;
+
+    // Find roots: workspaces that have children but no parent themselves
+    let roots: Vec<_> = workspaces
+        .iter()
+        .filter(|w| {
+            w.parent_ticket.is_none()
+                && workspaces
+                    .iter()
+                    .any(|other| other.parent_ticket.as_deref() == Some(&w.ticket))
+        })
+        .collect();
+
+    if roots.is_empty() {
+        if mode == Mode::Human {
+            println!(
+                "No stacked worktrees to submit. Use `parsec start <ticket> --on <parent>` to create a stack."
+            );
+        }
+        return Ok(());
+    }
+
+    // Build topological order: roots first, then children (BFS)
+    let mut ordered = Vec::new();
+    let mut queue: Vec<String> = Vec::new();
+    for root in &roots {
+        ordered.push(root.ticket.clone());
+        queue.push(root.ticket.clone());
+    }
+    while let Some(parent) = queue.first().cloned() {
+        queue.remove(0);
+        let children: Vec<_> = workspaces
+            .iter()
+            .filter(|w| w.parent_ticket.as_deref() == Some(parent.as_str()))
+            .collect();
+        for child in children {
+            ordered.push(child.ticket.clone());
+            queue.push(child.ticket.clone());
+        }
+    }
+
+    if mode == Mode::Human {
+        println!("Submitting stack ({} worktrees):", ordered.len());
+        for (i, ticket) in ordered.iter().enumerate() {
+            println!("  {}. {}", i + 1, ticket);
+        }
+        println!();
+    }
+
+    // Ship each in dependency order
+    let mut shipped = Vec::new();
+    let mut failed = Vec::new();
+    for ticket in &ordered {
+        if mode == Mode::Human {
+            eprintln!("Shipping {}...", ticket);
+        }
+        match super::ship(
+            repo, ticket, false, // draft
+            false, // no_pr
+            None,  // base_override
+            None,  // title_override
+            false, // skip_hooks
+            mode,
+        )
+        .await
+        {
+            Ok(()) => shipped.push(ticket.clone()),
+            Err(e) => {
+                eprintln!("error: failed to ship {}: {}", ticket, e);
+                failed.push((ticket.clone(), e.to_string()));
+                // Stop on first failure to prevent broken stack
+                break;
+            }
+        }
+    }
+
+    if mode == Mode::Human {
+        println!();
+        println!(
+            "Stack submit complete: {}/{} shipped",
+            shipped.len(),
+            ordered.len()
+        );
+        if !failed.is_empty() {
+            for (t, err) in &failed {
+                println!("  failed: {} - {}", t, err);
+            }
+        }
+    }
+
+    if !failed.is_empty() {
+        anyhow::bail!(
+            "Stack submit incomplete: {} of {} shipped",
+            shipped.len(),
+            ordered.len()
+        );
+    }
+
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -132,6 +132,14 @@ pub enum Command {
         /// Skip pre-ship hooks
         #[arg(long)]
         skip_hooks: bool,
+
+        /// Request review from GitHub users (can be specified multiple times)
+        #[arg(long, short = 'r')]
+        reviewer: Vec<String>,
+
+        /// Add labels to the PR (can be specified multiple times)
+        #[arg(long, short = 'l')]
+        label: Vec<String>,
     },
 
     /// Remove merged or stale worktrees
@@ -556,6 +564,8 @@ pub async fn run(cli: Cli) -> Result<()> {
             base,
             title,
             skip_hooks,
+            reviewer,
+            label,
         } => {
             if cli.dry_run {
                 eprintln!(
@@ -575,6 +585,8 @@ pub async fn run(cli: Cli) -> Result<()> {
                 base,
                 title,
                 skip_hooks,
+                reviewer,
+                label,
                 output_mode,
             )
             .await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -361,10 +361,15 @@ pub enum Command {
     ///
     /// Displays the dependency graph of worktrees created with --on.
     /// Use `parsec stack --sync` to rebase the entire chain.
+    /// Use `parsec stack --submit` to ship the entire stack at once.
     Stack {
         /// Sync the entire stack (rebase chain)
         #[arg(long)]
         sync: bool,
+
+        /// Ship the entire stack in dependency order
+        #[arg(long)]
+        submit: bool,
     },
 
     /// Print the main repository root path
@@ -704,8 +709,10 @@ pub async fn run(cli: Cli) -> Result<()> {
             assignee,
             all,
         } => commands::board(&repo_path, board_id, project, assignee, all, output_mode).await,
-        Command::Stack { sync } => {
-            if sync {
+        Command::Stack { sync, submit } => {
+            if submit {
+                commands::stack_submit(&repo_path, output_mode).await
+            } else if sync {
                 commands::stack_sync(&repo_path, output_mode).await
             } else {
                 commands::stack(&repo_path, output_mode).await

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -181,6 +181,12 @@ pub struct ShipConfig {
     pub draft: bool,
     #[serde(default)]
     pub default_base: Option<String>,
+    /// Default reviewers to request on PRs (GitHub usernames)
+    #[serde(default)]
+    pub default_reviewers: Vec<String>,
+    /// Default labels to apply to PRs
+    #[serde(default)]
+    pub default_labels: Vec<String>,
 }
 
 impl Default for ShipConfig {
@@ -190,6 +196,8 @@ impl Default for ShipConfig {
             auto_cleanup: true,
             draft: false,
             default_base: None,
+            default_reviewers: Vec::new(),
+            default_labels: Vec::new(),
         }
     }
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -798,4 +798,52 @@ impl GitHubClient {
             number,
         })
     }
+
+    /// Request reviews from GitHub users on a PR.
+    pub async fn request_reviewers(&self, pr_number: u64, reviewers: &[String]) -> Result<()> {
+        if reviewers.is_empty() {
+            return Ok(());
+        }
+        let payload = serde_json::json!({ "reviewers": reviewers });
+        let response = self
+            .post(&format!(
+                "{}/pulls/{}/requested_reviewers",
+                self.repo_path(),
+                pr_number
+            ))
+            .json(&payload)
+            .send()
+            .await
+            .context("Failed to request reviewers")?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Failed to request reviewers: {} {}", status, body);
+        }
+        Ok(())
+    }
+
+    /// Add labels to a PR/issue.
+    pub async fn add_labels(&self, issue_number: u64, labels: &[String]) -> Result<()> {
+        if labels.is_empty() {
+            return Ok(());
+        }
+        let payload = serde_json::json!({ "labels": labels });
+        let response = self
+            .post(&format!(
+                "{}/issues/{}/labels",
+                self.repo_path(),
+                issue_number
+            ))
+            .json(&payload)
+            .send()
+            .await
+            .context("Failed to add labels")?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Failed to add labels: {} {}", status, body);
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- **#257**: Add cross-platform CI test coverage (macOS, Windows) as informational checks
- **#238**: Add `--reviewer`/`--label` flags to `parsec ship` with config defaults
- **#234**: Stack navigation in PR body + `parsec stack --submit` for shipping entire stack

## PRs included
- #258 (Windows CI)
- #259 (Ship reviewers/labels)
- #260 (Stack navigation + submit)

All 3 PRs squash-merged to develop with CI passing.