### PR TITLE
[244] feat: parsec agent — dedicated non-interactive mode for AI agents

### DIFF
--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -68,6 +68,9 @@ pub async fn init_install(shell: &str, yes: bool) -> Result<()> {
     }
 
     if !yes {
+        if crate::env::is_agent() {
+            anyhow::bail!("Interactive confirmation is not available in agent mode. Use `parsec config shell --yes` to skip prompts.");
+        }
         let confirmed = dialoguer::Confirm::new()
             .with_prompt(format!(
                 "Add shell integration to {}?",

--- a/src/cli/commands/tracker_cmds.rs
+++ b/src/cli/commands/tracker_cmds.rs
@@ -115,6 +115,9 @@ pub async fn inbox(repo: &Path, pick: bool, mode: Mode) -> Result<()> {
             .iter()
             .map(|t| format!("{} — {} [{}]", t.key, t.summary, t.priority))
             .collect();
+        if crate::env::is_agent() {
+            anyhow::bail!("Interactive ticket picker is not available in agent mode. Use `parsec inbox` without --pick, then `parsec start <TICKET>`.");
+        }
         let selection = dialoguer::Select::new()
             .with_prompt("Pick a ticket to start")
             .items(&items)

--- a/src/cli/commands/workspace.rs
+++ b/src/cli/commands/workspace.rs
@@ -449,6 +449,9 @@ pub async fn switch(repo: &Path, ticket: Option<&str>, mode: Mode) -> Result<()>
                     format!("{}{title}", w.ticket)
                 })
                 .collect();
+            if crate::env::is_agent() {
+                anyhow::bail!("Interactive workspace picker is not available in agent mode. Specify the ticket ID explicitly: `parsec switch <TICKET>`");
+            }
             let selection = dialoguer::Select::new()
                 .with_prompt("Switch to workspace")
                 .items(&items)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -545,7 +545,7 @@ pub enum ConfigAction {
 
 pub async fn run(cli: Cli) -> Result<()> {
     let repo_path = cli.repo.unwrap_or_else(|| PathBuf::from("."));
-    let output_mode = if cli.json {
+    let output_mode = if cli.json || crate::env::is_agent() {
         output::Mode::Json
     } else if cli.quiet {
         output::Mode::Quiet

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -479,6 +479,10 @@ impl ParsecConfig {
 
     /// Interactively prompt the user to configure parsec and return the resulting config.
     pub fn init_interactive() -> Result<Self> {
+        if crate::env::is_agent() {
+            anyhow::bail!("Interactive config init is not available in agent mode. Use `parsec config show` or set config values directly.");
+        }
+
         let mut config = Self::default();
 
         // ---- Tracker provider ------------------------------------------------

--- a/src/env.rs
+++ b/src/env.rs
@@ -72,6 +72,20 @@ pub fn gitlab_token() -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
+// Agent mode
+// ---------------------------------------------------------------------------
+
+pub const PARSEC_AGENT: &str = "PARSEC_AGENT";
+
+/// Check if agent mode is active (via PARSEC_AGENT env var).
+/// In agent mode: JSON output is forced, interactive prompts are skipped.
+pub fn is_agent() -> bool {
+    std::env::var(PARSEC_AGENT)
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
 // Offline mode
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## feat: parsec agent — dedicated non-interactive mode for AI agents

**Ticket**: [244](https://github.com/erishforG/git-parsec/issues/244)

---

## Summary

<!-- Brief description of the changes -->

## Related Issue

<!-- Link to the related issue: Fixes #123 / Closes #123 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD
- [ ] Other (describe below)

## Pre-submit Checklist

- [ ] `cargo test` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy` passes
- [ ] I have added/updated relevant documentation (if applicable)

Shipped via `parsec ship 244`
