### PR TITLE
264: v0.4: Windows CI, ship reviewers/labels, stack submit, UNC path fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Removed 1 worktree(s):
 - **Pre-ship hooks** -- Run custom commands before shipping with configurable `[hooks]` pre_ship
 - **Issue creation** -- Create GitHub/Jira issues and start worktrees in one step with `parsec create`
 - **Release workflow** -- Merge, tag, and create GitHub Releases with `parsec release`
+- **PR reviewers and labels** -- Assign reviewers and labels on ship with `--reviewer`/`--label` or config defaults
+- **Stack submit** -- Ship an entire stack in topological order with `parsec stack --submit`
+- **Cross-platform** -- Tested on Linux, macOS, and Windows CI
 
 ---
 
@@ -315,7 +318,7 @@ $ parsec log
 | [`parsec ci`](#parsec-ci-ticket---watch---all) | Check CI pipeline status for a PR |
 | [`parsec merge`](#parsec-merge-ticket---rebase---no-wait---no-delete-branch) | Merge a PR from the terminal |
 | [`parsec diff`](#parsec-diff-ticket---stat---name-only) | View changes vs base branch |
-| [`parsec stack`](#parsec-stack---sync) | View and manage stacked PR dependencies |
+| [`parsec stack`](#parsec-stack---sync---submit) | View and manage stacked PR dependencies |
 | [`parsec board`](#parsec-board) | Show sprint as a Kanban board |
 | [`parsec init`](#parsec-init) | Install shell integration |
 | [`parsec config`](#parsec-config) | Configure parsec |
@@ -489,7 +492,7 @@ $ parsec ticket CL-2283 --json
 Push the branch, create a PR (GitHub) or MR (GitLab), and clean up the worktree. The forge is auto-detected from the remote URL.
 
 ```
-parsec ship <ticket> [--draft] [--no-pr] [--base <branch>] [--skip-hooks]
+parsec ship <ticket> [--draft] [--no-pr] [--base <branch>] [--skip-hooks] [--reviewer <user>]... [--label <name>]...
 ```
 
 | Option | Description |
@@ -498,6 +501,8 @@ parsec ship <ticket> [--draft] [--no-pr] [--base <branch>] [--skip-hooks]
 | `--no-pr` | Push only, skip PR/MR creation |
 | `--base <branch>` | Target base branch for PR (overrides config `default_base` and worktree base) |
 | `--skip-hooks` | Skip pre-ship hooks defined in config |
+| `-r, --reviewer <user>` | Request review from a GitHub user (repeatable) |
+| `-l, --label <name>` | Add a label to the PR (repeatable) |
 
 ```bash
 # Push + PR + cleanup
@@ -511,6 +516,17 @@ $ parsec ship PROJ-5678 --draft
 
 # Push only, no PR
 $ parsec ship PROJ-9000 --no-pr
+
+# Ship with reviewers and labels
+$ parsec ship PROJ-1234 --reviewer alice --reviewer bob --label "needs-review"
+```
+
+Reviewers and labels can also be set as defaults in config:
+
+```toml
+[ship]
+default_reviewers = ["alice", "bob"]
+default_labels = ["team-backend"]
 ```
 
 Token required: set `PARSEC_GITHUB_TOKEN` (or `GITHUB_TOKEN`, `GH_TOKEN`) for GitHub, or `PARSEC_GITLAB_TOKEN` (or `GITLAB_TOKEN`) for GitLab.
@@ -866,17 +882,18 @@ $ parsec diff PROJ-1234 --json
 
 ---
 
-### `parsec stack [--sync]`
+### `parsec stack [--sync] [--submit]`
 
-View and manage stacked PR dependencies. Worktrees created with `--on` form a dependency chain.
+View and manage stacked PR dependencies. Worktrees created with `--on` form a dependency chain. PRs include a **stack navigation table** showing parent/child relationships.
 
 ```
-parsec stack [--sync]
+parsec stack [--sync] [--submit]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--sync` | Rebase the entire stack chain |
+| `--submit` | Ship the entire stack in topological order (root first) |
 
 ```bash
 # Create a stack
@@ -898,7 +915,23 @@ $ parsec stack --sync
 $ parsec ship PROJ-1   # PR to main
 $ parsec ship PROJ-2   # PR to feature/PROJ-1
 $ parsec ship PROJ-3   # PR to feature/PROJ-2
+
+# Or ship the entire stack at once
+$ parsec stack --submit
+Submitting stack (3 worktrees):
+  1. PROJ-1
+  2. PROJ-2
+  3. PROJ-3
+Stack submit complete: 3/3 shipped
 ```
+
+Each PR body includes a stack navigation table:
+
+| | Ticket | Branch |
+|---|--------|--------|
+| ⬆ Parent | PROJ-1 | `feature/PROJ-1` |
+| **➡ Current** | **PROJ-2** | **`feature/PROJ-2`** |
+| ⬇ Child | PROJ-3 | `feature/PROJ-3` |
 
 ---
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -1274,6 +1274,8 @@
                   <tr><td><code>--no-pr</code></td><td>Push the branch but skip creating a PR/MR.</td></tr>
                   <tr><td><code>--base &lt;BRANCH&gt;</code></td><td>Override the target base branch for the PR.</td></tr>
                   <tr><td><code>--skip-hooks</code></td><td>Skip pre-ship hooks defined in <code>[hooks]</code> config.</td></tr>
+                  <tr><td><code>-r, --reviewer &lt;USER&gt;</code></td><td>Request review from a GitHub user (repeatable).</td></tr>
+                  <tr><td><code>-l, --label &lt;NAME&gt;</code></td><td>Add a label to the PR (repeatable).</td></tr>
                 </tbody>
               </table>
             </div>
@@ -1292,6 +1294,10 @@
 <span class="terminal-line"><span class="comment"># Open as draft PR</span></span>
 <span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-125</span> <span class="flag">--draft</span></span>
 <span class="terminal-line"><span class="success">✓</span> <span class="info">Draft PR created: </span><span class="link">github.com/org/myrepo/pull/43</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Ship with reviewers and labels</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-126</span> <span class="flag">--reviewer alice --reviewer bob --label needs-review</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR #44 created with reviewers and labels</span></span>
               </div>
             </div>
           </div>
@@ -1767,6 +1773,7 @@
                 </thead>
                 <tbody>
                   <tr><td><code>--sync</code></td><td>Re-target stacked PRs after an upstream PR was merged.</td></tr>
+                  <tr><td><code>--submit</code></td><td>Ship the entire stack in topological order (root first). Stops on first failure.</td></tr>
                 </tbody>
               </table>
             </div>
@@ -1781,6 +1788,13 @@
 <span class="terminal-line"><span class="info">  main</span></span>
 <span class="terminal-line"><span class="info">  └── </span><span class="link">feature/PROJ-123</span><span class="info">  (PROJ-123) PR #42 open</span></span>
 <span class="terminal-line"><span class="info">      └── </span><span class="link">feature/PROJ-124</span><span class="info">  (PROJ-124) PR #43 open</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Ship the entire stack at once</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec stack</span> <span class="flag">--submit</span></span>
+<span class="terminal-line"><span class="info">Submitting stack (2 worktrees):</span></span>
+<span class="terminal-line"><span class="info">  1. PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  2. PROJ-124</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Stack submit complete: 2/2 shipped</span></span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## v0.4: Windows CI, ship reviewers/labels, stack submit, UNC path fix

**Ticket**: [264](https://github.com/erishforG/git-parsec/pull/264)

Shipped via `parsec ship 264`
