### PR TITLE
[166] feat: Observability lite — execution ID, step status, JSONL log export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1", features = ["full"] }
 clap_mangen = "0.3"
 clap_complete = "4"
 dunce = "1"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/cli/commands/history.rs
+++ b/src/cli/commands/history.rs
@@ -18,6 +18,17 @@ pub async fn log(repo: &Path, ticket: Option<&str>, last: usize, mode: Mode) -> 
     Ok(())
 }
 
+pub async fn log_export(repo: &Path) -> Result<()> {
+    let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
+    let raw = crate::execlog::read_raw(&repo_root)?;
+    if raw.is_empty() {
+        eprintln!("No execution log entries. Run some commands first.");
+    } else {
+        print!("{}", raw);
+    }
+    Ok(())
+}
+
 pub async fn undo(repo: &Path, dry_run: bool, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;

--- a/src/cli/commands/ship.rs
+++ b/src/cli/commands/ship.rs
@@ -25,6 +25,8 @@ pub async fn ship(
     template: Option<String>,
     mode: Mode,
 ) -> Result<()> {
+    crate::execlog::set_ticket(ticket);
+
     let mut config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
     config.resolve_for_repo(manager.repo_root());
@@ -78,6 +80,7 @@ pub async fn ship(
     // Phase 1: Push only (don't clean up yet)
     // Idempotency: if workspace is already gone (cleaned up after a prior ship),
     // treat push as a no-op — the branch is already on the remote.
+    let push_start = std::time::Instant::now();
     let mut result = match manager.ship_push(ticket) {
         Ok(r) => r,
         Err(e) => {
@@ -112,6 +115,8 @@ pub async fn ship(
         }
     };
 
+    crate::execlog::record_step("push", "ok", push_start.elapsed().as_millis() as u64, None);
+
     // Resolve base branch: --base CLI > config default_base > worktree's base_branch
     if let Some(base) = base_override {
         result.base_branch = base;
@@ -134,6 +139,7 @@ pub async fn ship(
     }
 
     // Phase 2: Create PR/MR (async)
+    let pr_start = std::time::Instant::now();
     let mut pr_failed = false;
     if !no_pr && config.ship.auto_pr && !crate::env::is_offline() {
         let (ticket_title, ticket_url) =
@@ -245,6 +251,13 @@ pub async fn ship(
             }
         }
     }
+
+    crate::execlog::record_step(
+        "create_pr",
+        if pr_failed { "error" } else { "ok" },
+        pr_start.elapsed().as_millis() as u64,
+        result.pr_url.clone(),
+    );
 
     // Auto-comment PR link on the ticket if configured
     if config.tracker.comment_on_ship && !crate::env::is_offline() {

--- a/src/cli/commands/workspace.rs
+++ b/src/cli/commands/workspace.rs
@@ -21,6 +21,7 @@ pub async fn start(
     hook: Option<String>,
     mode: Mode,
 ) -> Result<()> {
+    crate::execlog::set_ticket(ticket);
     let mut config = ParsecConfig::load()?;
     let repo_root = git::get_repo_root(repo)?;
     config.resolve_for_repo(&repo_root);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -316,6 +316,10 @@ pub enum Command {
         /// Show last N entries (default: 20)
         #[arg(long, short = 'n', default_value = "20")]
         last: usize,
+
+        /// Export execution log as JSONL (for observability/debugging)
+        #[arg(long)]
+        export: bool,
     },
 
     /// Undo the last parsec operation
@@ -562,7 +566,42 @@ pub async fn run(cli: Cli) -> Result<()> {
         std::env::set_var("PARSEC_OFFLINE", "1");
     }
 
-    match cli.command {
+    // Observability: extract command name and set up execution tracking
+    let cmd_name = match &cli.command {
+        Command::Start { .. } => "start",
+        Command::List { .. } => "list",
+        Command::Status { .. } => "status",
+        Command::Ticket { .. } => "ticket",
+        Command::Ship { .. } => "ship",
+        Command::Clean { .. } => "clean",
+        Command::Conflicts => "conflicts",
+        Command::PrStatus { .. } => "pr-status",
+        Command::Merge { .. } => "merge",
+        Command::Ci { .. } => "ci",
+        Command::Diff { .. } => "diff",
+        Command::Switch { .. } => "switch",
+        Command::Sync { .. } => "sync",
+        Command::Open { .. } => "open",
+        Command::Adopt { .. } => "adopt",
+        Command::Log { .. } => "log",
+        Command::Undo { .. } => "undo",
+        Command::Inbox { .. } => "inbox",
+        Command::Board { .. } => "board",
+        Command::Stack { .. } => "stack",
+        Command::Root => "root",
+        Command::Init { .. } => "init",
+        Command::Config { .. } => "config",
+        Command::Doctor { .. } => "doctor",
+        Command::Release { .. } => "release",
+        Command::Create { .. } => "create",
+        Command::Rename { .. } => "rename",
+        Command::Compress { .. } => "compress",
+    };
+    let exec_id = crate::execlog::new_execution_id();
+    let exec_started_at = chrono::Utc::now();
+    let exec_start = std::time::Instant::now();
+
+    let result = match cli.command {
         Command::Start {
             ticket,
             base,
@@ -736,8 +775,16 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Switch { ticket } => {
             commands::switch(&repo_path, ticket.as_deref(), output_mode).await
         }
-        Command::Log { ticket, last } => {
-            commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
+        Command::Log {
+            ticket,
+            last,
+            export,
+        } => {
+            if export {
+                commands::log_export(&repo_path).await
+            } else {
+                commands::log(&repo_path, ticket.as_deref(), last, output_mode).await
+            }
         }
         Command::Undo { dry_run } => commands::undo(&repo_path, dry_run, output_mode).await,
         Command::Inbox { pick } => commands::inbox(&repo_path, pick, output_mode).await,
@@ -835,5 +882,33 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Compress { ticket, message } => {
             commands::compress(&repo_path, ticket.as_deref(), message, output_mode).await
         }
+    };
+
+    // Record execution entry (best-effort, never fail the command)
+    let duration = exec_start.elapsed();
+    let steps = crate::execlog::take_steps();
+    let ticket = crate::execlog::take_ticket();
+    let entry = crate::execlog::ExecEntry {
+        execution_id: exec_id,
+        command: cmd_name.to_string(),
+        ticket,
+        started_at: exec_started_at,
+        finished_at: chrono::Utc::now(),
+        duration_ms: duration.as_millis() as u64,
+        status: if result.is_ok() {
+            "ok".to_string()
+        } else {
+            "error".to_string()
+        },
+        error: result.as_ref().err().map(|e| format!("{e:#}")),
+        steps,
+    };
+    // Use repo_path for logging; skip if .parsec dir can't be resolved
+    if let Ok(root) = crate::git::get_main_repo_root(&repo_path)
+        .or_else(|_| crate::git::get_repo_root(&repo_path))
+    {
+        let _ = crate::execlog::append(&root, &entry);
     }
+
+    result
 }

--- a/src/execlog.rs
+++ b/src/execlog.rs
@@ -1,0 +1,125 @@
+//! Lightweight execution log for observability.
+//!
+//! Each parsec command invocation is recorded as an `ExecEntry` with a unique
+//! execution ID, timing, and optional step-level detail. Entries are stored as
+//! newline-delimited JSON (JSONL) in `.parsec/execlog.jsonl`.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// A single phase within a command execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecStep {
+    pub phase: String,
+    pub status: String,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// A complete command execution record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecEntry {
+    pub execution_id: String,
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ticket: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub duration_ms: u64,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub steps: Vec<ExecStep>,
+}
+
+// ---------------------------------------------------------------------------
+// Thread-local accumulators
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static CURRENT_STEPS: RefCell<Vec<ExecStep>> = const { RefCell::new(Vec::new()) };
+    static CURRENT_TICKET: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Record a step in the current execution context.
+pub fn record_step(phase: &str, status: &str, duration_ms: u64, detail: Option<String>) {
+    CURRENT_STEPS.with(|steps| {
+        steps.borrow_mut().push(ExecStep {
+            phase: phase.to_string(),
+            status: status.to_string(),
+            duration_ms,
+            detail,
+        });
+    });
+}
+
+/// Set the ticket for the current execution (called from commands).
+pub fn set_ticket(ticket: &str) {
+    CURRENT_TICKET.with(|t| *t.borrow_mut() = Some(ticket.to_string()));
+}
+
+/// Take all accumulated steps (clears the accumulator).
+pub fn take_steps() -> Vec<ExecStep> {
+    CURRENT_STEPS.with(|steps| std::mem::take(&mut *steps.borrow_mut()))
+}
+
+/// Take the ticket set during execution.
+pub fn take_ticket() -> Option<String> {
+    CURRENT_TICKET.with(|t| t.borrow_mut().take())
+}
+
+/// Generate a new execution ID (UUID v4).
+pub fn new_execution_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Persistence (JSONL)
+// ---------------------------------------------------------------------------
+
+fn execlog_path(repo_root: &Path) -> PathBuf {
+    repo_root.join(".parsec").join("execlog.jsonl")
+}
+
+/// Append an execution entry to the JSONL log.
+pub fn append(repo_root: &Path, entry: &ExecEntry) -> Result<()> {
+    let path = execlog_path(repo_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let line = serde_json::to_string(entry)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+    writeln!(file, "{}", line)?;
+    Ok(())
+}
+
+/// Load all execution entries from the JSONL log.
+#[allow(dead_code)]
+pub fn load(repo_root: &Path) -> Result<Vec<ExecEntry>> {
+    let path = execlog_path(repo_root);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let contents = fs::read_to_string(&path)?;
+    Ok(contents
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect())
+}
+
+/// Read raw JSONL content for export.
+pub fn read_raw(repo_root: &Path) -> Result<String> {
+    let path = execlog_path(repo_root);
+    if !path.exists() {
+        return Ok(String::new());
+    }
+    Ok(fs::read_to_string(&path)?)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod config;
 mod conflict;
 mod env;
+mod execlog;
 mod git;
 mod github;
 mod gitlab;


### PR DESCRIPTION
## feat: Observability lite — execution ID, step status, JSONL log export

**Ticket**: [166](https://github.com/erishforG/git-parsec/issues/166)

---

## Summary

<!-- Brief description of the changes -->

## Related Issue

<!-- Link to the related issue: Fixes #123 / Closes #123 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD
- [ ] Other (describe below)

## Pre-submit Checklist

- [ ] `cargo test` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy` passes
- [ ] I have added/updated relevant documentation (if applicable)

Shipped via `parsec ship 166`
