### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-04
+
 ### Added
-- `[worktree]` config section with `shared_cache` and `cache_strategy` for
-  selective build cache sharing between worktrees. New worktrees can now reuse
-  `target/`, `node_modules/`, `.venv/`, etc. from the main repo via symlink
-  (default) or recursive copy, eliminating cold-build cost on `parsec start`
-  (#207).
+- **Bitbucket Cloud forge** — full PR lifecycle support (create, list, view,
+  merge, comments). New tracker/forge entries `bitbucket` selectable via
+  `parsec config` and `[forge]` settings (#240).
+- **Bitbucket Pipelines CI integration** — `parsec ci` and `pr-status`
+  commands now report Bitbucket Pipelines build state alongside GitHub
+  Actions and GitLab CI (#279).
+- **`parsec compress` command** — squash a stack of related commits into a
+  single tidy commit before shipping, preserving co-author trailers (#236).
+- **`parsec ship --template`** — auto-populate the PR description from a
+  repository's `.github/PULL_REQUEST_TEMPLATE.md` (or first match under
+  `.github/PULL_REQUEST_TEMPLATE/`) (#233).
+- **`ship --reviewer` and `--label`** — attach reviewers and labels at PR
+  creation time (#261).
+- **Stack `--submit`** — open all PRs in a stack in one command (#261).
+- **Stack navigation comments** — auto-posted "← prev / next →" comments on
+  every PR in a stack so reviewers can walk the chain (#234).
+- **`ship.draft` config + `--draft` flag** — open PRs as drafts by default
+  when working in throwaway / WIP branches (#238).
+- **`[worktree]` shared build cache** — `shared_cache` and `cache_strategy`
+  settings let new worktrees reuse `target/`, `node_modules/`, `.venv/`, etc.
+  from the main repo via symlink (default) or recursive copy, eliminating
+  cold-build cost on `parsec start` (#207).
+- **Offline mode toggle** — `[behavior].offline` config and per-command
+  `--no-pr` / `--no-tracker` flags so parsec can operate without forge or
+  tracker connectivity (#237).
+- **Observability lite** — every command run now has an execution ID and
+  step timing; opt in to JSONL export via `[observability]` settings for
+  tooling/agents to consume (#166).
+- **Config JSON Schema + `parsec schema`** — schema published to
+  schemastore.org so editors auto-complete `parsec.toml`. The new
+  `parsec schema` subcommand emits the schema on demand (#239).
+- **Windows CI coverage** — full test matrix on Windows runners (#257).
+- 11 new integration tests across forge adapters and worktree paths (#278).
+
+### Changed
+- README and reference docs updated to cover ship `--reviewer` / `--label`,
+  stack `--submit`, Bitbucket adapter, offline flags, build cache config,
+  and `parsec compress` (#265).
+
+### Fixed
+- Windows UNC path issue (`\\?\` prefix) breaking worktree operations on
+  Windows hosts — resolved via the `dunce` crate (#263).
+
+### CI
+- Trigger CI on `release/**` branches in addition to feature branches and
+  develop, so release-prep work is exercised before merge (#277).
 
 ## [0.3.3] - 2026-04-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager — ticket to PR in one command. Parallel AI agent workflows with Jira & GitHub Issues integration."

--- a/README.md
+++ b/README.md
@@ -114,7 +114,15 @@ Removed 1 worktree(s):
 - **Release workflow** -- Merge, tag, and create GitHub Releases with `parsec release`
 - **PR reviewers and labels** -- Assign reviewers and labels on ship with `--reviewer`/`--label` or config defaults
 - **Stack submit** -- Ship an entire stack in topological order with `parsec stack --submit`
-- **Cross-platform** -- Tested on Linux, macOS, and Windows CI
+- **Stack navigation comments** -- Auto-posted "← prev / next →" comments on each PR in a stack
+- **PR template auto-fill** -- `parsec ship --template` populates the PR description from `.github/PULL_REQUEST_TEMPLATE.md`
+- **Compress branch history** -- `parsec compress` squashes a branch's commits into a single tidy commit before shipping
+- **Bitbucket Cloud** -- Full PR lifecycle (create, list, view, merge, comments) and Bitbucket Pipelines CI status
+- **Offline mode** -- Global `--offline` flag (and `[workspace].offline` config) skips all network operations (tracker, PR, fetch) so parsec keeps working without connectivity
+- **Observability** -- Every command run gets an execution ID with per-step timing; `parsec log --export` emits JSONL for tooling and AI agents to consume
+- **Config JSON Schema** -- `parsec config schema` outputs a JSON Schema (also published to schemastore.org) so editors auto-complete `config.toml`
+- **Draft-by-default** -- `[ship].draft = true` config or `--draft` flag opens PRs as drafts for WIP work
+- **Cross-platform** -- Tested on Linux, macOS, and Windows CI; UNC path handling on Windows
 
 ---
 
@@ -327,6 +335,7 @@ $ parsec log
 | [`parsec new-issue`](#parsec-new-issue) | Create a new issue (alias with extra options) |
 | [`parsec release`](#parsec-release-version) | Merge, tag, and create a GitHub Release |
 | [`parsec rename`](#parsec-rename-ticket---new-ticket-id) | Re-ticket a workspace to a different ticket ID |
+| [`parsec compress`](#parsec-compress-ticket--m-message) | Squash all branch commits into one |
 
 ---
 
@@ -628,6 +637,7 @@ parsec log [ticket] [-n, --last N]
 |--------|-------------|
 | `[ticket]` | Filter to a specific ticket |
 | `-n, --last N` | Show last N entries (default: 20) |
+| `--export` | Emit the log as JSONL (one JSON object per line). Each entry includes execution ID and per-step timing for observability/debugging |
 
 ```bash
 $ parsec log
@@ -645,6 +655,11 @@ $ parsec log PROJ-1234
 
 # Last 3 entries only
 $ parsec log --last 3
+
+# Export as JSONL (for tooling / AI agents)
+$ parsec log --export
+{"execution_id":"01HQ3D8R2K8...","op":"start","ticket":"PROJ-1234","steps":[{"name":"fetch_title","ms":214},{"name":"create_worktree","ms":98}],"started_at":"2026-04-15T09:14:01Z","duration_ms":312}
+{"execution_id":"01HQ3D9V7Z2...","op":"ship","ticket":"PROJ-1234","steps":[{"name":"push","ms":820},{"name":"create_pr","ms":1305},{"name":"cleanup","ms":42}],"started_at":"2026-04-15T14:02:18Z","duration_ms":2167}
 ```
 
 ---
@@ -1037,6 +1052,16 @@ $ parsec config completions zsh
 
 # Install man page
 $ sudo parsec config man
+
+# Output the JSON Schema for config.toml (also published to schemastore.org)
+$ parsec config schema > parsec-schema.json
+```
+
+The JSON Schema is published to **schemastore.org** so editors with schemastore integration (VS Code, IntelliJ, Helix) auto-complete and validate `~/.config/parsec/config.toml` and per-repo `.parsec.toml` automatically. To pin the schema locally instead, add to your config:
+
+```toml
+# ~/.config/parsec/config.toml
+#:schema https://json.schemastore.org/parsec.json
 ```
 
 ---
@@ -1186,6 +1211,33 @@ $ parsec rename PROJ-100 --new PROJ-200 --json
 
 ---
 
+### `parsec compress [ticket] [-m <message>]`
+
+Squash all of a branch's commits into a single tidy commit before shipping. The branch is reset to the merge-base with the base branch and the cumulative changes are re-committed as one. Co-author trailers from squashed commits are preserved.
+
+```
+parsec compress [ticket] [-m <message>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `ticket` | Optional. Auto-detects the current worktree's ticket if omitted. |
+| `-m, --message <text>` | Custom commit message. Default: combines all squashed commit messages. |
+
+```bash
+# Compress the current worktree's branch
+$ parsec compress
+Compressed 7 commits into one on feature/PROJ-1234.
+
+# Compress a specific ticket with a custom message
+$ parsec compress PROJ-1234 -m "feat: add user authentication"
+
+# Combine with ship
+$ parsec compress && parsec ship
+```
+
+---
+
 ## Global Flags
 
 These flags work on every command:
@@ -1193,6 +1245,7 @@ These flags work on every command:
 | Flag | Description |
 |------|-------------|
 | `--dry-run` | Preview what a command would do without making changes |
+| `--offline` | Skip all network operations (tracker, PR, fetch). Also enabled by `[workspace].offline = true` in config |
 | `--json` | Machine-readable JSON output |
 | `-q, --quiet` | Suppress non-essential output |
 | `--repo <path>` | Target a different repository |
@@ -1280,6 +1333,9 @@ Config file: `~/.config/parsec/config.toml`
 layout = "sibling"
 base_dir = ".parsec/workspaces"
 branch_prefix = "feature/"
+# Skip all network operations (tracker, PR, fetch). Equivalent to passing
+# --offline on every command. Useful for air-gapped / flight-mode dev.
+offline = false
 
 [worktree]
 # Directories to share from the main repo into new worktrees so that
@@ -1293,7 +1349,7 @@ shared_cache = ["target", "node_modules", ".venv"]
 cache_strategy = "symlink"
 
 [tracker]
-# "jira" | "github" | "gitlab" | "none"
+# "jira" | "github" | "gitlab" | "bitbucket" | "none"
 provider = "jira"
 
 [tracker.jira]
@@ -1307,10 +1363,29 @@ base_url = "https://yourcompany.atlassian.net"
 base_url = "https://gitlab.com"
 # Auth: PARSEC_GITLAB_TOKEN env var
 
+[tracker.bitbucket]
+# workspace = "your-bitbucket-workspace"
+# Auth: PARSEC_BITBUCKET_TOKEN (or BITBUCKET_TOKEN) env var
+# api_base override: PARSEC_BITBUCKET_API_BASE env var
+
+[forge]
+# Auto-detected from the remote URL when omitted. Override here if multiple
+# forges are reachable (e.g., GitHub for PRs, Bitbucket Pipelines for CI).
+# provider = "github" | "gitlab" | "bitbucket"
+
 [ship]
 auto_pr = true        # Create PR/MR on ship
 auto_cleanup = true   # Remove worktree after ship
-draft = false         # Create PRs as drafts
+draft = false         # Open PRs as drafts by default
+# template = ".github/PULL_REQUEST_TEMPLATE.md"  # Auto-fill PR description
+# default_reviewers = ["alice", "bob"]            # Reviewers added on every ship
+# default_labels    = ["needs-review"]             # Labels added on every ship
+
+[observability]
+# Enable per-step timing in `parsec log --export` JSONL output.
+# Each command run gets a unique execution ID; useful for tooling and AI
+# agents to correlate parsec actions with downstream effects.
+enabled = true
 
 [hooks]
 # Commands to run in new worktrees after creation
@@ -1348,9 +1423,13 @@ pre_ship = ["cargo test", "cargo clippy"]
 | `GH_TOKEN` | Fallback GitHub token |
 | `PARSEC_GITLAB_TOKEN` | GitLab token for MR creation |
 | `GITLAB_TOKEN` | Fallback GitLab token |
+| `PARSEC_BITBUCKET_TOKEN` | Bitbucket Cloud app password / access token |
+| `BITBUCKET_TOKEN` | Fallback Bitbucket token |
+| `PARSEC_BITBUCKET_API_BASE` | Override Bitbucket API base URL (test/mock servers) |
 | `PARSEC_JIRA_PROJECT` | Default Jira project key for `board` |
 | `PARSEC_JIRA_BOARD_ID` | Default Jira board ID for `board` |
 | `PARSEC_JIRA_ASSIGNEE` | Default assignee filter for `board` |
+| `PARSEC_OFFLINE` | Set to `1` to force offline mode (same as `--offline`) |
 
 Token priority: `PARSEC_*_TOKEN` > platform-specific variables.
 
@@ -1390,11 +1469,12 @@ $ echo $?
 
 | Feature | parsec | GitButler | worktrunk | git worktree | git-town |
 |---------|--------|-----------|-----------|--------------|----------|
-| Ticket tracker integration | Jira + GitHub Issues | No | No | No | No |
+| Ticket tracker integration | Jira + GitHub + GitLab + Bitbucket | No | No | No | No |
 | Physical isolation | Yes (worktrees) | No (virtual branches) | Yes (worktrees) | Yes | No |
 | Conflict detection | Cross-worktree | N/A | No | No | No |
 | One-step ship (push+PR+clean) | Yes | No | No | No | Yes |
-| GitHub + GitLab | Both | Both | GitHub | No | GitHub, GitLab, Gitea, Bitbucket |
+| Forges | GitHub + GitLab + Bitbucket | Both | GitHub | No | GitHub, GitLab, Gitea, Bitbucket |
+| CI integrations | GitHub Actions + GitLab CI + Bitbucket Pipelines | No | No | No | No |
 | Operation history + undo | Yes | Yes | No | No | Yes (undo) |
 | JSON output | Yes | Yes | No | No | No |
 | CI monitoring | Yes (--watch) | No | No | No | No |

--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -1087,6 +1087,7 @@
           <li><a href="#ai-agents">AI Agent Workflows</a></li>
           <li><a href="#stacked-prs">Stacked PRs</a></li>
           <li><a href="#new-features">New Features</a></li>
+          <li><a href="#v04-features">What's New in v0.4</a></li>
         </ul>
       </div>
 
@@ -1428,7 +1429,7 @@
                 <tr>
                   <td><code>tracker.type</code></td>
                   <td>Issue tracker backend.</td>
-                  <td><code>"jira"</code> / <code>"github"</code> / <code>"gitlab"</code></td>
+                  <td><code>"jira"</code> / <code>"github"</code> / <code>"gitlab"</code> / <code>"bitbucket"</code></td>
                 </tr>
                 <tr>
                   <td><code>tracker.base_url</code></td>
@@ -1734,6 +1735,179 @@
               <p>Customize the release workflow in your config file with <code>[release]</code> section: set the target branch, tag prefix, and whether to include a changelog.</p>
             </div>
           </div>
+        </section>
+
+        <!-- ==============================
+             WHAT'S NEW IN v0.4
+             ============================== -->
+        <section class="guide-section reveal" id="v04-features">
+          <div class="section-heading">
+            <h2>What's New in v0.4</h2>
+            <a href="#v04-features" class="section-anchor">#</a>
+          </div>
+
+          <p>
+            v0.4 broadens forge support to Bitbucket Cloud, adds workflow utilities (<code>compress</code>, <code>--template</code>, stack navigation comments), and introduces operational primitives — offline mode, observability JSONL, and a published config schema — designed for tooling and AI agents.
+          </p>
+
+          <h3>Bitbucket Cloud — full PR lifecycle</h3>
+          <p>
+            parsec now speaks Bitbucket Cloud's API: <code>parsec ship</code> opens PRs, <code>parsec pr-status</code> reports CI from Bitbucket Pipelines, <code>parsec ci</code> tails build status, and <code>parsec merge</code> merges from the terminal. Tracker integration uses the same <code>tracker.bitbucket</code> config block.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">Bitbucket setup</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Auth via env var</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">export</span> <span class="info">PARSEC_BITBUCKET_TOKEN=</span><span class="arg">"&lt;app-password&gt;"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Configure in ~/.config/parsec/config.toml</span></span>
+<span class="terminal-line"><span class="info">[tracker]</span></span>
+<span class="terminal-line"><span class="info">provider = </span><span class="arg">"bitbucket"</span></span>
+<span class="terminal-line"><span class="info">[tracker.bitbucket]</span></span>
+<span class="terminal-line"><span class="info">workspace = </span><span class="arg">"my-team"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">CL-2208</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR opened: bitbucket.org/my-team/repo/pull-requests/142</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Bitbucket Pipelines: BUILD #318 in_progress</span></span>
+            </div>
+          </div>
+
+          <h3>Compress branch history with <code>parsec compress</code></h3>
+          <p>
+            Squash a branch's commits into one tidy commit before shipping. Co-author trailers from squashed commits are preserved automatically.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parsec compress</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Squash all branch commits into one</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Compressed 7 commits into one on feature/PROJ-123</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># With a custom message</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span> <span class="flag">-m</span> <span class="arg">"feat: add user authentication"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Compose: tidy history then ship</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span> &amp;&amp; <span class="command">parsec ship</span></span>
+            </div>
+          </div>
+
+          <h3>Stack navigation comments</h3>
+          <p>
+            When you ship a stacked PR, parsec auto-posts <em>"← previous PR"</em> / <em>"next PR →"</em> navigation comments on every PR in the stack. Reviewers can walk the chain without leaving the PR view.
+          </p>
+
+          <h3>PR template auto-fill — <code>ship --template</code></h3>
+          <p>
+            Use the repository's <code>.github/PULL_REQUEST_TEMPLATE.md</code> (or the first match under <code>.github/PULL_REQUEST_TEMPLATE/</code>) as the PR description automatically. Combine with <code>ship.template</code> in <code>config.toml</code> to make it the default.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">ship --template</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-123</span> <span class="flag">--template</span></span>
+<span class="terminal-line"><span class="info">Loaded .github/PULL_REQUEST_TEMPLATE.md (348 chars)</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR opened with template body</span></span>
+            </div>
+          </div>
+
+          <h3>Offline mode — <code>--offline</code> / <code>[workspace].offline</code></h3>
+          <p>
+            Skip all network operations: tracker lookups, PR creation, fetches. Use a global <code>--offline</code> flag, the <code>PARSEC_OFFLINE=1</code> env var, or set <code>offline = true</code> under <code>[workspace]</code> in <code>config.toml</code>. Per-command escapes (<code>--no-pr</code>, <code>--no-tracker</code>) remain available for finer control.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">offline mode</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Per-invocation</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">CL-2208</span> <span class="flag">--offline</span> <span class="flag">--title</span> <span class="arg">"Add login retry"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Persistent — flight mode</span></span>
+<span class="terminal-line"><span class="info">[workspace]</span></span>
+<span class="terminal-line"><span class="info">offline = </span><span class="arg">true</span></span>
+            </div>
+          </div>
+
+          <h3>Observability — execution IDs + JSONL export</h3>
+          <p>
+            Every command run gets a unique execution ID and per-step timing. <code>parsec log --export</code> emits one JSON object per line for tooling and AI agents to consume. Combined with <code>--json</code> on individual commands, parsec is fully introspectable.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parsec log --export</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec log</span> <span class="flag">--export</span> | <span class="command">jq</span> <span class="arg">'select(.duration_ms &gt; 1000)'</span></span>
+<span class="terminal-line"><span class="info">{</span></span>
+<span class="terminal-line"><span class="info">  "execution_id": "01HQ3D9V7Z2...",</span></span>
+<span class="terminal-line"><span class="info">  "op": "ship",</span></span>
+<span class="terminal-line"><span class="info">  "ticket": "PROJ-123",</span></span>
+<span class="terminal-line"><span class="info">  "steps": [</span></span>
+<span class="terminal-line"><span class="info">    {"name":"push","ms":820},</span></span>
+<span class="terminal-line"><span class="info">    {"name":"create_pr","ms":1305},</span></span>
+<span class="terminal-line"><span class="info">    {"name":"cleanup","ms":42}</span></span>
+<span class="terminal-line"><span class="info">  ],</span></span>
+<span class="terminal-line"><span class="info">  "duration_ms": 2167</span></span>
+<span class="terminal-line"><span class="info">}</span></span>
+            </div>
+          </div>
+
+          <h3>Config JSON Schema — editor autocomplete</h3>
+          <p>
+            The schema for <code>config.toml</code> is published to <a href="https://schemastore.org">schemastore.org</a>, so VS Code, IntelliJ, Helix, and any editor with schemastore integration auto-complete and validate every key. <code>parsec config schema</code> emits the schema for offline use.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">config schema</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config schema</span> > parsec-schema.json</span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Pin schema in your config for editor support</span></span>
+<span class="terminal-line"><span class="info">#:schema https://json.schemastore.org/parsec.json</span></span>
+            </div>
+          </div>
+
+          <h3>Worktree build cache sharing — <code>[worktree].shared_cache</code></h3>
+          <p>
+            New worktrees can reuse <code>target/</code>, <code>node_modules/</code>, <code>.venv/</code>, etc. from the main repo via symlink (default) or recursive copy. Eliminates cold-build cost on <code>parsec start</code> for any project with significant dependency caches.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">[worktree] config</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="info">[worktree]</span></span>
+<span class="terminal-line"><span class="info">shared_cache = </span><span class="arg">["target", "node_modules", ".venv"]</span></span>
+<span class="terminal-line"><span class="comment"># "symlink" (default) — fast, zero-disk; parallel build of same artifact may race</span></span>
+<span class="terminal-line"><span class="comment"># "copy"             — independent caches per worktree, no race risk, more disk</span></span>
+<span class="terminal-line"><span class="info">cache_strategy = </span><span class="arg">"symlink"</span></span>
+            </div>
+          </div>
+
+          <h3>Draft-by-default — <code>ship.draft</code></h3>
+          <p>
+            Set <code>[ship].draft = true</code> in <code>config.toml</code> to open every PR as a draft, or pass <code>--draft</code> per ship. Useful for iterative WIP review flows where you want CI feedback before requesting human review.
+          </p>
         </section>
 
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1960,6 +1960,66 @@
           </p>
           <div class="feature-code">$ parsec diff --stat</div>
         </div>
+
+        <!-- Feature: Bitbucket Cloud (v0.4) -->
+        <div class="feature-card featured reveal reveal-delay-1">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+          </div>
+          <h3>Bitbucket Cloud + Pipelines</h3>
+          <p>
+            New in v0.4. Full PR lifecycle on Bitbucket Cloud — create, list, view, merge, comments — and Bitbucket Pipelines build status surfaced in <code>parsec ci</code> and <code>parsec pr-status</code> alongside GitHub Actions and GitLab CI.
+          </p>
+          <div class="feature-code">$ parsec ship CL-2208 &nbsp;&nbsp;<span style="color: var(--text-muted)"># auto-detects Bitbucket remote</span></div>
+        </div>
+
+        <!-- Feature: Compress (v0.4) -->
+        <div class="feature-card reveal reveal-delay-2">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/><line x1="14" y1="10" x2="21" y2="3"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
+          </div>
+          <h3>Compress Branch History</h3>
+          <p>
+            New in v0.4. <code>parsec compress</code> squashes a branch's commits into one tidy commit before shipping, preserving co-author trailers. Optional <code>--message</code> for a custom commit subject.
+          </p>
+          <div class="feature-code">$ parsec compress -m "feat: add user authentication"</div>
+        </div>
+
+        <!-- Feature: Offline (v0.4) -->
+        <div class="feature-card reveal reveal-delay-3">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><line x1="1" y1="1" x2="23" y2="23"/><path d="M16.72 11.06A10.94 10.94 0 0119 12.55"/><path d="M5 12.55a10.94 10.94 0 015.17-2.39"/><path d="M10.71 5.05A16 16 0 0122.58 9"/><path d="M1.42 9a15.91 15.91 0 014.7-2.88"/><path d="M8.53 16.11a6 6 0 016.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+          </div>
+          <h3>Offline Mode</h3>
+          <p>
+            New in v0.4. Global <code>--offline</code> flag (and <code>[workspace].offline</code> config) skips all network operations — tracker lookups, PR creation, fetches — so parsec keeps working on a plane, in CI without secrets, or in air-gapped environments.
+          </p>
+          <div class="feature-code">$ parsec start CL-2208 --offline --title "Add login retry"</div>
+        </div>
+
+        <!-- Feature: Observability JSONL (v0.4) -->
+        <div class="feature-card featured reveal reveal-delay-1">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          </div>
+          <h3>Observability — Execution IDs + JSONL</h3>
+          <p>
+            New in v0.4. Every command run gets an execution ID and per-step timing. <code>parsec log --export</code> emits JSONL — one line per run with <code>execution_id</code>, <code>op</code>, <code>ticket</code>, <code>steps</code>, and <code>duration_ms</code> — for tooling and AI agents to consume.
+          </p>
+          <div class="feature-code">$ parsec log --export | jq 'select(.duration_ms > 1000)'</div>
+        </div>
+
+        <!-- Feature: Config JSON Schema (v0.4) -->
+        <div class="feature-card reveal reveal-delay-2">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><polyline points="14 2 14 8 20 8"/><path d="M20 13v7a2 2 0 01-2 2H6a2 2 0 01-2-2V4a2 2 0 012-2h8z"/><line x1="9" y1="13" x2="15" y2="13"/><line x1="9" y1="17" x2="15" y2="17"/></svg>
+          </div>
+          <h3>Config JSON Schema</h3>
+          <p>
+            New in v0.4. The <code>config.toml</code> JSON Schema is published to <a href="https://schemastore.org">schemastore.org</a> so VS Code, IntelliJ, and Helix auto-complete and validate every key. <code>parsec config schema</code> emits the schema for offline use.
+          </p>
+          <div class="feature-code">$ parsec config schema > parsec-schema.json</div>
+        </div>
       </div>
     </div>
   </section>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -984,6 +984,7 @@
           <li><a href="#create">create</a></li>
           <li><a href="#new-issue">new-issue</a></li>
           <li><a href="#rename">rename</a></li>
+          <li><a href="#compress">compress</a></li>
           <li><a href="#release">release</a></li>
         </ul>
       </div>
@@ -1065,6 +1066,7 @@
             <div class="flag-chip"><code>-q</code> / <code>--quiet</code> <span class="flag-desc">suppress non-essential output</span></div>
             <div class="flag-chip"><code>--repo &lt;PATH&gt;</code> <span class="flag-desc">target repository path</span></div>
             <div class="flag-chip"><code>--dry-run</code> <span class="flag-desc">preview changes without executing</span></div>
+            <div class="flag-chip"><code>--offline</code> <span class="flag-desc">skip all network ops (tracker, PR, fetch)</span></div>
           </div>
         </div>
 
@@ -1914,6 +1916,7 @@
                 </thead>
                 <tbody>
                   <tr><td><code>--last &lt;N&gt;</code></td><td>Show only the last N operations.</td></tr>
+                  <tr><td><code>--export</code></td><td>Emit the log as JSONL (one JSON object per line). Each entry includes <code>execution_id</code> and per-step timing for observability/debugging by tooling and AI agents.</td></tr>
                 </tbody>
               </table>
             </div>
@@ -1930,6 +1933,11 @@
 <span class="terminal-line"><span class="info">  2024-01-15 09:05  </span><span class="success">start</span>   <span class="arg">PROJ-123</span><span class="info">  worktree created</span></span>
 <span class="terminal-line"><span class="info">  2024-01-14 17:44  </span><span class="success">start</span>   <span class="arg">PROJ-125</span><span class="info">  worktree created</span></span>
 <span class="terminal-line"><span class="info">  2024-01-14 16:30  </span><span class="success">clean</span>   <span class="info">  3 worktrees removed</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># JSONL export — one JSON object per line, with execution_id and per-step timing</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec log</span> <span class="flag">--export</span></span>
+<span class="terminal-line"><span class="info">{"execution_id":"01HQ3D8R2K8...","op":"start","ticket":"PROJ-123","steps":[{"name":"fetch_title","ms":214},{"name":"create_worktree","ms":98}],"duration_ms":312}</span></span>
+<span class="terminal-line"><span class="info">{"execution_id":"01HQ3D9V7Z2...","op":"ship","ticket":"PROJ-123","steps":[{"name":"push","ms":820},{"name":"create_pr","ms":1305},{"name":"cleanup","ms":42}],"duration_ms":2167}</span></span>
               </div>
             </div>
           </div>
@@ -2095,6 +2103,7 @@
                   <tr><td><code>show</code></td><td>Display current configuration (redacts sensitive tokens).</td></tr>
                   <tr><td><code>man</code></td><td>Open the parsec manual in your pager.</td></tr>
                   <tr><td><code>completions &lt;SHELL&gt;</code></td><td>Generate shell completion script for <code>zsh</code>, <code>bash</code>, or <code>fish</code>.</td></tr>
+                  <tr><td><code>schema</code></td><td>Output the JSON Schema for <code>config.toml</code>. The schema is also published to <a href="https://schemastore.org">schemastore.org</a> so editors auto-complete configuration files.</td></tr>
                   <tr><td><code>shell</code></td><td><em>Deprecated.</em> Use <code>parsec init &lt;SHELL&gt;</code> instead.</td></tr>
                 </tbody>
               </table>
@@ -2118,6 +2127,9 @@
 <span class="terminal-line">&nbsp;</span>
 <span class="terminal-line"><span class="comment"># Show current config</span></span>
 <span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config show</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Output the JSON Schema (also at https://json.schemastore.org/parsec.json)</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config schema</span> > parsec-schema.json</span>
               </div>
             </div>
           </div>
@@ -2323,6 +2335,62 @@
 <span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec rename</span> <span class="arg">OLD-99</span> <span class="arg">NEW-100</span> <span class="flag">--dry-run</span></span>
 <span class="terminal-line"><span class="info">Would rename branch feature/OLD-99-… → feature/NEW-100-…</span></span>
 <span class="terminal-line"><span class="info">Would update workspace directory and state file</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- compress -->
+          <div class="cmd-block reveal" id="compress">
+            <div class="cmd-heading">
+              <span class="cmd-name">compress</span>
+              <span class="cmd-short-desc">Squash all branch commits into one</span>
+              <a href="#compress" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Resets the branch to the merge-base with the base branch and re-commits all changes as a single commit. Co-author trailers from squashed commits are preserved. Useful before <code>parsec ship</code> to keep PR history tidy.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec compress</span> <span class="opt">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Argument</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>[TICKET]</code></td><td>Optional. Auto-detects the current worktree's ticket if omitted.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>-m, --message &lt;TEXT&gt;</code></td><td>Custom commit message. Default: combines all squashed commit messages.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec compress</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Compress current worktree's branch</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Compressed 7 commits into one on feature/PROJ-1234</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Compress with custom message</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span> <span class="arg">PROJ-1234</span> <span class="flag">-m</span> <span class="arg">"feat: add user authentication"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Combine with ship</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span> &amp;&amp; <span class="command">parsec ship</span></span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Version bump and full documentation pass for the v0.4 milestone, on top of the 16 already-merged feature/fix PRs.

## Changes
- **Cargo.toml**: `0.3.3` → `0.4.0` (the release workflow reads this string to tag and `cargo publish`).
- **CHANGELOG.md**: convert `[Unreleased]` → `[0.4.0] - 2026-05-04` with Added/Changed/Fixed/CI sections covering all 16 milestone commits.
- **README.md**: features list, command reference, global flags, configuration, environment variables, and the comparison table all refreshed to v0.4 surface area (Bitbucket as 1st-class forge, `parsec compress`, `parsec config schema`, `log --export`, `[worktree]`, `[observability]`, `--offline`, `PARSEC_OFFLINE`, Bitbucket env vars).
- **docs/index.html**: 5 new feature cards — Bitbucket Cloud + Pipelines, Compress, Offline Mode, Observability JSONL, Config Schema. `--offline` added to the global options banner.
- **docs/reference/index.html**: new `compress` command block, `--offline` in global options, `log --export` with JSONL example, `config schema` subcommand with schemastore reference.
- **docs/guide/index.html**: `tracker.type` includes `bitbucket`; new **What's New in v0.4** section with end-to-end examples for each new feature. Sidebar entry added.

## Why this matters
The release workflow on merge to `main` snapshots `docs/{index,guide,reference}.html` to `docs/v/0.4.0/` permanently — these updates ensure the snapshot is complete instead of frozen with v0.3 framing.

## Test plan
- [x] `cargo check` passes on `chore/release-0.4.0` with version 0.4.0
- [x] CHANGELOG entries cross-checked against the 16 commits between `main` and `develop`
- [x] All 5 missing v0.4 features documented in README + docs/reference (compress, schema, JSONL, offline, Bitbucket)
- [ ] PR CI green (Format / Clippy / Check / Test on linux-mac-windows / Build / Security Audit)
- [ ] Merge into `develop` → then open `develop → main` PR to fire release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)