### PR TITLE
236: feat: parsec compress — squash branch commits

### DIFF
--- a/src/cli/commands/compress.rs
+++ b/src/cli/commands/compress.rs
@@ -1,0 +1,103 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::config::ParsecConfig;
+use crate::git;
+use crate::output::Mode;
+use crate::worktree::WorktreeManager;
+
+pub async fn compress(
+    repo: &Path,
+    ticket: Option<&str>,
+    message: Option<String>,
+    mode: Mode,
+) -> Result<()> {
+    let config = ParsecConfig::load()?;
+    let manager = WorktreeManager::new(repo, &config)?;
+
+    // Resolve ticket from arg or current worktree
+    let ticket = match ticket {
+        Some(t) => t.to_string(),
+        None => {
+            let cwd = std::env::current_dir()?;
+            let workspaces = manager.list()?;
+            workspaces
+                .iter()
+                .find(|w| cwd.starts_with(&w.path))
+                .map(|w| w.ticket.clone())
+                .ok_or_else(|| anyhow::anyhow!("Not in a parsec worktree. Specify a ticket."))?
+        }
+    };
+
+    let workspace = manager.get(&ticket)?;
+
+    // Find merge-base with the base branch
+    let merge_base = git::run_output(
+        &workspace.path,
+        &["merge-base", "HEAD", &workspace.base_branch],
+    )?;
+
+    // Count commits to squash
+    let log_output = git::run_output(
+        &workspace.path,
+        &["rev-list", "--count", &format!("{}..HEAD", merge_base)],
+    )?;
+    let commit_count: u64 = log_output.parse().unwrap_or(0);
+
+    if commit_count <= 1 {
+        if mode == Mode::Human {
+            println!(
+                "Nothing to compress — branch has {} commit(s) since base.",
+                commit_count
+            );
+        }
+        return Ok(());
+    }
+
+    // Get the default commit message (combine all commit messages)
+    let combined_msg = if let Some(ref msg) = message {
+        msg.clone()
+    } else {
+        git::run_output(
+            &workspace.path,
+            &["log", "--format=%s", &format!("{}..HEAD", merge_base)],
+        )?
+    };
+
+    // Soft reset to merge-base
+    git::run(&workspace.path, &["reset", "--soft", &merge_base])?;
+
+    // Recommit with combined or custom message
+    let final_message = if message.is_some() {
+        combined_msg
+    } else {
+        // Use first commit message as primary, rest as bullet points
+        let lines: Vec<&str> = combined_msg.lines().collect();
+        if lines.len() == 1 {
+            lines[0].to_string()
+        } else {
+            format!(
+                "{}\n\nSquashed {} commits:\n{}",
+                lines[0],
+                commit_count,
+                lines
+                    .iter()
+                    .map(|l| format!("- {}", l))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        }
+    };
+
+    git::run(&workspace.path, &["commit", "-m", &final_message])?;
+
+    if mode == Mode::Human {
+        println!(
+            "Compressed {} commits into 1 for ticket {}.",
+            commit_count, ticket
+        );
+    }
+
+    Ok(())
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,4 +1,5 @@
 mod ci;
+mod compress;
 mod config;
 mod diff;
 mod doctor;
@@ -11,6 +12,7 @@ mod tracker_cmds;
 mod workspace;
 
 pub use ci::*;
+pub use compress::*;
 pub use config::*;
 pub use diff::*;
 pub use doctor::*;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -466,6 +466,20 @@ pub enum Command {
         start: bool,
     },
 
+    /// Squash all branch commits into one
+    ///
+    /// Resets the branch to the merge-base with the base branch and
+    /// re-commits all changes as a single commit. Use --message to
+    /// set a custom commit message.
+    Compress {
+        /// Ticket identifier (auto-detects current worktree if omitted)
+        ticket: Option<String>,
+
+        /// Custom commit message (default: combines all squashed messages)
+        #[arg(long, short)]
+        message: Option<String>,
+    },
+
     /// Rename a workspace to a different ticket ID
     ///
     /// Changes the ticket ID, renames the branch, and moves the worktree directory.
@@ -792,6 +806,9 @@ pub async fn run(cli: Cli) -> Result<()> {
                 return Ok(());
             }
             commands::rename(&repo_path, &old_ticket, &new_ticket, output_mode).await
+        }
+        Command::Compress { ticket, message } => {
+            commands::compress(&repo_path, ticket.as_deref(), message, output_mode).await
         }
     }
 }


### PR DESCRIPTION
## feat: parsec compress — squash branch commits

**Ticket**: [236](https://github.com/erishforG/git-parsec/issues/236)

Shipped via `parsec ship 236`
