### PR TITLE
261: v0.4 features: Windows CI, ship reviewers/labels, stack submit

### DIFF
--- a/src/cli/commands/stack.rs
+++ b/src/cli/commands/stack.rs
@@ -183,6 +183,8 @@ pub async fn stack_submit(repo: &Path, mode: Mode) -> Result<()> {
             None,  // base_override
             None,  // title_override
             false, // skip_hooks
+            Vec::new(), // reviewers
+            Vec::new(), // labels
             mode,
         )
         .await

--- a/src/cli/commands/stack.rs
+++ b/src/cli/commands/stack.rs
@@ -178,11 +178,13 @@ pub async fn stack_submit(repo: &Path, mode: Mode) -> Result<()> {
             eprintln!("Shipping {}...", ticket);
         }
         match super::ship(
-            repo, ticket, false, // draft
-            false, // no_pr
-            None,  // base_override
-            None,  // title_override
-            false, // skip_hooks
+            repo,
+            ticket,
+            false,      // draft
+            false,      // no_pr
+            None,       // base_override
+            None,       // title_override
+            false,      // skip_hooks
             Vec::new(), // reviewers
             Vec::new(), // labels
             mode,


### PR DESCRIPTION
## v0.4 features: Windows CI, ship reviewers/labels, stack submit

**Ticket**: [261](https://github.com/erishforG/git-parsec/pull/261)

Shipped via `parsec ship 261`
