### PR TITLE
docs: ship v0.4.0 versioned snapshot

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -31,6 +31,24 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://erishforg.github.io/git-parsec/v/0.4.0/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://erishforg.github.io/git-parsec/v/0.4.0/guide/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://erishforg.github.io/git-parsec/v/0.4.0/reference/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
     <loc>https://erishforg.github.io/git-parsec/v/0.3.3/</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>never</changefreq>

--- a/docs/v/0.4.0/guide/index.html
+++ b/docs/v/0.4.0/guide/index.html
@@ -1,0 +1,1987 @@
+<!DOCTYPE html>
+<html lang="en" data-doc-version="0.4.0">
+<head>
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex, follow">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Getting Started Guide — git-parsec | Install, configure, ship in 5 minutes</title>
+  <meta name="description" content="Install git-parsec in 30 seconds, configure Jira / GitHub / GitLab / Bitbucket in 2 minutes, and ship your first PR in 5. Step-by-step recipes for stacked PRs, offline mode, observability, and build cache sharing.">
+  <meta name="keywords" content="git-parsec, parsec, guide, getting started, installation, shell integration, Jira, GitHub Issues, GitLab, Bitbucket, stacked PRs, AI agents, offline mode, observability">
+  <meta name="author" content="erishforG">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://erishforg.github.io/git-parsec/guide/">
+  <meta property="og:title" content="Getting Started Guide — git-parsec">
+  <meta property="og:description" content="Install, configure, and ship your first PR with git-parsec. Recipes for stacked PRs, Bitbucket, offline mode, observability, and build cache.">
+  <meta property="og:site_name" content="git-parsec">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://erishforg.github.io/git-parsec/demo.gif">
+  <meta property="og:image:alt" content="git-parsec terminal demo">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Getting Started Guide — git-parsec">
+  <meta name="twitter:description" content="Install, configure, and ship your first PR with git-parsec.">
+  <meta name="twitter:image" content="https://erishforg.github.io/git-parsec/demo.gif">
+  <meta name="theme-color" content="#0a0e1a">
+  <link rel="canonical" href="https://erishforg.github.io/git-parsec/guide/">
+  <link rel="alternate" type="text/plain" href="/git-parsec/llms.txt" title="LLM-friendly summary">
+  <link rel="alternate" type="text/plain" href="/git-parsec/llms-full.txt" title="LLM-friendly full text">
+  <!-- Schema.org Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": "Getting Started with git-parsec",
+    "description": "Install git-parsec, configure your tracker (Jira / GitHub Issues / GitLab / Bitbucket), and ship your first PR in five minutes. Includes recipes for stacked PRs, Bitbucket Cloud setup, offline mode, observability JSONL, config schema autocomplete, and worktree build cache.",
+    "url": "https://erishforg.github.io/git-parsec/guide/",
+    "image": "https://erishforg.github.io/git-parsec/demo.gif",
+    "author": { "@type": "Person", "name": "erishforG", "url": "https://github.com/erishforG" },
+    "publisher": { "@type": "Person", "name": "erishforG" },
+    "datePublished": "2026-04-22",
+    "dateModified": "2026-05-04",
+    "inLanguage": "en",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "git-parsec",
+      "url": "https://erishforg.github.io/git-parsec/"
+    },
+    "about": {
+      "@type": "SoftwareApplication",
+      "name": "git-parsec",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "macOS, Linux, Windows"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://erishforg.github.io/git-parsec/" },
+      { "@type": "ListItem", "position": 2, "name": "Guide", "item": "https://erishforg.github.io/git-parsec/guide/" }
+    ]
+  }
+  </script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@400;500;600;700;800;900&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    /* ================================================
+       RESET & BASE
+       ================================================ */
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg-deep: #060a14;
+      --bg-base: #0a0e1a;
+      --bg-raised: #0f1424;
+      --bg-card: #111828;
+      --bg-card-hover: #151d30;
+
+      --accent-cyan: #4FC3F7;
+      --accent-blue: #2196F3;
+      --accent-teal: #26C6DA;
+      --accent-electric: #40E0D0;
+      --accent-purple: #7C4DFF;
+      --accent-glow: rgba(79, 195, 247, 0.15);
+      --accent-glow-strong: rgba(79, 195, 247, 0.3);
+
+      --text-primary: #e8edf5;
+      --text-secondary: #8892a4;
+      --text-muted: #5a6577;
+      --text-code: #b4c7e7;
+
+      --border-subtle: rgba(79, 195, 247, 0.08);
+      --border-accent: rgba(79, 195, 247, 0.2);
+
+      --radius-sm: 6px;
+      --radius-md: 12px;
+      --radius-lg: 20px;
+      --radius-xl: 28px;
+
+      --font-display: 'Outfit', sans-serif;
+      --font-body: 'Source Sans 3', sans-serif;
+      --font-mono: 'JetBrains Mono', monospace;
+
+      --sidebar-width: 260px;
+      --nav-height: 65px;
+    }
+
+    html {
+      scroll-behavior: smooth;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    body {
+      font-family: var(--font-body);
+      background: var(--bg-deep);
+      color: var(--text-primary);
+      line-height: 1.6;
+      overflow-x: hidden;
+    }
+
+    /* ================================================
+       STARFIELD BACKGROUND
+       ================================================ */
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background:
+        radial-gradient(1.5px 1.5px at 20% 30%, rgba(79, 195, 247, 0.4) 50%, transparent 50%),
+        radial-gradient(1px 1px at 40% 70%, rgba(255, 255, 255, 0.3) 50%, transparent 50%),
+        radial-gradient(1.2px 1.2px at 60% 20%, rgba(38, 198, 218, 0.35) 50%, transparent 50%),
+        radial-gradient(1px 1px at 80% 50%, rgba(255, 255, 255, 0.25) 50%, transparent 50%),
+        radial-gradient(1.3px 1.3px at 10% 80%, rgba(79, 195, 247, 0.3) 50%, transparent 50%),
+        radial-gradient(0.8px 0.8px at 70% 85%, rgba(255, 255, 255, 0.2) 50%, transparent 50%),
+        radial-gradient(1px 1px at 90% 15%, rgba(64, 224, 208, 0.3) 50%, transparent 50%),
+        radial-gradient(1.1px 1.1px at 35% 45%, rgba(255, 255, 255, 0.15) 50%, transparent 50%),
+        radial-gradient(0.9px 0.9px at 55% 65%, rgba(79, 195, 247, 0.2) 50%, transparent 50%),
+        radial-gradient(1px 1px at 85% 35%, rgba(255, 255, 255, 0.2) 50%, transparent 50%),
+        radial-gradient(1.4px 1.4px at 15% 55%, rgba(38, 198, 218, 0.25) 50%, transparent 50%),
+        radial-gradient(0.7px 0.7px at 45% 90%, rgba(255, 255, 255, 0.15) 50%, transparent 50%),
+        radial-gradient(1px 1px at 75% 10%, rgba(79, 195, 247, 0.25) 50%, transparent 50%),
+        radial-gradient(0.9px 0.9px at 25% 75%, rgba(255, 255, 255, 0.18) 50%, transparent 50%),
+        radial-gradient(1.2px 1.2px at 95% 60%, rgba(64, 224, 208, 0.2) 50%, transparent 50%),
+        radial-gradient(0.8px 0.8px at 5% 40%, rgba(255, 255, 255, 0.12) 50%, transparent 50%),
+        radial-gradient(1px 1px at 50% 5%, rgba(79, 195, 247, 0.3) 50%, transparent 50%),
+        radial-gradient(1.1px 1.1px at 65% 50%, rgba(255, 255, 255, 0.1) 50%, transparent 50%);
+      pointer-events: none;
+      z-index: 0;
+      animation: starDrift 120s linear infinite;
+    }
+
+    @keyframes starDrift {
+      0% { transform: translateY(0); }
+      100% { transform: translateY(-30px); }
+    }
+
+    /* ================================================
+       NAV
+       ================================================ */
+    nav {
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      z-index: 100;
+      padding: 16px 0;
+      background: rgba(6, 10, 20, 0.85);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border-subtle);
+      height: var(--nav-height);
+    }
+
+    .nav-inner {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 0 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      text-decoration: none;
+      color: var(--text-primary);
+    }
+
+    .nav-brand-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      background: linear-gradient(135deg, var(--accent-cyan), var(--accent-teal));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+      font-weight: 700;
+      color: var(--bg-deep);
+      font-family: var(--font-mono);
+    }
+
+    .nav-brand span {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 18px;
+      letter-spacing: -0.02em;
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 32px;
+      list-style: none;
+    }
+
+    .nav-links a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    .nav-links a:hover { color: var(--accent-cyan); }
+    .nav-links a.active { color: var(--accent-cyan); }
+
+    .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 20px;
+      background: transparent;
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-sm);
+      color: var(--accent-cyan);
+      text-decoration: none;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all 0.25s;
+    }
+
+    .nav-cta:hover {
+      background: var(--accent-glow);
+      border-color: var(--accent-cyan);
+      box-shadow: 0 0 20px rgba(79, 195, 247, 0.15);
+    }
+
+    .nav-cta svg { width: 16px; height: 16px; }
+
+    /* ================================================
+       DOCS LAYOUT
+       ================================================ */
+    .docs-layout {
+      display: flex;
+      min-height: 100vh;
+      padding-top: var(--nav-height);
+      position: relative;
+      z-index: 1;
+    }
+
+    /* ================================================
+       SIDEBAR
+       ================================================ */
+    .sidebar {
+      width: var(--sidebar-width);
+      flex-shrink: 0;
+      position: fixed;
+      top: var(--nav-height);
+      left: 0;
+      bottom: 0;
+      overflow-y: auto;
+      background: var(--bg-card);
+      border-right: 1px solid var(--border-subtle);
+      padding: 32px 0 48px;
+      z-index: 10;
+    }
+
+    .sidebar::-webkit-scrollbar { width: 4px; }
+    .sidebar::-webkit-scrollbar-track { background: transparent; }
+    .sidebar::-webkit-scrollbar-thumb { background: var(--bg-raised); border-radius: 2px; }
+
+    .sidebar-header {
+      padding: 0 20px 20px;
+      border-bottom: 1px solid var(--border-subtle);
+      margin-bottom: 16px;
+    }
+
+    .sidebar-title {
+      font-family: var(--font-display);
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-muted);
+    }
+
+    .sidebar-section { margin-bottom: 8px; }
+
+    .sidebar-category {
+      padding: 8px 20px 6px;
+      font-family: var(--font-mono);
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-muted);
+      margin-top: 16px;
+    }
+
+    .sidebar-nav { list-style: none; }
+
+    .sidebar-nav li a {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 7px 20px;
+      font-family: var(--font-body);
+      font-size: 14px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      transition: all 0.15s;
+      border-left: 2px solid transparent;
+    }
+
+    .sidebar-nav li a:hover {
+      color: var(--text-primary);
+      background: rgba(79, 195, 247, 0.04);
+      border-left-color: var(--border-accent);
+    }
+
+    .sidebar-nav li a.active {
+      color: var(--accent-cyan);
+      background: var(--accent-glow);
+      border-left-color: var(--accent-cyan);
+    }
+
+    /* Also link to reference page */
+    .sidebar-also {
+      margin-top: 32px;
+      padding: 16px 20px;
+      border-top: 1px solid var(--border-subtle);
+    }
+
+    .sidebar-also-label {
+      font-size: 11px;
+      font-family: var(--font-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-muted);
+      margin-bottom: 10px;
+    }
+
+    .sidebar-also a {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      color: var(--accent-cyan);
+      text-decoration: none;
+      transition: opacity 0.2s;
+    }
+
+    .sidebar-also a:hover { opacity: 0.8; }
+
+    /* ================================================
+       MAIN CONTENT
+       ================================================ */
+    .docs-main {
+      flex: 1;
+      margin-left: var(--sidebar-width);
+      min-width: 0;
+    }
+
+    .docs-content {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 56px 48px 120px;
+    }
+
+    /* Page header */
+    .page-header {
+      margin-bottom: 64px;
+      padding-bottom: 40px;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .page-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent-cyan);
+      margin-bottom: 16px;
+    }
+
+    .page-label::before {
+      content: '';
+      width: 20px;
+      height: 1px;
+      background: var(--accent-cyan);
+    }
+
+    .page-title {
+      font-family: var(--font-display);
+      font-size: clamp(32px, 4vw, 48px);
+      font-weight: 800;
+      line-height: 1.1;
+      letter-spacing: -0.03em;
+      margin-bottom: 16px;
+    }
+
+    .page-title .gradient-text {
+      background: linear-gradient(135deg, var(--accent-cyan) 0%, var(--accent-teal) 40%, var(--accent-electric) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .page-desc {
+      font-size: 17px;
+      color: var(--text-secondary);
+      line-height: 1.7;
+      max-width: 600px;
+    }
+
+    /* ================================================
+       GUIDE SECTIONS
+       ================================================ */
+    .guide-section {
+      margin-bottom: 80px;
+      scroll-margin-top: calc(var(--nav-height) + 24px);
+    }
+
+    .section-heading {
+      display: flex;
+      align-items: baseline;
+      gap: 16px;
+      margin-bottom: 20px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .section-heading h2 {
+      font-family: var(--font-display);
+      font-size: 26px;
+      font-weight: 800;
+      letter-spacing: -0.025em;
+      color: var(--text-primary);
+    }
+
+    .section-anchor {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 18px;
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+
+    .section-heading:hover .section-anchor { opacity: 1; }
+
+    .guide-section p {
+      font-size: 16px;
+      color: var(--text-secondary);
+      line-height: 1.75;
+      margin-bottom: 20px;
+    }
+
+    .guide-section h3 {
+      font-family: var(--font-display);
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--text-primary);
+      margin: 32px 0 12px;
+      letter-spacing: -0.01em;
+    }
+
+    /* inline code */
+    code {
+      font-family: var(--font-mono);
+      font-size: 0.88em;
+      color: var(--text-code);
+      background: rgba(79, 195, 247, 0.07);
+      border: 1px solid rgba(79, 195, 247, 0.12);
+      border-radius: 4px;
+      padding: 1px 6px;
+    }
+
+    /* Terminal blocks */
+    .terminal-wrap {
+      margin: 20px 0;
+      background: var(--bg-base);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow:
+        0 4px 6px rgba(0, 0, 0, 0.3),
+        0 12px 32px rgba(0, 0, 0, 0.35),
+        0 0 0 1px rgba(79, 195, 247, 0.04);
+    }
+
+    .terminal-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 16px;
+      background: var(--bg-raised);
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .terminal-dot {
+      width: 11px;
+      height: 11px;
+      border-radius: 50%;
+    }
+
+    .terminal-dot:nth-child(1) { background: #ff5f57; }
+    .terminal-dot:nth-child(2) { background: #febc2e; }
+    .terminal-dot:nth-child(3) { background: #28c840; }
+
+    .terminal-title-label {
+      flex: 1;
+      text-align: center;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-right: 30px;
+    }
+
+    .terminal-body {
+      padding: 20px 24px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.8;
+      overflow-x: auto;
+    }
+
+    .terminal-body .comment { color: var(--text-muted); }
+    .terminal-body .prompt { color: var(--accent-cyan); }
+    .terminal-body .command { color: var(--text-primary); }
+    .terminal-body .flag { color: var(--accent-purple); }
+    .terminal-body .success { color: #28c840; }
+    .terminal-body .info { color: var(--text-secondary); }
+    .terminal-body .link { color: var(--accent-teal); }
+    .terminal-body .arg { color: #ffb74d; }
+    .terminal-body .output { color: var(--text-secondary); }
+
+    .terminal-line {
+      display: block;
+      white-space: pre;
+    }
+
+    /* Callout boxes */
+    .callout {
+      display: flex;
+      gap: 16px;
+      padding: 20px 24px;
+      border-radius: var(--radius-md);
+      margin: 24px 0;
+    }
+
+    .callout-info {
+      background: var(--accent-glow);
+      border: 1px solid var(--border-accent);
+    }
+
+    .callout-warn {
+      background: rgba(255, 183, 77, 0.06);
+      border: 1px solid rgba(255, 183, 77, 0.2);
+    }
+
+    .callout-tip {
+      background: rgba(40, 200, 64, 0.05);
+      border: 1px solid rgba(40, 200, 64, 0.2);
+    }
+
+    .callout-icon {
+      font-size: 18px;
+      flex-shrink: 0;
+      line-height: 1.5;
+    }
+
+    .callout-body {
+      flex: 1;
+    }
+
+    .callout-title {
+      font-family: var(--font-display);
+      font-size: 14px;
+      font-weight: 700;
+      margin-bottom: 6px;
+    }
+
+    .callout-info .callout-title { color: var(--accent-cyan); }
+    .callout-warn .callout-title { color: #ffb74d; }
+    .callout-tip .callout-title { color: #28c840; }
+
+    .callout p {
+      font-size: 14px;
+      color: var(--text-secondary);
+      margin-bottom: 0;
+    }
+
+    /* Step list */
+    .step-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+      margin: 24px 0;
+    }
+
+    .step-item {
+      display: flex;
+      gap: 20px;
+      align-items: flex-start;
+    }
+
+    .step-num {
+      flex-shrink: 0;
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: var(--accent-glow);
+      border: 1px solid var(--border-accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--accent-cyan);
+      margin-top: 2px;
+    }
+
+    .step-content h4 {
+      font-family: var(--font-display);
+      font-size: 16px;
+      font-weight: 700;
+      color: var(--text-primary);
+      margin-bottom: 6px;
+    }
+
+    .step-content p {
+      font-size: 14px;
+      color: var(--text-secondary);
+      margin-bottom: 0;
+    }
+
+    /* Config table */
+    .config-table-wrap {
+      margin: 20px 0;
+      overflow-x: auto;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--border-subtle);
+    }
+
+    .config-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+
+    .config-table thead th {
+      padding: 12px 16px;
+      text-align: left;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      background: var(--bg-raised);
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .config-table tbody td {
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border-subtle);
+      vertical-align: top;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .config-table tbody tr:last-child td { border-bottom: none; }
+    .config-table tbody tr:hover td { background: rgba(79, 195, 247, 0.02); }
+
+    .config-table td:first-child {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--text-code);
+      white-space: nowrap;
+    }
+
+    /* Tracker cards */
+    .tracker-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 16px;
+      margin: 24px 0;
+    }
+
+    .tracker-card {
+      padding: 24px;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      transition: border-color 0.3s, box-shadow 0.3s;
+    }
+
+    .tracker-card:hover {
+      border-color: var(--border-accent);
+      box-shadow: 0 0 20px rgba(79, 195, 247, 0.06);
+    }
+
+    .tracker-card h4 {
+      font-family: var(--font-display);
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--text-primary);
+      margin-bottom: 8px;
+    }
+
+    .tracker-card p {
+      font-size: 13px;
+      color: var(--text-secondary);
+      line-height: 1.6;
+      margin-bottom: 12px;
+    }
+
+    .tracker-card .tracker-type {
+      display: inline-block;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      padding: 3px 8px;
+      background: var(--accent-glow);
+      border: 1px solid var(--border-accent);
+      border-radius: 100px;
+      color: var(--accent-cyan);
+    }
+
+    /* Workflow flow diagram */
+    .workflow-flow {
+      display: flex;
+      align-items: center;
+      gap: 0;
+      margin: 28px 0;
+      overflow-x: auto;
+      padding: 4px 0;
+    }
+
+    .flow-step {
+      flex-shrink: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .flow-box {
+      padding: 12px 18px;
+      background: var(--bg-card);
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-md);
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--accent-cyan);
+      white-space: nowrap;
+    }
+
+    .flow-label {
+      font-size: 11px;
+      color: var(--text-muted);
+      text-align: center;
+    }
+
+    .flow-arrow {
+      flex-shrink: 0;
+      color: var(--text-muted);
+      font-size: 18px;
+      margin: 0 4px;
+      padding-bottom: 20px;
+    }
+
+    /* Agent card grid */
+    .agent-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+      margin: 24px 0;
+    }
+
+    .agent-card {
+      padding: 24px;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      transition: border-color 0.3s;
+    }
+
+    .agent-card:hover { border-color: var(--border-accent); }
+
+    .agent-card-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+
+    .agent-card-icon {
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      background: var(--accent-glow);
+      border: 1px solid var(--border-accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+    }
+
+    .agent-card h4 {
+      font-family: var(--font-display);
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+
+    .agent-card p {
+      font-size: 13px;
+      color: var(--text-secondary);
+      line-height: 1.6;
+      margin-bottom: 0;
+    }
+
+    /* Stacked PR diagram */
+    .stack-diagram {
+      background: var(--bg-raised);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      padding: 24px;
+      margin: 20px 0;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 2;
+    }
+
+    .stack-diagram .branch-main { color: var(--accent-teal); }
+    .stack-diagram .branch-feat { color: var(--accent-cyan); }
+    .stack-diagram .branch-pr { color: #28c840; }
+    .stack-diagram .branch-arrow { color: var(--text-muted); }
+
+    /* ================================================
+       FOOTER
+       ================================================ */
+    .docs-footer {
+      position: relative;
+      z-index: 1;
+      padding: 32px 0;
+      border-top: 1px solid var(--border-subtle);
+      margin-left: var(--sidebar-width);
+    }
+
+    .footer-inner {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 0 48px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .footer-left {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+    }
+
+    .footer-brand {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 15px;
+      color: var(--text-secondary);
+    }
+
+    .footer-links {
+      display: flex;
+      gap: 20px;
+      list-style: none;
+    }
+
+    .footer-links a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 13px;
+      transition: color 0.2s;
+    }
+
+    .footer-links a:hover { color: var(--accent-cyan); }
+
+    .footer-right {
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    /* ================================================
+       RESPONSIVE
+       ================================================ */
+    @media (max-width: 900px) {
+      :root { --sidebar-width: 0px; }
+
+      .sidebar {
+        position: static;
+        width: 100%;
+        height: auto;
+        border-right: none;
+        border-bottom: 1px solid var(--border-subtle);
+        overflow-x: auto;
+        overflow-y: hidden;
+        white-space: nowrap;
+        padding: 12px 0;
+        display: flex;
+        flex-direction: row;
+      }
+
+      .sidebar-header { display: none; }
+      .sidebar-section { display: inline-flex; flex-direction: row; margin-bottom: 0; }
+      .sidebar-category { display: none; }
+      .sidebar-nav { display: inline-flex; flex-direction: row; }
+      .sidebar-also { display: none; }
+
+      .sidebar-nav li a {
+        border-left: none;
+        border-bottom: 2px solid transparent;
+        padding: 8px 14px;
+        white-space: nowrap;
+        font-size: 12px;
+      }
+
+      .sidebar-nav li a.active {
+        border-left: none;
+        border-bottom-color: var(--accent-cyan);
+      }
+
+      .docs-layout { flex-direction: column; }
+      .docs-main { margin-left: 0; }
+      .docs-content { padding: 32px 20px 80px; }
+      .docs-footer { margin-left: 0; }
+
+      .footer-inner {
+        padding: 0 20px;
+        flex-direction: column;
+        gap: 16px;
+        text-align: center;
+      }
+
+      .footer-left { flex-direction: column; gap: 12px; }
+      .tracker-grid { grid-template-columns: 1fr; }
+      .agent-grid { grid-template-columns: 1fr; }
+      .workflow-flow { gap: 0; }
+    }
+
+    @media (max-width: 480px) {
+      .nav-links { display: none; }
+      .terminal-body { font-size: 11px; padding: 14px 16px; }
+    }
+
+    /* ================================================
+       SCROLLBAR
+       ================================================ */
+    ::-webkit-scrollbar { width: 8px; height: 8px; }
+    ::-webkit-scrollbar-track { background: var(--bg-deep); }
+    ::-webkit-scrollbar-thumb { background: var(--bg-card); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--bg-card-hover); }
+
+    ::selection {
+      background: rgba(79, 195, 247, 0.25);
+      color: var(--text-primary);
+    }
+
+    /* Reveal */
+    .reveal {
+      opacity: 0;
+      transform: translateY(16px);
+      transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+    }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+
+    /* ================================================
+       VERSION SWITCHER
+       ================================================ */
+    .version-switcher {
+      position: relative;
+      margin-left: 12px;
+    }
+    .version-btn {
+      background: var(--bg-raised);
+      color: var(--accent-cyan);
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-sm);
+      padding: 4px 10px;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: background 0.2s;
+      display: flex;
+      align-items: center;
+      gap: 2px;
+    }
+    .version-btn:hover { background: var(--bg-card); }
+    .version-arrow { font-size: 0.7rem; }
+    .version-dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 6px);
+      left: 0;
+      background: var(--bg-raised);
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-sm);
+      min-width: 160px;
+      z-index: 1000;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    }
+    .version-dropdown.open { display: block; }
+    .version-dropdown a {
+      display: block;
+      padding: 8px 14px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      transition: background 0.15s, color 0.15s;
+    }
+    .version-dropdown a:hover {
+      background: var(--bg-card);
+      color: var(--text-primary);
+    }
+    .version-dropdown a.active {
+      color: var(--accent-cyan);
+      background: var(--accent-glow);
+    }
+    .version-banner {
+      background: rgba(255, 193, 7, 0.12);
+      border-bottom: 1px solid rgba(255, 193, 7, 0.3);
+      color: #ffd54f;
+      text-align: center;
+      padding: 8px 16px;
+      font-family: var(--font-body);
+      font-size: 0.9rem;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 10000;
+    }
+    .version-banner a {
+      color: #fff;
+      text-decoration: underline;
+      margin-left: 4px;
+    }
+    .version-banner a:hover { color: var(--accent-cyan); }
+  </style>
+</head>
+<body>
+
+  <!-- ============ NAV ============ -->
+  <nav>
+    <div class="nav-inner">
+      <a href="/git-parsec/v/0.4.0/" class="nav-brand">
+        <div class="nav-brand-icon">P</div>
+        <span>git-parsec</span>
+      </a>
+      <ul class="nav-links">
+        <li><a href="/git-parsec/v/0.4.0/#features">Features</a></li>
+        <li><a href="/git-parsec/v/0.4.0/#comparison">Compare</a></li>
+        <li><a href="/git-parsec/v/0.4.0/#quickstart">Quick Start</a></li>
+        <li><a href="/git-parsec/v/0.4.0/reference/" class="active">Docs</a></li>
+        <li><a href="/git-parsec/v/0.4.0/#install">Install</a></li>
+      </ul>
+      <a href="https://github.com/erishforG/git-parsec" class="nav-cta" target="_blank" rel="noopener">
+        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        GitHub
+      </a>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+
+    <!-- ============ SIDEBAR ============ -->
+    <aside class="sidebar" id="sidebar">
+      <div class="sidebar-header">
+        <div class="sidebar-title">Guide</div>
+      </div>
+
+      <div class="sidebar-section">
+        <ul class="sidebar-nav">
+          <li><a href="#installation">Installation</a></li>
+          <li><a href="#shell-integration">Shell Integration</a></li>
+          <li><a href="#quick-start">Quick Start Workflow</a></li>
+          <li><a href="#tracker-config">Tracker Configuration</a></li>
+          <li><a href="#ai-agents">AI Agent Workflows</a></li>
+          <li><a href="#stacked-prs">Stacked PRs</a></li>
+          <li><a href="#new-features">New Features</a></li>
+          <li><a href="#recipes">Recipes &amp; Examples</a></li>
+        </ul>
+      </div>
+
+      <div class="sidebar-also">
+        <div class="sidebar-also-label">Also see</div>
+        <a href="/git-parsec/v/0.4.0/reference/">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+          Command Reference
+        </a>
+      </div>
+    </aside>
+
+    <!-- ============ MAIN CONTENT ============ -->
+    <main class="docs-main">
+      <div class="docs-content">
+
+        <!-- Page Header -->
+        <div class="page-header reveal">
+          <div class="page-label">Documentation</div>
+          <h1 class="page-title">Getting <span class="gradient-text">Started</span></h1>
+          <p class="page-desc">
+            Everything you need to go from zero to shipping PRs with parsec. Installation, configuration, and key workflows explained.
+          </p>
+        </div>
+
+        <!-- ==============================
+             INSTALLATION
+             ============================== -->
+        <section class="guide-section reveal" id="installation">
+          <div class="section-heading">
+            <h2>Installation</h2>
+            <a href="#installation" class="section-anchor">#</a>
+          </div>
+
+          <p>
+            parsec is a single Rust binary with no runtime dependencies. Install via <code>cargo</code>, or build from source.
+          </p>
+
+          <h3>Via cargo (recommended)</h3>
+          <p>
+            The fastest path. Requires <a href="https://rustup.rs" style="color: var(--accent-cyan);">Rust and cargo</a> to be installed.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">install via cargo</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">cargo install</span> <span class="arg">git-parsec</span></span>
+<span class="terminal-line"><span class="info">  Compiling git-parsec v0.2.4</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Installed ~/.cargo/bin/parsec</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Verify installation</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec</span> <span class="flag">--version</span></span>
+<span class="terminal-line"><span class="info">  parsec 0.3.3</span></span>
+            </div>
+          </div>
+
+          <h3>Build from source</h3>
+          <p>
+            Clone the repository and build with <code>cargo build --release</code>. The compiled binary is at <code>./target/release/parsec</code>.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">build from source</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">git clone</span> <span class="link">https://github.com/erishforG/git-parsec.git</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">cd</span> <span class="arg">git-parsec</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">cargo build</span> <span class="flag">--release</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Binary at ./target/release/parsec</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Move to a directory on your $PATH</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">cp</span> <span class="arg">./target/release/parsec</span> <span class="arg">/usr/local/bin/</span></span>
+            </div>
+          </div>
+
+          <h3>Shell completions</h3>
+          <p>
+            Generate tab completions for your shell. Completions cover all commands and flags.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">shell completions</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># zsh — add to fpath</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config completions</span> <span class="arg">zsh</span> > ~/.zsh/completions/_parsec</span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># bash</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config completions</span> <span class="arg">bash</span> > ~/.local/share/bash-completion/completions/parsec</span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># fish</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config completions</span> <span class="arg">fish</span> > ~/.config/fish/completions/parsec.fish</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- ==============================
+             SHELL INTEGRATION
+             ============================== -->
+        <section class="guide-section reveal" id="shell-integration">
+          <div class="section-heading">
+            <h2>Shell Integration</h2>
+            <a href="#shell-integration" class="section-anchor">#</a>
+          </div>
+
+          <p>
+            Shell integration is the single most impactful quality-of-life improvement parsec offers. It hooks into your shell to enable seamless directory switching and automatic working-directory recovery.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">enable shell integration</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Add to ~/.zshrc (or ~/.bashrc for bash)</span></span>
+<span class="terminal-line"><span class="command">eval</span> "$(<span class="command">parsec init</span> <span class="arg">zsh</span>)"</span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Reload your shell</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">source</span> <span class="arg">~/.zshrc</span></span>
+            </div>
+          </div>
+
+          <h3>What shell integration does</h3>
+
+          <ol class="step-list">
+            <li class="step-item">
+              <div class="step-num">1</div>
+              <div class="step-content">
+                <h4>Auto-cd on switch</h4>
+                <p>When you run <code>parsec switch TICKET</code>, your shell automatically changes directory into the worktree. Without integration, parsec can only print the path — your shell script would need to call <code>cd $(parsec switch TICKET)</code> manually.</p>
+              </div>
+            </li>
+            <li class="step-item">
+              <div class="step-num">2</div>
+              <div class="step-content">
+                <h4>CWD recovery after merge/clean</h4>
+                <p>When parsec removes a worktree you're currently inside (e.g. after <code>parsec merge</code>), your shell would normally be stranded in a deleted directory. Shell integration detects this and automatically moves you back to the main repository root.</p>
+              </div>
+            </li>
+          </ol>
+
+          <div class="callout callout-tip">
+            <div class="callout-icon">&#10003;</div>
+            <div class="callout-body">
+              <div class="callout-title">Recommended for all users</div>
+              <p>Shell integration has no downsides and makes the switch/merge workflow significantly smoother. Add the <code>eval</code> line to your rc file during first-time setup.</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ==============================
+             QUICK START WORKFLOW
+             ============================== -->
+        <section class="guide-section reveal" id="quick-start">
+          <div class="section-heading">
+            <h2>Quick Start Workflow</h2>
+            <a href="#quick-start" class="section-anchor">#</a>
+          </div>
+
+          <p>
+            The core parsec lifecycle follows a simple loop: <strong>start &rarr; code &rarr; ship &rarr; merge &rarr; clean</strong>. Each step is one command.
+          </p>
+
+          <div class="workflow-flow">
+            <div class="flow-step">
+              <div class="flow-box">start</div>
+              <div class="flow-label">create workspace</div>
+            </div>
+            <div class="flow-arrow">&#8594;</div>
+            <div class="flow-step">
+              <div class="flow-box">code</div>
+              <div class="flow-label">work &amp; commit</div>
+            </div>
+            <div class="flow-arrow">&#8594;</div>
+            <div class="flow-step">
+              <div class="flow-box">ship</div>
+              <div class="flow-label">push + open PR</div>
+            </div>
+            <div class="flow-arrow">&#8594;</div>
+            <div class="flow-step">
+              <div class="flow-box">merge</div>
+              <div class="flow-label">merge PR</div>
+            </div>
+            <div class="flow-arrow">&#8594;</div>
+            <div class="flow-step">
+              <div class="flow-box">clean</div>
+              <div class="flow-label">remove worktrees</div>
+            </div>
+          </div>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">full lifecycle demo</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># 1. Create an isolated workspace from a Jira ticket</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created worktree for PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  Branch: </span><span class="link">feature/PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  Path:   ../myrepo.PROJ-123</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># 2. Switch into the worktree (auto-cd with shell integration)</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec switch</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="comment"># shell: → cd ../myrepo.PROJ-123</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># 3. Do your work, commit as usual</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">git add</span> <span class="arg">.</span> <span class="command">&amp;&amp; git commit</span> <span class="arg">-m "feat: auth flow"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># 4. Check for conflicts with parallel work</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec conflicts</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">No conflicts across 3 worktrees</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># 5. Ship: push + open PR + clean worktree</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Pushed feature/PROJ-123 (3 commits)</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR #42 created: </span><span class="link">github.com/org/myrepo/pull/42</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Worktree cleaned up</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># 6. After review — merge and clean up remote branch</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec merge</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR #42 merged into main</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># 7. Tidy up any remaining worktrees</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec clean</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Removed 1 merged worktree</span></span>
+            </div>
+          </div>
+
+          <div class="callout callout-info">
+            <div class="callout-icon">&#9432;</div>
+            <div class="callout-body">
+              <div class="callout-title">First-time setup</div>
+              <p>Before running <code>parsec start</code> for the first time, run <code>parsec config init</code> to configure your issue tracker and GitHub token. See <a href="#tracker-config" style="color: var(--accent-cyan);">Tracker Configuration</a> below.</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ==============================
+             TRACKER CONFIGURATION
+             ============================== -->
+        <section class="guide-section reveal" id="tracker-config">
+          <div class="section-heading">
+            <h2>Tracker Configuration</h2>
+            <a href="#tracker-config" class="section-anchor">#</a>
+          </div>
+
+          <p>
+            parsec integrates with three issue trackers. Run <code>parsec config init</code> for an interactive setup wizard, or edit <code>~/.config/parsec/config.toml</code> directly.
+          </p>
+
+          <div class="tracker-grid">
+            <div class="tracker-card">
+              <h4>Jira</h4>
+              <p>Connect to Jira Cloud or Jira Server. parsec fetches ticket titles, statuses, and assignees automatically.</p>
+              <span class="tracker-type">Cloud &amp; Server</span>
+            </div>
+            <div class="tracker-card">
+              <h4>GitHub Issues</h4>
+              <p>Works out of the box when your remote is GitHub. Uses the same token as your GitHub API access.</p>
+              <span class="tracker-type">github.com</span>
+            </div>
+            <div class="tracker-card">
+              <h4>GitLab</h4>
+              <p>Connects to GitLab.com or self-hosted GitLab instances via personal access token.</p>
+              <span class="tracker-type">Cloud &amp; Self-hosted</span>
+            </div>
+          </div>
+
+          <h3>Jira setup</h3>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parsec config init — Jira</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config init</span></span>
+<span class="terminal-line"><span class="info">  ? Tracker type:      </span><span class="arg">jira</span></span>
+<span class="terminal-line"><span class="info">  ? Jira base URL:     </span><span class="arg">https://myorg.atlassian.net</span></span>
+<span class="terminal-line"><span class="info">  ? Jira email:        </span><span class="arg">you@company.com</span></span>
+<span class="terminal-line"><span class="info">  ? Jira API token:    </span><span class="arg">***</span></span>
+<span class="terminal-line"><span class="info">  ? GitHub token:      </span><span class="arg">ghp_***</span></span>
+<span class="terminal-line"><span class="info">  ? Default branch:    </span><span class="arg">main</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Config saved to ~/.config/parsec/config.toml</span></span>
+            </div>
+          </div>
+
+          <div class="callout callout-info">
+            <div class="callout-icon">&#9432;</div>
+            <div class="callout-body">
+              <div class="callout-title">Jira API token</div>
+              <p>Generate a Jira API token at <a href="https://id.atlassian.com/manage-profile/security/api-tokens" style="color: var(--accent-cyan);">id.atlassian.com/manage-profile/security/api-tokens</a>. parsec uses it for read-only ticket lookups; it never writes to Jira.</p>
+            </div>
+          </div>
+
+          <h3>GitHub Issues setup</h3>
+          <p>
+            When your repo remote is GitHub, parsec automatically uses GitHub Issues as the tracker. Provide a personal access token with <code>repo</code> scope.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parsec config init — GitHub Issues</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config init</span></span>
+<span class="terminal-line"><span class="info">  ? Tracker type:      </span><span class="arg">github</span></span>
+<span class="terminal-line"><span class="info">  ? GitHub token:      </span><span class="arg">ghp_***</span></span>
+<span class="terminal-line"><span class="info">  ? Default branch:    </span><span class="arg">main</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Config saved</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Ticket IDs are GitHub issue numbers</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">42</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created worktree for issue #42: Fix pagination bug</span></span>
+            </div>
+          </div>
+
+          <h3>Config file reference</h3>
+          <p>
+            The config file lives at <code>~/.config/parsec/config.toml</code>. You can edit it directly.
+          </p>
+
+          <div class="config-table-wrap">
+            <table class="config-table">
+              <thead>
+                <tr><th>Key</th><th>Description</th><th>Example</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>tracker.type</code></td>
+                  <td>Issue tracker backend.</td>
+                  <td><code>"jira"</code> / <code>"github"</code> / <code>"gitlab"</code> / <code>"bitbucket"</code></td>
+                </tr>
+                <tr>
+                  <td><code>tracker.base_url</code></td>
+                  <td>Base URL for Jira/GitLab self-hosted.</td>
+                  <td><code>"https://myorg.atlassian.net"</code></td>
+                </tr>
+                <tr>
+                  <td><code>tracker.token</code></td>
+                  <td>API token for the tracker.</td>
+                  <td>Jira API token or GitLab PAT</td>
+                </tr>
+                <tr>
+                  <td><code>github.token</code></td>
+                  <td>GitHub personal access token (for PR creation).</td>
+                  <td><code>"ghp_..."</code></td>
+                </tr>
+                <tr>
+                  <td><code>git.default_branch</code></td>
+                  <td>Default base branch for new worktrees.</td>
+                  <td><code>"main"</code> / <code>"develop"</code></td>
+                </tr>
+                <tr>
+                  <td><code>git.worktree_prefix</code></td>
+                  <td>Directory prefix for new worktrees.</td>
+                  <td><code>".."</code> (sibling dirs)</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="callout callout-warn">
+            <div class="callout-icon">!</div>
+            <div class="callout-body">
+              <div class="callout-title">No tracker configured</div>
+              <p>parsec still works without a tracker configured. Use <code>--title "My description"</code> with <code>parsec start</code> to provide a description manually. Ticket IDs become local labels only.</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ==============================
+             AI AGENT WORKFLOWS
+             ============================== -->
+        <section class="guide-section reveal" id="ai-agents">
+          <div class="section-heading">
+            <h2>AI Agent Workflows</h2>
+            <a href="#ai-agents" class="section-anchor">#</a>
+          </div>
+
+          <p>
+            parsec was built from day one for parallel AI agent execution. Each worktree is an isolated git environment — agents can run <code>git add</code>, <code>git commit</code>, and <code>git push</code> simultaneously without <code>index.lock</code> collisions.
+          </p>
+
+          <div class="agent-grid">
+            <div class="agent-card">
+              <div class="agent-card-header">
+                <div class="agent-card-icon">&#128274;</div>
+                <h4>Zero index.lock conflicts</h4>
+              </div>
+              <p>Each worktree has its own <code>.git/index</code>. Parallel agents never contend on the same file. No retries, no wasted tokens.</p>
+            </div>
+            <div class="agent-card">
+              <div class="agent-card-header">
+                <div class="agent-card-icon">&#128200;</div>
+                <h4>JSON output for scripting</h4>
+              </div>
+              <p>Every command supports <code>--json</code> for machine-readable output. Poll <code>pr-status</code>, check <code>ci</code>, trigger <code>merge</code> — all scriptable.</p>
+            </div>
+            <div class="agent-card">
+              <div class="agent-card-header">
+                <div class="agent-card-icon">&#128269;</div>
+                <h4>Conflict detection</h4>
+              </div>
+              <p><code>parsec conflicts</code> surfaces which files are modified by multiple agents before any PR is opened — catch issues early.</p>
+            </div>
+            <div class="agent-card">
+              <div class="agent-card-header">
+                <div class="agent-card-icon">&#128196;</div>
+                <h4>Operation history &amp; undo</h4>
+              </div>
+              <p><code>parsec log</code> shows every action. <code>parsec undo</code> rolls back the last step — useful when an agent ships prematurely.</p>
+            </div>
+          </div>
+
+          <h3>Running multiple agents in parallel</h3>
+          <p>
+            Each agent gets its own worktree. Launch them concurrently from a coordinator script — parsec handles isolation so agents never need to coordinate on git state.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parallel agent launch script</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment">#!/bin/bash</span></span>
+<span class="terminal-line"><span class="comment"># Each ticket becomes an isolated, independent workspace</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="command">parsec start</span> <span class="arg">PROJ-120</span> <span class="flag">--quiet</span> &amp;</span>
+<span class="terminal-line"><span class="command">parsec start</span> <span class="arg">PROJ-121</span> <span class="flag">--quiet</span> &amp;</span>
+<span class="terminal-line"><span class="command">parsec start</span> <span class="arg">PROJ-122</span> <span class="flag">--quiet</span> &amp;</span>
+<span class="terminal-line"><span class="command">wait</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Agent 1 works in ./myrepo.PROJ-120</span></span>
+<span class="terminal-line"><span class="comment"># Agent 2 works in ./myrepo.PROJ-121  ← no conflicts</span></span>
+<span class="terminal-line"><span class="comment"># Agent 3 works in ./myrepo.PROJ-122</span></span>
+            </div>
+          </div>
+
+          <h3>JSON output for automation</h3>
+          <p>
+            Use <code>--json</code> on any command to get structured output suitable for piping into <code>jq</code> or a coordinator agent.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">JSON output examples</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Check if PR is mergeable</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec pr-status</span> <span class="arg">PROJ-120</span> <span class="flag">--json</span> | <span class="command">jq</span> <span class="arg">'.mergeable'</span></span>
+<span class="terminal-line"><span class="info">  true</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Wait for CI then merge</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ci</span> <span class="arg">PROJ-120</span> <span class="flag">--watch</span> <span class="flag">--json</span></span>
+<span class="terminal-line"><span class="comment"># polls until complete, exits 0 on success</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec merge</span> <span class="arg">PROJ-120</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># List all worktrees as JSON</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec list</span> <span class="flag">--json</span> | <span class="command">jq</span> <span class="arg">'.[].ticket'</span></span>
+<span class="terminal-line"><span class="info">  "PROJ-120"</span></span>
+<span class="terminal-line"><span class="info">  "PROJ-121"</span></span>
+<span class="terminal-line"><span class="info">  "PROJ-122"</span></span>
+            </div>
+          </div>
+
+          <div class="callout callout-tip">
+            <div class="callout-icon">&#10003;</div>
+            <div class="callout-body">
+              <div class="callout-title">Agent best practices</div>
+              <p>Run <code>parsec conflicts</code> before any agent calls <code>parsec ship</code>. This surfaces file-level overlaps between parallel workstreams before they become merge conflicts.</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ==============================
+             STACKED PRs
+             ============================== -->
+        <section class="guide-section reveal" id="stacked-prs">
+          <div class="section-heading">
+            <h2>Stacked PRs</h2>
+            <a href="#stacked-prs" class="section-anchor">#</a>
+          </div>
+
+          <p>
+            Stacked PRs let you build a chain of dependent changes — each PR targets the previous ticket's branch rather than <code>main</code>. This is useful when a feature spans multiple tickets, or when you want incremental review of a large change.
+          </p>
+
+          <h3>Creating a stack with <code>--on</code></h3>
+          <p>
+            Pass <code>--on &lt;TICKET&gt;</code> to <code>parsec start</code> to create a worktree whose base is another ticket's branch.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">stacked PR workflow</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Base ticket — targets main</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">PROJ-100</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created worktree, base: </span><span class="link">main</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Second ticket — stacks on PROJ-100</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">PROJ-101</span> <span class="flag">--on</span> <span class="arg">PROJ-100</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created worktree, base: </span><span class="link">feature/PROJ-100</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Third in the chain</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">PROJ-102</span> <span class="flag">--on</span> <span class="arg">PROJ-101</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created worktree, base: </span><span class="link">feature/PROJ-101</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Visualize the stack</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec stack</span></span>
+<span class="terminal-line"><span class="info">  main</span></span>
+<span class="terminal-line"><span class="info">  └── </span><span class="link">feature/PROJ-100</span><span class="info">  PR #10 open</span></span>
+<span class="terminal-line"><span class="info">      └── </span><span class="link">feature/PROJ-101</span><span class="info">  PR #11 open</span></span>
+<span class="terminal-line"><span class="info">          └── </span><span class="link">feature/PROJ-102</span><span class="info">  PR #12 open</span></span>
+            </div>
+          </div>
+
+          <h3>After merging a stacked PR</h3>
+          <p>
+            When the base PR in a stack is merged, the child PR's target becomes stale — it still points to the merged branch. Use <code>parsec stack --sync</code> to automatically re-target all stacked PRs to their correct new bases.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parsec stack --sync</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># PROJ-100 was merged to main</span></span>
+<span class="terminal-line"><span class="comment"># Now re-target PROJ-101 to main</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec stack</span> <span class="flag">--sync</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR #11 retargeted: </span><span class="link">feature/PROJ-100</span><span class="info"> → </span><span class="link">main</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Stack synchronized</span></span>
+            </div>
+          </div>
+
+          <div class="callout callout-info">
+            <div class="callout-icon">&#9432;</div>
+            <div class="callout-body">
+              <div class="callout-title">Merge order matters</div>
+              <p>Always merge stacked PRs from the bottom of the stack upward — merge the base first, then <code>parsec stack --sync</code>, then merge the next PR. Skipping <code>--sync</code> results in child PRs targeting already-merged branches.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="guide-section reveal" id="new-features">
+          <div class="section-heading">
+            <h2>New Features</h2>
+            <a href="#new-features" class="section-anchor">#</a>
+          </div>
+
+          <p>
+            Recent additions to parsec that extend the workflow beyond worktree management into issue creation, release automation, and customizable hooks.
+          </p>
+
+          <h3>Issue creation with <code>parsec create</code></h3>
+          <p>
+            Create issues directly from the terminal without leaving your workflow. Works with GitHub Issues and Jira. Use <code>--start</code> to immediately begin work on the new issue.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parsec create</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Create a GitHub issue</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec create</span> <span class="flag">--title</span> <span class="arg">"Fix login redirect"</span> <span class="flag">--label</span> <span class="arg">"bug"</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created #145: Fix login redirect</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Create and start working immediately</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec create</span> <span class="flag">--title</span> <span class="arg">"Add caching layer"</span> <span class="flag">--start</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created #146: Add caching layer</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created workspace at </span><span class="link">~/myrepo.146</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># For Jira with issue type</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec new-issue</span> <span class="flag">--title</span> <span class="arg">"API caching"</span> <span class="flag">--issue-type</span> <span class="arg">Story</span> <span class="flag">--project</span> <span class="arg">CL</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created CL-42: API caching</span></span>
+            </div>
+          </div>
+
+          <h3>Release workflow with <code>parsec release</code></h3>
+          <p>
+            Automate the entire release process: merge develop to main, create a version tag, and publish a GitHub Release with auto-generated changelog — all in one command.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parsec release</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec release</span> <span class="arg">0.3.3</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Merged develop → main</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Tagged </span><span class="link">v0.3.3</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">GitHub Release: </span><span class="link">github.com/org/repo/releases/tag/v0.3.3</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Always preview first with --dry-run</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec release</span> <span class="arg">0.4.0</span> <span class="flag">--dry-run</span></span>
+<span class="terminal-line"><span class="info">Would merge develop → main</span></span>
+<span class="terminal-line"><span class="info">Would tag v0.4.0</span></span>
+            </div>
+          </div>
+
+          <h3>Pre-ship hooks</h3>
+          <p>
+            Define commands that run automatically before <code>parsec ship</code> pushes your branch. Great for ensuring tests pass and linting is clean before creating a PR.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">config.toml</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># ~/.config/parsec/config.toml</span></span>
+<span class="terminal-line"><span class="info">[hooks]</span></span>
+<span class="terminal-line"><span class="info">post_create = ["npm install"]</span></span>
+<span class="terminal-line"><span class="info">pre_ship = ["cargo test", "cargo clippy"]</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Skip hooks when needed</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-123</span> <span class="flag">--skip-hooks</span></span>
+            </div>
+          </div>
+
+          <div class="callout callout-info">
+            <div class="callout-icon">&#9432;</div>
+            <div class="callout-body">
+              <div class="callout-title">Release configuration</div>
+              <p>Customize the release workflow in your config file with <code>[release]</code> section: set the target branch, tag prefix, and whether to include a changelog.</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ==============================
+             WHAT'S NEW IN v0.4
+             ============================== -->
+        <section class="guide-section reveal" id="recipes">
+          <div class="section-heading">
+            <h2>Recipes &amp; Examples</h2>
+            <a href="#recipes" class="section-anchor">#</a>
+          </div>
+
+          <p>
+            End-to-end examples for the workflow patterns parsec is built around — Bitbucket Cloud setup, history compression, stacked PR navigation, PR templates, offline / headless mode, observability via JSONL, editor autocomplete via the JSON Schema, and worktree build cache sharing. Each recipe is self-contained — copy the snippets and adapt to your repo.
+          </p>
+
+          <h3>Bitbucket Cloud — full PR lifecycle</h3>
+          <p>
+            parsec now speaks Bitbucket Cloud's API: <code>parsec ship</code> opens PRs, <code>parsec pr-status</code> reports CI from Bitbucket Pipelines, <code>parsec ci</code> tails build status, and <code>parsec merge</code> merges from the terminal. Tracker integration uses the same <code>tracker.bitbucket</code> config block.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">Bitbucket setup</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Auth via env var</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">export</span> <span class="info">PARSEC_BITBUCKET_TOKEN=</span><span class="arg">"&lt;app-password&gt;"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Configure in ~/.config/parsec/config.toml</span></span>
+<span class="terminal-line"><span class="info">[tracker]</span></span>
+<span class="terminal-line"><span class="info">provider = </span><span class="arg">"bitbucket"</span></span>
+<span class="terminal-line"><span class="info">[tracker.bitbucket]</span></span>
+<span class="terminal-line"><span class="info">workspace = </span><span class="arg">"my-team"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">CL-2208</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR opened: bitbucket.org/my-team/repo/pull-requests/142</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Bitbucket Pipelines: BUILD #318 in_progress</span></span>
+            </div>
+          </div>
+
+          <h3>Compress branch history with <code>parsec compress</code></h3>
+          <p>
+            Squash a branch's commits into one tidy commit before shipping. Co-author trailers from squashed commits are preserved automatically.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parsec compress</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Squash all branch commits into one</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Compressed 7 commits into one on feature/PROJ-123</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># With a custom message</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span> <span class="flag">-m</span> <span class="arg">"feat: add user authentication"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Compose: tidy history then ship</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span> &amp;&amp; <span class="command">parsec ship</span></span>
+            </div>
+          </div>
+
+          <h3>Stack navigation comments</h3>
+          <p>
+            When you ship a stacked PR, parsec auto-posts <em>"← previous PR"</em> / <em>"next PR →"</em> navigation comments on every PR in the stack. Reviewers can walk the chain without leaving the PR view.
+          </p>
+
+          <h3>PR template auto-fill — <code>ship --template</code></h3>
+          <p>
+            Use the repository's <code>.github/PULL_REQUEST_TEMPLATE.md</code> (or the first match under <code>.github/PULL_REQUEST_TEMPLATE/</code>) as the PR description automatically. Combine with <code>ship.template</code> in <code>config.toml</code> to make it the default.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">ship --template</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-123</span> <span class="flag">--template</span></span>
+<span class="terminal-line"><span class="info">Loaded .github/PULL_REQUEST_TEMPLATE.md (348 chars)</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR opened with template body</span></span>
+            </div>
+          </div>
+
+          <h3>Offline mode — <code>--offline</code> / <code>[workspace].offline</code></h3>
+          <p>
+            Skip all network operations: tracker lookups, PR creation, fetches. Use a global <code>--offline</code> flag, the <code>PARSEC_OFFLINE=1</code> env var, or set <code>offline = true</code> under <code>[workspace]</code> in <code>config.toml</code>. Per-command escapes (<code>--no-pr</code>, <code>--no-tracker</code>) remain available for finer control.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">offline mode</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Per-invocation</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">CL-2208</span> <span class="flag">--offline</span> <span class="flag">--title</span> <span class="arg">"Add login retry"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Persistent — flight mode</span></span>
+<span class="terminal-line"><span class="info">[workspace]</span></span>
+<span class="terminal-line"><span class="info">offline = </span><span class="arg">true</span></span>
+            </div>
+          </div>
+
+          <h3>Observability — execution IDs + JSONL export</h3>
+          <p>
+            Every command run gets a unique execution ID and per-step timing. <code>parsec log --export</code> emits one JSON object per line for tooling and AI agents to consume. Combined with <code>--json</code> on individual commands, parsec is fully introspectable.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">parsec log --export</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec log</span> <span class="flag">--export</span> | <span class="command">jq</span> <span class="arg">'select(.duration_ms &gt; 1000)'</span></span>
+<span class="terminal-line"><span class="info">{</span></span>
+<span class="terminal-line"><span class="info">  "execution_id": "01HQ3D9V7Z2...",</span></span>
+<span class="terminal-line"><span class="info">  "op": "ship",</span></span>
+<span class="terminal-line"><span class="info">  "ticket": "PROJ-123",</span></span>
+<span class="terminal-line"><span class="info">  "steps": [</span></span>
+<span class="terminal-line"><span class="info">    {"name":"push","ms":820},</span></span>
+<span class="terminal-line"><span class="info">    {"name":"create_pr","ms":1305},</span></span>
+<span class="terminal-line"><span class="info">    {"name":"cleanup","ms":42}</span></span>
+<span class="terminal-line"><span class="info">  ],</span></span>
+<span class="terminal-line"><span class="info">  "duration_ms": 2167</span></span>
+<span class="terminal-line"><span class="info">}</span></span>
+            </div>
+          </div>
+
+          <h3>Config JSON Schema — editor autocomplete</h3>
+          <p>
+            The schema for <code>config.toml</code> is published to <a href="https://schemastore.org">schemastore.org</a>, so VS Code, IntelliJ, Helix, and any editor with schemastore integration auto-complete and validate every key. <code>parsec config schema</code> emits the schema for offline use.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">config schema</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config schema</span> > parsec-schema.json</span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Pin schema in your config for editor support</span></span>
+<span class="terminal-line"><span class="info">#:schema https://json.schemastore.org/parsec.json</span></span>
+            </div>
+          </div>
+
+          <h3>Worktree build cache sharing — <code>[worktree].shared_cache</code></h3>
+          <p>
+            New worktrees can reuse <code>target/</code>, <code>node_modules/</code>, <code>.venv/</code>, etc. from the main repo via symlink (default) or recursive copy. Eliminates cold-build cost on <code>parsec start</code> for any project with significant dependency caches.
+          </p>
+
+          <div class="terminal-wrap">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+              <span class="terminal-title-label">[worktree] config</span>
+            </div>
+            <div class="terminal-body">
+<span class="terminal-line"><span class="info">[worktree]</span></span>
+<span class="terminal-line"><span class="info">shared_cache = </span><span class="arg">["target", "node_modules", ".venv"]</span></span>
+<span class="terminal-line"><span class="comment"># "symlink" (default) — fast, zero-disk; parallel build of same artifact may race</span></span>
+<span class="terminal-line"><span class="comment"># "copy"             — independent caches per worktree, no race risk, more disk</span></span>
+<span class="terminal-line"><span class="info">cache_strategy = </span><span class="arg">"symlink"</span></span>
+            </div>
+          </div>
+
+          <h3>Draft-by-default — <code>ship.draft</code></h3>
+          <p>
+            Set <code>[ship].draft = true</code> in <code>config.toml</code> to open every PR as a draft, or pass <code>--draft</code> per ship. Useful for iterative WIP review flows where you want CI feedback before requesting human review.
+          </p>
+        </section>
+
+      </div>
+      <!-- end docs-content -->
+    </main>
+  </div>
+  <!-- end docs-layout -->
+
+  <!-- ============ FOOTER ============ -->
+  <footer class="docs-footer">
+    <div class="footer-inner">
+      <div class="footer-left">
+        <span class="footer-brand">git-parsec</span>
+        <ul class="footer-links">
+          <li><a href="https://github.com/erishforG/git-parsec" target="_blank" rel="noopener">GitHub</a></li>
+          <li><a href="https://github.com/erishforG/git-parsec/issues" target="_blank" rel="noopener">Issues</a></li>
+          <li><a href="https://github.com/erishforG/git-parsec/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
+          <li><a href="/git-parsec/v/0.4.0/reference/">Command Reference</a></li>
+        </ul>
+      </div>
+      <div class="footer-right">Built with Rust. Designed for velocity.</div>
+    </div>
+  </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      // Scroll reveal
+      const reveals = document.querySelectorAll('.reveal');
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('visible'); });
+      }, { threshold: 0.05, rootMargin: '0px 0px -20px 0px' });
+      reveals.forEach(el => observer.observe(el));
+
+      // Active sidebar link
+      const sections = document.querySelectorAll('.guide-section[id]');
+      const sidebarLinks = document.querySelectorAll('.sidebar-nav a');
+
+      const markActive = (id) => {
+        sidebarLinks.forEach(a => {
+          a.classList.toggle('active', a.getAttribute('href') === '#' + id);
+        });
+      };
+
+      const scrollObserver = new IntersectionObserver((entries) => {
+        entries.forEach(e => {
+          if (e.isIntersecting) markActive(e.target.id);
+        });
+      }, { threshold: 0, rootMargin: '-65px 0px -65% 0px' });
+
+      sections.forEach(el => scrollObserver.observe(el));
+    });
+  </script>
+  <script src="/git-parsec/version-switcher.js"></script>
+</body>
+</html>

--- a/docs/v/0.4.0/index.html
+++ b/docs/v/0.4.0/index.html
@@ -1,0 +1,2286 @@
+<!DOCTYPE html>
+<html lang="en" data-doc-version="0.4.0">
+<head>
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex, follow">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>git-parsec — From ticket to PR. One command. | Git worktree lifecycle manager</title>
+  <meta name="description" content="From ticket to PR in one command. git-parsec manages git worktree lifecycles with Jira, GitHub Issues, GitLab, and Bitbucket integration. Stacked PRs, multi-forge, observability JSONL.">
+  <meta name="keywords" content="git, worktree, CLI, Rust, Jira, GitHub, GitLab, Bitbucket, stacked PR, parallel development, AI agents, developer tools, git-parsec, parsec, ticket to PR, AI coding agent">
+  <meta name="author" content="erishforG">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://erishforg.github.io/git-parsec/">
+  <meta property="og:title" content="git-parsec — From ticket to PR. One command.">
+  <meta property="og:description" content="Git worktree lifecycle manager with Jira, GitHub, GitLab & Bitbucket integration. Stacked PRs, multi-forge CI, observability JSONL — built for parallel developers and AI coding agents.">
+  <meta property="og:site_name" content="git-parsec">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://erishforg.github.io/git-parsec/demo.gif">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="git-parsec terminal demo — parsec start, list, ship">
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="git-parsec — From ticket to PR. One command.">
+  <meta name="twitter:description" content="Git worktree lifecycle manager with Jira, GitHub, GitLab & Bitbucket. Stacked PRs, multi-forge CI, observability JSONL.">
+  <meta name="twitter:image" content="https://erishforg.github.io/git-parsec/demo.gif">
+  <meta name="twitter:image:alt" content="git-parsec terminal demo">
+  <!-- Canonical -->
+  <link rel="canonical" href="https://erishforg.github.io/git-parsec/">
+  <meta name="theme-color" content="#0a0e1a">
+  <!-- AEO: emerging llms.txt standard for LLM crawlers -->
+  <link rel="alternate" type="text/plain" href="/git-parsec/llms.txt" title="LLM-friendly summary">
+  <link rel="alternate" type="text/plain" href="/git-parsec/llms-full.txt" title="LLM-friendly full text">
+  <!-- Schema.org Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "git-parsec",
+    "alternateName": ["parsec", "git parsec"],
+    "applicationCategory": "DeveloperApplication",
+    "applicationSubCategory": "VersionControlSystem",
+    "operatingSystem": "macOS, Linux, Windows",
+    "description": "Git worktree lifecycle manager. Create isolated workspaces from ticket IDs (Jira, GitHub Issues, GitLab, Bitbucket), work in parallel without index.lock conflicts, ship with one command (push + PR + cleanup). Multi-forge support (GitHub, GitLab, Bitbucket Cloud), stacked PRs with auto-posted navigation comments, multi-CI status (Actions, GitLab CI, Bitbucket Pipelines), observability via JSONL, headless and offline modes for CI and AI agents.",
+    "url": "https://erishforg.github.io/git-parsec/",
+    "downloadUrl": "https://github.com/erishforG/git-parsec/releases",
+    "softwareVersion": "0.4.0",
+    "datePublished": "2026-05-04",
+    "softwareRequirements": "git >= 2.30, Rust toolchain (cargo install) or pre-built binary",
+    "releaseNotes": "https://github.com/erishforG/git-parsec/blob/main/CHANGELOG.md",
+    "screenshot": "https://erishforg.github.io/git-parsec/demo.gif",
+    "author": {
+      "@type": "Person",
+      "name": "erishforG",
+      "url": "https://github.com/erishforG"
+    },
+    "codeRepository": "https://github.com/erishforG/git-parsec",
+    "programmingLanguage": "Rust",
+    "license": "https://opensource.org/licenses/MIT",
+    "keywords": ["git", "worktree", "CLI", "Jira", "GitHub Issues", "GitLab", "Bitbucket", "Bitbucket Cloud", "Bitbucket Pipelines", "parallel development", "AI agents", "AI coding agent", "developer tools", "pull request", "CI/CD", "stacked PRs", "git worktree manager", "ticket to PR", "observability", "JSONL"],
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "Ship a feature with git-parsec — from ticket to merged PR",
+    "description": "End-to-end flow for taking a tracker ticket (Jira, GitHub Issues, GitLab, Bitbucket) all the way to a merged PR using git-parsec.",
+    "totalTime": "PT60S",
+    "tool": [
+      { "@type": "HowToTool", "name": "git-parsec CLI" },
+      { "@type": "HowToTool", "name": "git" }
+    ],
+    "step": [
+      {
+        "@type": "HowToStep",
+        "position": 1,
+        "name": "Start a workspace from a ticket",
+        "text": "Run `parsec start PROJ-1234`. parsec creates an isolated git worktree, fetches the ticket title from Jira/GitHub Issues/GitLab/Bitbucket, and names the branch consistently."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 2,
+        "name": "Switch into the workspace",
+        "text": "Run `parsec switch PROJ-1234` (with shell integration installed, this auto-cd's into the worktree directory)."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 3,
+        "name": "Make commits the normal way",
+        "text": "Use git as usual. Multiple workspaces never collide on .git/index.lock because each worktree has its own index."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 4,
+        "name": "Ship — push, open PR, clean up",
+        "text": "Run `parsec ship PROJ-1234`. parsec pushes the branch, opens a PR or MR on the matching forge, and removes the worktree."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 5,
+        "name": "Watch CI and merge",
+        "text": "Run `parsec ci PROJ-1234 --watch` to tail CI status, then `parsec merge PROJ-1234` to merge from the terminal once green."
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://erishforg.github.io/git-parsec/" }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is git-parsec?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "git-parsec (parsec) is a command-line tool that manages the full lifecycle of git worktrees tied to issue tickets. It creates isolated workspaces from ticket IDs, enables parallel development without lock conflicts, and ships features with one command (push + PR/MR + cleanup). It integrates with Jira, GitHub Issues, and GitLab."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does parsec differ from git worktree?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Plain git worktree only creates and removes worktrees. parsec adds full lifecycle management: ticket tracker integration (Jira, GitHub Issues, GitLab), one-step shipping (push + PR + cleanup), cross-worktree conflict detection, operation history with undo, CI status monitoring, stacked PR support, and machine-readable JSON output for AI agents."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can multiple AI agents use parsec on the same repository?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Each parsec workspace is a separate git worktree with its own index, so multiple AI agents (or developers) can run git add, commit, and push simultaneously without index.lock conflicts. Every command supports --json for structured output, and parsec doctor --ai outputs workflow rules optimized for AI consumption."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I install parsec?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Install via cargo: cargo install git-parsec. Or download pre-built binaries for macOS (Apple Silicon, Intel), Linux, and Windows from the GitHub Releases page. Or build from source: git clone and cargo build --release."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does parsec support GitLab?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. parsec supports GitLab for both issue tracking and merge request creation. Set provider = gitlab in your config and configure the base_url. Authentication uses PARSEC_GITLAB_TOKEN or GITLAB_TOKEN environment variables."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do stacked PRs work in parsec?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Use parsec start CHILD --on PARENT to create dependent worktrees. When you ship, parsec automatically sets the correct base branch for each PR. Use parsec stack to view the dependency graph and parsec stack --sync to rebase the entire chain."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does parsec work with GitHub Enterprise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. parsec auto-detects GitHub Enterprise from the git remote URL and routes API calls to the correct host. Token resolution is host-aware, supporting both github.com and GitHub Enterprise instances."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can I undo a parsec operation?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. parsec log shows all operations with timestamps, and parsec undo reverses the last one. Undoing a start removes the worktree; undoing a ship or clean re-creates it from the branch if still available."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I protect branches from accidental shipping?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Add a [policy] section to ~/.config/parsec/config.toml with protected_branches and allowed_ship_targets. parsec will reject ship and merge operations that violate these rules, returning error code E009."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are parsec error codes?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "When using --json mode, parsec returns structured error codes (E001 through E013) with specific exit codes for programmatic handling. For example, E001 means no token configured (exit 2), E002 means CI failing (exit 4), E003 means conflicts detected (exit 3). This enables AI agents and scripts to handle errors precisely."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does parsec support Bitbucket Cloud?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, since v0.4. parsec speaks Bitbucket Cloud's API for the full PR lifecycle (create, list, view, merge, comments). CI status from Bitbucket Pipelines is surfaced through `parsec ci` and `parsec pr-status`, exactly the same shape as GitHub Actions and GitLab CI. Authenticate via PARSEC_BITBUCKET_TOKEN or BITBUCKET_TOKEN env var; configure tracker.bitbucket in config.toml with your workspace name."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I run parsec offline (without network access)?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Use the global --offline flag, set PARSEC_OFFLINE=1, or set [workspace].offline = true in ~/.config/parsec/config.toml. Offline mode skips all network operations: tracker title lookups, PR/MR creation, and remote fetches. Per-command flags --no-pr and --no-tracker offer finer control. Useful for air-gapped environments, CI without secrets, and flight-mode development."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I export parsec's operation log for tooling or AI agents?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Run `parsec log --export` to emit JSONL — one JSON object per line. Each entry contains an execution_id, op (start/ship/clean/etc.), ticket, steps array with per-step name and ms duration, started_at timestamp, and total duration_ms. Pipe through jq to filter (e.g., `parsec log --export | jq 'select(.duration_ms > 1000)'`) or ingest directly in observability pipelines."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I squash my branch commits before shipping?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Run `parsec compress` (added in v0.4) to squash all commits on the current branch into one tidy commit. Co-author trailers from squashed commits are preserved automatically. Pass `--message` for a custom commit message, otherwise messages are concatenated. Common pattern: `parsec compress && parsec ship`."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I get editor autocomplete for parsec's config.toml?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "parsec's config schema is published to schemastore.org as parsec.json. Editors with schemastore integration (VS Code, IntelliJ, Helix) automatically validate and autocomplete ~/.config/parsec/config.toml and per-repo .parsec.toml. To pin the schema explicitly, add `#:schema https://json.schemastore.org/parsec.json` at the top of your config. Run `parsec config schema` to emit the schema for offline use."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What forges and CI systems does parsec support?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Forges: GitHub (github.com and GitHub Enterprise), GitLab (gitlab.com and self-hosted), and Bitbucket Cloud — with full PR lifecycle (create, list, view, merge, comments) on each. CI integrations: GitHub Actions, GitLab CI, and Bitbucket Pipelines. parsec ci and parsec pr-status work the same shape on every forge — auto-detected from the git remote URL."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does parsec speed up cold starts on large repos?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. The [worktree].shared_cache config lets new worktrees reuse target/, node_modules/, .venv/, etc. from the main repo via symlink (default, zero-disk overhead) or recursive copy (independent caches per worktree). Eliminates cold-build cost on `parsec start` for any project with significant dependency caches."
+        }
+      }
+    ]
+  }
+  </script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@400;500;600;700;800;900&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    /* ================================================
+       RESET & BASE
+       ================================================ */
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg-deep: #060a14;
+      --bg-base: #0a0e1a;
+      --bg-raised: #0f1424;
+      --bg-card: #111828;
+      --bg-card-hover: #151d30;
+
+      --accent-cyan: #4FC3F7;
+      --accent-blue: #2196F3;
+      --accent-teal: #26C6DA;
+      --accent-electric: #40E0D0;
+      --accent-purple: #7C4DFF;
+      --accent-glow: rgba(79, 195, 247, 0.15);
+      --accent-glow-strong: rgba(79, 195, 247, 0.3);
+
+      --text-primary: #e8edf5;
+      --text-secondary: #8892a4;
+      --text-muted: #5a6577;
+      --text-code: #b4c7e7;
+
+      --border-subtle: rgba(79, 195, 247, 0.08);
+      --border-accent: rgba(79, 195, 247, 0.2);
+
+      --radius-sm: 6px;
+      --radius-md: 12px;
+      --radius-lg: 20px;
+      --radius-xl: 28px;
+
+      --font-display: 'Outfit', sans-serif;
+      --font-body: 'Source Sans 3', sans-serif;
+      --font-mono: 'JetBrains Mono', monospace;
+    }
+
+    html {
+      scroll-behavior: smooth;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    body {
+      font-family: var(--font-body);
+      background: var(--bg-deep);
+      color: var(--text-primary);
+      line-height: 1.6;
+      overflow-x: hidden;
+    }
+
+    /* ================================================
+       STARFIELD BACKGROUND
+       ================================================ */
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background:
+        radial-gradient(1.5px 1.5px at 20% 30%, rgba(79, 195, 247, 0.4) 50%, transparent 50%),
+        radial-gradient(1px 1px at 40% 70%, rgba(255, 255, 255, 0.3) 50%, transparent 50%),
+        radial-gradient(1.2px 1.2px at 60% 20%, rgba(38, 198, 218, 0.35) 50%, transparent 50%),
+        radial-gradient(1px 1px at 80% 50%, rgba(255, 255, 255, 0.25) 50%, transparent 50%),
+        radial-gradient(1.3px 1.3px at 10% 80%, rgba(79, 195, 247, 0.3) 50%, transparent 50%),
+        radial-gradient(0.8px 0.8px at 70% 85%, rgba(255, 255, 255, 0.2) 50%, transparent 50%),
+        radial-gradient(1px 1px at 90% 15%, rgba(64, 224, 208, 0.3) 50%, transparent 50%),
+        radial-gradient(1.1px 1.1px at 35% 45%, rgba(255, 255, 255, 0.15) 50%, transparent 50%),
+        radial-gradient(0.9px 0.9px at 55% 65%, rgba(79, 195, 247, 0.2) 50%, transparent 50%),
+        radial-gradient(1px 1px at 85% 35%, rgba(255, 255, 255, 0.2) 50%, transparent 50%),
+        radial-gradient(1.4px 1.4px at 15% 55%, rgba(38, 198, 218, 0.25) 50%, transparent 50%),
+        radial-gradient(0.7px 0.7px at 45% 90%, rgba(255, 255, 255, 0.15) 50%, transparent 50%),
+        radial-gradient(1px 1px at 75% 10%, rgba(79, 195, 247, 0.25) 50%, transparent 50%),
+        radial-gradient(0.9px 0.9px at 25% 75%, rgba(255, 255, 255, 0.18) 50%, transparent 50%),
+        radial-gradient(1.2px 1.2px at 95% 60%, rgba(64, 224, 208, 0.2) 50%, transparent 50%),
+        radial-gradient(0.8px 0.8px at 5% 40%, rgba(255, 255, 255, 0.12) 50%, transparent 50%),
+        radial-gradient(1px 1px at 50% 5%, rgba(79, 195, 247, 0.3) 50%, transparent 50%),
+        radial-gradient(1.1px 1.1px at 65% 50%, rgba(255, 255, 255, 0.1) 50%, transparent 50%);
+      pointer-events: none;
+      z-index: 0;
+      animation: starDrift 120s linear infinite;
+    }
+
+    @keyframes starDrift {
+      0% { transform: translateY(0); }
+      100% { transform: translateY(-30px); }
+    }
+
+    /* ================================================
+       LAYOUT
+       ================================================ */
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 24px;
+      position: relative;
+      z-index: 1;
+    }
+
+    section {
+      position: relative;
+      z-index: 1;
+    }
+
+    /* ================================================
+       NAV
+       ================================================ */
+    nav {
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      z-index: 100;
+      padding: 16px 0;
+      background: rgba(6, 10, 20, 0.8);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border-subtle);
+      transition: background 0.3s;
+    }
+
+    .nav-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      text-decoration: none;
+      color: var(--text-primary);
+    }
+
+    .nav-brand-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      background: linear-gradient(135deg, var(--accent-cyan), var(--accent-teal));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+      font-weight: 700;
+      color: var(--bg-deep);
+      font-family: var(--font-mono);
+    }
+
+    .nav-brand span {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 18px;
+      letter-spacing: -0.02em;
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 32px;
+      list-style: none;
+    }
+
+    .nav-links a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    .nav-links a:hover {
+      color: var(--accent-cyan);
+    }
+
+    .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 20px;
+      background: transparent;
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-sm);
+      color: var(--accent-cyan);
+      text-decoration: none;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all 0.25s;
+    }
+
+    .nav-cta:hover {
+      background: var(--accent-glow);
+      border-color: var(--accent-cyan);
+      box-shadow: 0 0 20px rgba(79, 195, 247, 0.15);
+    }
+
+    .nav-cta svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    /* ================================================
+       HERO
+       ================================================ */
+    .hero {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      padding: 140px 0 100px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      top: -20%;
+      right: -10%;
+      width: 800px;
+      height: 800px;
+      background: radial-gradient(circle, rgba(79, 195, 247, 0.06) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    .hero::after {
+      content: '';
+      position: absolute;
+      bottom: -10%;
+      left: -15%;
+      width: 600px;
+      height: 600px;
+      background: radial-gradient(circle, rgba(38, 198, 218, 0.04) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 80px;
+      align-items: center;
+    }
+
+    .hero-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 16px;
+      background: var(--accent-glow);
+      border: 1px solid var(--border-accent);
+      border-radius: 100px;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--accent-cyan);
+      margin-bottom: 28px;
+      animation: fadeSlideIn 0.8s ease-out both;
+    }
+
+    .hero-badge::before {
+      content: '';
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent-cyan);
+      animation: pulse 2s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(79, 195, 247, 0.4); }
+      50% { opacity: 0.7; box-shadow: 0 0 0 6px rgba(79, 195, 247, 0); }
+    }
+
+    .hero h1 {
+      font-family: var(--font-display);
+      font-size: clamp(40px, 5vw, 64px);
+      font-weight: 900;
+      line-height: 1.08;
+      letter-spacing: -0.035em;
+      margin-bottom: 24px;
+      animation: fadeSlideIn 0.8s 0.1s ease-out both;
+    }
+
+    .hero h1 .gradient-text {
+      background: linear-gradient(135deg, var(--accent-cyan) 0%, var(--accent-teal) 40%, var(--accent-electric) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero-subtitle {
+      font-size: 18px;
+      color: var(--text-secondary);
+      line-height: 1.7;
+      margin-bottom: 40px;
+      max-width: 520px;
+      animation: fadeSlideIn 0.8s 0.2s ease-out both;
+    }
+
+    .hero-actions {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+      animation: fadeSlideIn 0.8s 0.3s ease-out both;
+    }
+
+    .btn-primary {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 28px;
+      background: linear-gradient(135deg, var(--accent-cyan), var(--accent-blue));
+      color: var(--bg-deep);
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 15px;
+      border: none;
+      border-radius: var(--radius-md);
+      text-decoration: none;
+      cursor: pointer;
+      transition: all 0.3s;
+      box-shadow: 0 4px 24px rgba(79, 195, 247, 0.25);
+    }
+
+    .btn-primary:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 32px rgba(79, 195, 247, 0.35);
+    }
+
+    .btn-secondary {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 28px;
+      background: var(--bg-card);
+      color: var(--text-primary);
+      font-family: var(--font-display);
+      font-weight: 600;
+      font-size: 15px;
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      text-decoration: none;
+      cursor: pointer;
+      transition: all 0.3s;
+    }
+
+    .btn-secondary:hover {
+      background: var(--bg-card-hover);
+      border-color: var(--border-accent);
+    }
+
+    /* Hero Terminal */
+    .hero-terminal {
+      background: var(--bg-base);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow:
+        0 4px 6px rgba(0, 0, 0, 0.3),
+        0 24px 48px rgba(0, 0, 0, 0.4),
+        0 0 0 1px rgba(79, 195, 247, 0.05),
+        inset 0 1px 0 rgba(255, 255, 255, 0.03);
+      animation: fadeSlideUp 1s 0.4s ease-out both;
+      position: relative;
+    }
+
+    .hero-terminal::after {
+      content: '';
+      position: absolute;
+      inset: -1px;
+      border-radius: var(--radius-lg);
+      background: linear-gradient(135deg, rgba(79, 195, 247, 0.1), transparent 50%, rgba(38, 198, 218, 0.05));
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    .terminal-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 14px 18px;
+      background: var(--bg-raised);
+      border-bottom: 1px solid var(--border-subtle);
+      position: relative;
+      z-index: 1;
+    }
+
+    .terminal-dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+
+    .terminal-dot:nth-child(1) { background: #ff5f57; }
+    .terminal-dot:nth-child(2) { background: #febc2e; }
+    .terminal-dot:nth-child(3) { background: #28c840; }
+
+    .terminal-title {
+      flex: 1;
+      text-align: center;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-right: 36px;
+    }
+
+    .terminal-body {
+      padding: 24px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.8;
+      position: relative;
+      z-index: 1;
+      overflow-x: auto;
+    }
+
+    .terminal-body .comment { color: var(--text-muted); }
+    .terminal-body .prompt { color: var(--accent-cyan); }
+    .terminal-body .command { color: var(--text-primary); }
+    .terminal-body .flag { color: var(--accent-purple); }
+    .terminal-body .success { color: #28c840; }
+    .terminal-body .info { color: var(--text-secondary); }
+    .terminal-body .link { color: var(--accent-teal); }
+    .terminal-body .arg { color: #ffb74d; }
+
+    .terminal-line {
+      display: block;
+      white-space: pre;
+    }
+
+    .terminal-line.typing::after {
+      content: '';
+      display: inline-block;
+      width: 8px;
+      height: 16px;
+      background: var(--accent-cyan);
+      margin-left: 2px;
+      animation: blink 1s step-end infinite;
+      vertical-align: text-bottom;
+    }
+
+    @keyframes blink {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0; }
+    }
+
+    /* ================================================
+       ANIMATIONS
+       ================================================ */
+    @keyframes fadeSlideIn {
+      from { opacity: 0; transform: translateY(12px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes fadeSlideUp {
+      from { opacity: 0; transform: translateY(30px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .reveal {
+      opacity: 0;
+      transform: translateY(24px);
+      transition: opacity 0.7s ease-out, transform 0.7s ease-out;
+    }
+
+    .reveal.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .reveal-delay-1 { transition-delay: 0.1s; }
+    .reveal-delay-2 { transition-delay: 0.2s; }
+    .reveal-delay-3 { transition-delay: 0.3s; }
+    .reveal-delay-4 { transition-delay: 0.4s; }
+    .reveal-delay-5 { transition-delay: 0.5s; }
+    .reveal-delay-6 { transition-delay: 0.6s; }
+
+    /* ================================================
+       SECTION HEADERS
+       ================================================ */
+    .section-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent-cyan);
+      margin-bottom: 16px;
+    }
+
+    .section-label::before {
+      content: '';
+      width: 20px;
+      height: 1px;
+      background: var(--accent-cyan);
+    }
+
+    .section-title {
+      font-family: var(--font-display);
+      font-size: clamp(32px, 4vw, 48px);
+      font-weight: 800;
+      line-height: 1.15;
+      letter-spacing: -0.03em;
+      margin-bottom: 16px;
+    }
+
+    .section-desc {
+      font-size: 17px;
+      color: var(--text-secondary);
+      line-height: 1.7;
+      max-width: 600px;
+    }
+
+    /* ================================================
+       PROBLEM SECTION
+       ================================================ */
+    .problem-section {
+      padding: 120px 0;
+      position: relative;
+    }
+
+    .problem-section::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--border-accent), transparent);
+    }
+
+    .problem-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 80px;
+      margin-top: 64px;
+      align-items: start;
+    }
+
+    .problem-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .problem-item {
+      display: flex;
+      gap: 16px;
+      padding: 20px;
+      background: rgba(255, 87, 87, 0.04);
+      border: 1px solid rgba(255, 87, 87, 0.1);
+      border-radius: var(--radius-md);
+      transition: border-color 0.3s;
+    }
+
+    .problem-item:hover {
+      border-color: rgba(255, 87, 87, 0.2);
+    }
+
+    .problem-icon {
+      flex-shrink: 0;
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      background: rgba(255, 87, 87, 0.1);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+    }
+
+    .problem-item h4 {
+      font-family: var(--font-display);
+      font-size: 15px;
+      font-weight: 700;
+      margin-bottom: 4px;
+      color: var(--text-primary);
+    }
+
+    .problem-item p {
+      font-size: 14px;
+      color: var(--text-secondary);
+      line-height: 1.6;
+    }
+
+    .solution-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .solution-item {
+      display: flex;
+      gap: 16px;
+      padding: 20px;
+      background: var(--accent-glow);
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-md);
+      transition: border-color 0.3s, box-shadow 0.3s;
+    }
+
+    .solution-item:hover {
+      border-color: rgba(79, 195, 247, 0.3);
+      box-shadow: 0 0 24px rgba(79, 195, 247, 0.08);
+    }
+
+    .solution-icon {
+      flex-shrink: 0;
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      background: rgba(79, 195, 247, 0.15);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+    }
+
+    .solution-item h4 {
+      font-family: var(--font-display);
+      font-size: 15px;
+      font-weight: 700;
+      margin-bottom: 4px;
+      color: var(--text-primary);
+    }
+
+    .solution-item p {
+      font-size: 14px;
+      color: var(--text-secondary);
+      line-height: 1.6;
+    }
+
+    .problem-col-header {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 14px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 24px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .problem-col-header.bad { color: #ff5f57; }
+    .problem-col-header.good { color: var(--accent-cyan); }
+
+    .problem-col-header::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: currentColor;
+      opacity: 0.2;
+    }
+
+    /* ================================================
+       FEATURES SECTION
+       ================================================ */
+    .features-section {
+      padding: 120px 0;
+      position: relative;
+    }
+
+    .features-section::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--border-accent), transparent);
+    }
+
+    .features-header {
+      text-align: center;
+      margin-bottom: 72px;
+    }
+
+    .features-header .section-desc {
+      margin: 0 auto;
+    }
+
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 20px;
+    }
+
+    .feature-card {
+      padding: 32px;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-lg);
+      transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .feature-card::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, var(--accent-cyan), var(--accent-teal));
+      opacity: 0;
+      transition: opacity 0.4s;
+    }
+
+    .feature-card:hover {
+      background: var(--bg-card-hover);
+      border-color: var(--border-accent);
+      transform: translateY(-4px);
+      box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3), 0 0 0 1px var(--border-accent);
+    }
+
+    .feature-card:hover::before {
+      opacity: 1;
+    }
+
+    .feature-card.featured {
+      grid-column: span 2;
+      background: linear-gradient(135deg, var(--bg-card) 0%, rgba(79, 195, 247, 0.05) 100%);
+      border-color: var(--border-accent);
+    }
+
+    .feature-icon {
+      width: 48px;
+      height: 48px;
+      border-radius: 14px;
+      background: var(--accent-glow);
+      border: 1px solid var(--border-accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 20px;
+    }
+
+    .feature-icon svg {
+      width: 24px;
+      height: 24px;
+      stroke: var(--accent-cyan);
+      fill: none;
+      stroke-width: 1.8;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .feature-card h3 {
+      font-family: var(--font-display);
+      font-size: 18px;
+      font-weight: 700;
+      margin-bottom: 10px;
+      letter-spacing: -0.01em;
+    }
+
+    .feature-card p {
+      font-size: 14px;
+      color: var(--text-secondary);
+      line-height: 1.7;
+    }
+
+    .feature-code {
+      margin-top: 16px;
+      padding: 12px 16px;
+      background: var(--bg-deep);
+      border-radius: var(--radius-sm);
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--text-code);
+      overflow-x: auto;
+    }
+
+    /* ================================================
+       COMPARISON TABLE
+       ================================================ */
+    .comparison-section {
+      padding: 120px 0;
+      position: relative;
+    }
+
+    .comparison-section::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--border-accent), transparent);
+    }
+
+    .comparison-header {
+      text-align: center;
+      margin-bottom: 64px;
+    }
+
+    .comparison-header .section-desc {
+      margin: 0 auto;
+    }
+
+    .comparison-table-wrapper {
+      overflow-x: auto;
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--border-subtle);
+    }
+
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+
+    .comparison-table thead th {
+      padding: 20px 24px;
+      text-align: left;
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 14px;
+      background: var(--bg-raised);
+      border-bottom: 1px solid var(--border-subtle);
+      white-space: nowrap;
+    }
+
+    .comparison-table thead th:first-child {
+      color: var(--text-secondary);
+    }
+
+    .comparison-table thead th.highlight {
+      color: var(--accent-cyan);
+      position: relative;
+    }
+
+    .comparison-table thead th.highlight::after {
+      content: 'RECOMMENDED';
+      position: absolute;
+      top: 6px;
+      right: 16px;
+      font-family: var(--font-mono);
+      font-size: 9px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      padding: 2px 8px;
+      background: rgba(79, 195, 247, 0.15);
+      border: 1px solid var(--border-accent);
+      border-radius: 100px;
+      color: var(--accent-cyan);
+    }
+
+    .comparison-table tbody td {
+      padding: 16px 24px;
+      border-bottom: 1px solid var(--border-subtle);
+      color: var(--text-secondary);
+    }
+
+    .comparison-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .comparison-table tbody td:first-child {
+      font-weight: 500;
+      color: var(--text-primary);
+      white-space: nowrap;
+    }
+
+    .comparison-table tbody td.highlight {
+      background: rgba(79, 195, 247, 0.03);
+    }
+
+    .comparison-table .check {
+      color: #28c840;
+      font-weight: 600;
+    }
+
+    .comparison-table .cross {
+      color: var(--text-muted);
+    }
+
+    .comparison-table .partial {
+      color: #febc2e;
+    }
+
+    /* ================================================
+       QUICKSTART SECTION
+       ================================================ */
+    .quickstart-section {
+      padding: 120px 0;
+      position: relative;
+    }
+
+    .quickstart-section::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--border-accent), transparent);
+    }
+
+    .quickstart-header {
+      text-align: center;
+      margin-bottom: 64px;
+    }
+
+    .quickstart-header .section-desc {
+      margin: 0 auto;
+    }
+
+    .quickstart-steps {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+      margin-bottom: 64px;
+    }
+
+    .step-card {
+      padding: 32px;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-lg);
+      position: relative;
+      transition: border-color 0.3s;
+    }
+
+    .step-card:hover {
+      border-color: var(--border-accent);
+    }
+
+    .step-number {
+      font-family: var(--font-display);
+      font-size: 48px;
+      font-weight: 900;
+      background: linear-gradient(180deg, rgba(79, 195, 247, 0.3), rgba(79, 195, 247, 0.05));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      line-height: 1;
+      margin-bottom: 16px;
+    }
+
+    .step-card h3 {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 17px;
+      margin-bottom: 8px;
+    }
+
+    .step-card p {
+      font-size: 14px;
+      color: var(--text-secondary);
+      line-height: 1.6;
+      margin-bottom: 16px;
+    }
+
+    .step-code {
+      padding: 12px 16px;
+      background: var(--bg-deep);
+      border-radius: var(--radius-sm);
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--accent-cyan);
+      overflow-x: auto;
+    }
+
+    /* ================================================
+       INSTALL SECTION
+       ================================================ */
+    .install-section {
+      padding: 120px 0;
+      position: relative;
+    }
+
+    .install-section::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--border-accent), transparent);
+    }
+
+    .install-wrapper {
+      max-width: 720px;
+      margin: 0 auto;
+      text-align: center;
+    }
+
+    .install-wrapper .section-desc {
+      margin: 0 auto 48px;
+    }
+
+    .install-options {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .install-option {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 28px;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      transition: all 0.3s;
+    }
+
+    .install-option:hover {
+      border-color: var(--border-accent);
+      background: var(--bg-card-hover);
+    }
+
+    .install-option-label {
+      font-family: var(--font-display);
+      font-weight: 600;
+      font-size: 14px;
+      color: var(--text-secondary);
+      white-space: nowrap;
+      min-width: 120px;
+      text-align: left;
+    }
+
+    .install-option-cmd {
+      font-family: var(--font-mono);
+      font-size: 14px;
+      color: var(--accent-cyan);
+      flex: 1;
+      text-align: left;
+      padding-left: 24px;
+    }
+
+    .install-option-badge {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 4px 10px;
+      border-radius: 100px;
+      white-space: nowrap;
+    }
+
+    .install-option-badge.available {
+      background: rgba(40, 200, 64, 0.1);
+      color: #28c840;
+      border: 1px solid rgba(40, 200, 64, 0.2);
+    }
+
+    .install-option-badge.soon {
+      background: rgba(254, 188, 46, 0.1);
+      color: #febc2e;
+      border: 1px solid rgba(254, 188, 46, 0.2);
+    }
+
+    /* ================================================
+       CTA SECTION
+       ================================================ */
+    .cta-section {
+      padding: 120px 0 160px;
+      text-align: center;
+      position: relative;
+    }
+
+    .cta-section::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 600px;
+      height: 400px;
+      background: radial-gradient(ellipse, rgba(79, 195, 247, 0.06), transparent 70%);
+      pointer-events: none;
+    }
+
+    .cta-title {
+      font-family: var(--font-display);
+      font-size: clamp(36px, 4.5vw, 56px);
+      font-weight: 900;
+      letter-spacing: -0.03em;
+      line-height: 1.1;
+      margin-bottom: 20px;
+    }
+
+    .cta-desc {
+      font-size: 18px;
+      color: var(--text-secondary);
+      max-width: 500px;
+      margin: 0 auto 40px;
+      line-height: 1.7;
+    }
+
+    .cta-actions {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .cta-install-cmd {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 24px;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      font-family: var(--font-mono);
+      font-size: 14px;
+      color: var(--text-code);
+      cursor: pointer;
+      transition: all 0.3s;
+      text-decoration: none;
+    }
+
+    .cta-install-cmd:hover {
+      border-color: var(--border-accent);
+      background: var(--bg-card-hover);
+    }
+
+    .cta-install-cmd .dollar {
+      color: var(--text-muted);
+    }
+
+    /* ================================================
+       FOOTER
+       ================================================ */
+    footer {
+      position: relative;
+      z-index: 1;
+      padding: 40px 0;
+      border-top: 1px solid var(--border-subtle);
+    }
+
+    .footer-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .footer-left {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+    }
+
+    .footer-brand {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 15px;
+      color: var(--text-secondary);
+    }
+
+    .footer-links {
+      display: flex;
+      gap: 24px;
+      list-style: none;
+    }
+
+    .footer-links a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 13px;
+      transition: color 0.2s;
+    }
+
+    .footer-links a:hover {
+      color: var(--accent-cyan);
+    }
+
+    .footer-right {
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    /* ================================================
+       RESPONSIVE
+       ================================================ */
+    @media (max-width: 1024px) {
+      .hero-grid {
+        grid-template-columns: 1fr;
+        gap: 48px;
+      }
+
+      .features-grid {
+        grid-template-columns: repeat(2, 1fr);
+      }
+
+      .feature-card.featured {
+        grid-column: span 2;
+      }
+    }
+
+    @media (max-width: 768px) {
+      .nav-links { display: none; }
+
+      .hero {
+        padding: 120px 0 80px;
+        min-height: auto;
+      }
+
+      .problem-grid {
+        grid-template-columns: 1fr;
+        gap: 48px;
+      }
+
+      .features-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .feature-card.featured {
+        grid-column: span 1;
+      }
+
+      .quickstart-steps {
+        grid-template-columns: 1fr;
+      }
+
+      .comparison-table-wrapper {
+        margin: 0 -24px;
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+      }
+
+      .install-option {
+        flex-direction: column;
+        gap: 12px;
+        align-items: flex-start;
+      }
+
+      .install-option-cmd {
+        padding-left: 0;
+      }
+
+      .footer-inner {
+        flex-direction: column;
+        gap: 16px;
+        text-align: center;
+      }
+
+      .footer-left {
+        flex-direction: column;
+        gap: 12px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .container { padding: 0 16px; }
+
+      .terminal-body {
+        font-size: 11px;
+        padding: 16px;
+      }
+
+      .hero-actions {
+        flex-direction: column;
+        width: 100%;
+      }
+
+      .btn-primary, .btn-secondary {
+        width: 100%;
+        justify-content: center;
+      }
+
+      .cta-actions {
+        flex-direction: column;
+      }
+    }
+
+    /* ================================================
+       SCROLLBAR
+       ================================================ */
+    ::-webkit-scrollbar { width: 8px; height: 8px; }
+    ::-webkit-scrollbar-track { background: var(--bg-deep); }
+    ::-webkit-scrollbar-thumb { background: var(--bg-card); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--bg-card-hover); }
+
+    /* ================================================
+       SELECTION
+       ================================================ */
+    ::selection {
+      background: rgba(79, 195, 247, 0.25);
+      color: var(--text-primary);
+    }
+
+    /* Demo Section */
+    .demo-section {
+      padding: 80px 0;
+    }
+
+    .demo-header {
+      text-align: center;
+      margin-bottom: 48px;
+    }
+
+    .demo-container {
+      max-width: 900px;
+      margin: 0 auto;
+      border-radius: 12px;
+      overflow: hidden;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+    }
+
+    .demo-gif {
+      width: 100%;
+      display: block;
+    }
+
+    /* ================================================
+       VERSION SWITCHER
+       ================================================ */
+    .version-switcher {
+      position: relative;
+      margin-left: 12px;
+    }
+    .version-btn {
+      background: var(--bg-raised);
+      color: var(--accent-cyan);
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-sm);
+      padding: 4px 10px;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: background 0.2s;
+      display: flex;
+      align-items: center;
+      gap: 2px;
+    }
+    .version-btn:hover { background: var(--bg-card); }
+    .version-arrow { font-size: 0.7rem; }
+    .version-dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 6px);
+      left: 0;
+      background: var(--bg-raised);
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-sm);
+      min-width: 160px;
+      z-index: 1000;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    }
+    .version-dropdown.open { display: block; }
+    .version-dropdown a {
+      display: block;
+      padding: 8px 14px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      transition: background 0.15s, color 0.15s;
+    }
+    .version-dropdown a:hover {
+      background: var(--bg-card);
+      color: var(--text-primary);
+    }
+    .version-dropdown a.active {
+      color: var(--accent-cyan);
+      background: var(--accent-glow);
+    }
+    .version-banner {
+      background: rgba(255, 193, 7, 0.12);
+      border-bottom: 1px solid rgba(255, 193, 7, 0.3);
+      color: #ffd54f;
+      text-align: center;
+      padding: 8px 16px;
+      font-family: var(--font-body);
+      font-size: 0.9rem;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 10000;
+    }
+    .version-banner a {
+      color: #fff;
+      text-decoration: underline;
+      margin-left: 4px;
+    }
+    .version-banner a:hover { color: var(--accent-cyan); }
+  </style>
+</head>
+<body>
+
+  <!-- ============ NAV ============ -->
+  <nav>
+    <div class="nav-inner">
+      <a href="/git-parsec/v/0.4.0/" class="nav-brand">
+        <div class="nav-brand-icon">P</div>
+        <span>git-parsec</span>
+      </a>
+      <ul class="nav-links">
+        <li><a href="#features">Features</a></li>
+        <li><a href="#comparison">Compare</a></li>
+        <li><a href="#quickstart">Quick Start</a></li>
+        <li><a href="/git-parsec/v/0.4.0/reference/">Docs</a></li>
+        <li><a href="#install">Install</a></li>
+      </ul>
+      <a href="https://github.com/erishforG/git-parsec" class="nav-cta" target="_blank" rel="noopener">
+        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        GitHub
+      </a>
+    </div>
+  </nav>
+
+  <!-- ============ HERO ============ -->
+  <section class="hero" id="hero">
+    <div class="container">
+      <div class="hero-grid">
+        <div>
+          <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+            <div class="hero-badge">Built with Rust</div>
+            <div class="hero-badge">AI-Native</div>
+          </div>
+          <h1>
+            From ticket to PR<br>
+            <span class="gradient-text">in one command.</span>
+          </h1>
+          <p class="hero-subtitle">
+            Run 5 AI agents in parallel — zero <code>index.lock</code> conflicts. git-parsec gives every agent its own isolated worktree, tied to your issue tracker. No retries, no wasted tokens, no merge chaos.
+          </p>
+          <div class="hero-actions">
+            <a href="#install" class="btn-primary">
+              Get Started
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+            </a>
+            <a href="https://github.com/erishforG/git-parsec" class="btn-secondary" target="_blank" rel="noopener">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+              View on GitHub
+            </a>
+            <a href="https://github.com/erishforG/git-parsec" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;">
+              <img src="https://img.shields.io/github/stars/erishforG/git-parsec?style=social" alt="GitHub Stars" style="height:28px;">
+            </a>
+          </div>
+        </div>
+        <div class="hero-terminal">
+          <div class="terminal-bar">
+            <div class="terminal-dot"></div>
+            <div class="terminal-dot"></div>
+            <div class="terminal-dot"></div>
+            <div class="terminal-title">parsec -- zsh</div>
+          </div>
+          <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Run 5 AI agents in parallel — no lock conflicts</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">CL-2283</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">Created worktree for </span><span class="arg">CL-2283</span></span>
+<span class="terminal-line"><span class="info">  Title: Collect HeuristicCompletionException handling</span></span>
+<span class="terminal-line"><span class="info">  Branch: </span><span class="link">feature/CL-2283</span></span>
+<span class="terminal-line"><span class="info">  Path: ../myproject.CL-2283</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Each agent gets its own isolated worktree</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">CL-2290</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">Created worktree for </span><span class="arg">CL-2290</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Ship it -- push, create PR, cleanup</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">CL-2283</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">Pushed </span><span class="link">feature/CL-2283</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">PR created: </span><span class="link">github.com/org/repo/pull/42</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">Worktree cleaned up</span></span>
+<span class="terminal-line typing">&nbsp;</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ PROBLEM / SOLUTION ============ -->
+  <section class="problem-section" id="problem">
+    <div class="container">
+      <div class="reveal">
+        <div class="section-label">The Problem</div>
+        <div class="section-title">Git wasn't built for<br>AI agent workflows.</div>
+        <p class="section-desc">
+          When AI agents run in parallel on the same repo, they collide on <code>.git/index.lock</code> — crashing mid-task, burning tokens on retries, and leaving broken state. Worktrees solve isolation, but lack the lifecycle management agents need.
+        </p>
+      </div>
+
+      <div class="problem-grid">
+        <div class="reveal reveal-delay-1">
+          <div class="problem-col-header bad">
+            Without parsec
+          </div>
+          <ul class="problem-list">
+            <li class="problem-item">
+              <div class="problem-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#ff5f57" stroke-width="2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </div>
+              <div>
+                <h4>Lock contention</h4>
+                <p>Parallel git operations collide on <code>.git/index.lock</code>, blocking agents and developers.</p>
+              </div>
+            </li>
+            <li class="problem-item">
+              <div class="problem-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#ff5f57" stroke-width="2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </div>
+              <div>
+                <h4>Manual worktree management</h4>
+                <p>Create branch, add worktree, remember paths, clean up manually. Error-prone and tedious.</p>
+              </div>
+            </li>
+            <li class="problem-item">
+              <div class="problem-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#ff5f57" stroke-width="2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </div>
+              <div>
+                <h4>No ticket connection</h4>
+                <p>Branches and worktrees have no link to your issue tracker. Context gets lost.</p>
+              </div>
+            </li>
+            <li class="problem-item">
+              <div class="problem-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#ff5f57" stroke-width="2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </div>
+              <div>
+                <h4>Invisible conflicts</h4>
+                <p>Parallel work silently edits the same files. You only find out at merge time.</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+
+        <div class="reveal reveal-delay-2">
+          <div class="problem-col-header good">
+            With parsec
+          </div>
+          <ul class="solution-list">
+            <li class="solution-item">
+              <div class="solution-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--accent-cyan)" stroke-width="2" stroke-linecap="round"><path d="M20 6L9 17l-5-5"/></svg>
+              </div>
+              <div>
+                <h4>Zero-conflict parallelism</h4>
+                <p>Each ticket gets its own isolated worktree. No lock contention, ever.</p>
+              </div>
+            </li>
+            <li class="solution-item">
+              <div class="solution-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--accent-cyan)" stroke-width="2" stroke-linecap="round"><path d="M20 6L9 17l-5-5"/></svg>
+              </div>
+              <div>
+                <h4>One-command lifecycle</h4>
+                <p><code>parsec start</code> creates everything. <code>parsec ship</code> pushes, PRs, and cleans up.</p>
+              </div>
+            </li>
+            <li class="solution-item">
+              <div class="solution-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--accent-cyan)" stroke-width="2" stroke-linecap="round"><path d="M20 6L9 17l-5-5"/></svg>
+              </div>
+              <div>
+                <h4>Ticket tracker integration</h4>
+                <p>Jira and GitHub Issues built in. Branches auto-named, PR titles auto-filled.</p>
+              </div>
+            </li>
+            <li class="solution-item">
+              <div class="solution-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--accent-cyan)" stroke-width="2" stroke-linecap="round"><path d="M20 6L9 17l-5-5"/></svg>
+              </div>
+              <div>
+                <h4>Early conflict detection</h4>
+                <p><code>parsec conflicts</code> warns when worktrees touch the same files -- before you merge.</p>
+              </div>
+            </li>
+            <li class="solution-item">
+              <div class="solution-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--accent-cyan)" stroke-width="2" stroke-linecap="round"><path d="M20 6L9 17l-5-5"/></svg>
+              </div>
+              <div>
+                <h4>Full operation history</h4>
+                <p><code>parsec log</code> shows everything parsec has done. <code>parsec undo</code> rolls back the last step if something goes wrong.</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ DEMO ============ -->
+  <section class="demo-section" id="demo">
+    <div class="container">
+      <div class="demo-header reveal">
+        <div class="section-label">See it in action</div>
+        <div class="section-title">From ticket to PR in 60 seconds.</div>
+      </div>
+      <div class="demo-container reveal reveal-delay-1">
+        <img src="/git-parsec/demo.gif" alt="git-parsec demo showing start, list, switch, log, undo, and clean commands" class="demo-gif" loading="lazy">
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ FEATURES ============ -->
+  <section class="features-section" id="features">
+    <div class="container">
+      <div class="features-header reveal">
+        <div class="section-label">Features</div>
+        <div class="section-title">Everything you need.<br>Nothing you don't.</div>
+        <p class="section-desc">
+          A focused toolset for the complete worktree lifecycle -- from creating isolated workspaces to shipping production-ready PRs.
+        </p>
+      </div>
+
+      <div class="features-grid">
+        <!-- 1. Ticket-driven worktrees -->
+        <div class="feature-card featured reveal reveal-delay-1">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/><path d="M9 14l2 2 4-4"/></svg>
+          </div>
+          <h3>Ticket-driven worktrees</h3>
+          <p>
+            <code>parsec start PROJ-123</code> creates an isolated worktree, fetches the title from your tracker (Jira · GitHub Issues · GitLab Issues · Bitbucket), and names the branch consistently. <code>parsec adopt</code> and <code>--branch</code> bring existing branches under management. Sibling layout (<code>../repo.ticket/</code>) keeps directories clean and IDE-friendly.
+          </p>
+          <div class="feature-code">$ parsec start PROJ-123 &nbsp;&nbsp;<span style="color: var(--text-muted)"># worktree + tracker fetch + branch in one call</span></div>
+        </div>
+
+        <!-- 2. Stacked PRs -->
+        <div class="feature-card featured reveal reveal-delay-2">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/></svg>
+          </div>
+          <h3>Stacked PRs done right</h3>
+          <p>
+            Chain workspaces with <code>parsec start CHILD --on PARENT</code>. <code>parsec stack --submit</code> opens every PR in the stack in topological order. Auto-posted <em>"← prev / next →"</em> navigation comments let reviewers walk the chain without leaving the PR view. <code>--sync</code> rebases the whole chain when the base moves.
+          </p>
+          <div class="feature-code">$ parsec stack --submit &nbsp;&nbsp;<span style="color: var(--text-muted)"># root first, with nav comments</span></div>
+        </div>
+
+        <!-- 3. Multi-forge -->
+        <div class="feature-card featured reveal reveal-delay-3">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+          </div>
+          <h3>Multi-forge, multi-CI</h3>
+          <p>
+            Full PR lifecycle on <strong>GitHub</strong>, <strong>GitLab</strong>, and <strong>Bitbucket Cloud</strong>. CI status from <strong>Actions</strong>, <strong>GitLab CI</strong>, and <strong>Bitbucket Pipelines</strong> — all surfaced through the same <code>parsec ci</code> and <code>parsec pr-status</code> commands. Auto-detected from the remote URL.
+          </p>
+          <div class="feature-code">$ parsec ci --watch &nbsp;&nbsp;<span style="color: var(--text-muted)"># works the same on any forge</span></div>
+        </div>
+
+        <!-- 4. One-step ship + lifecycle -->
+        <div class="feature-card featured reveal reveal-delay-1">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </div>
+          <h3>One-step ship + lifecycle</h3>
+          <p>
+            <code>parsec ship</code> pushes, opens the PR, and removes the worktree. <code>parsec merge</code> waits for CI, merges, and cleans up. <code>parsec clean</code> sweeps already-merged branches. <code>parsec conflicts</code> flags cross-worktree file overlap before push. <code>parsec undo</code> reverses the last operation. Every mutating command supports <code>--dry-run</code>.
+          </p>
+          <div class="feature-code">$ parsec ship PROJ-1234 &nbsp;&nbsp;<span style="color: var(--text-muted)"># push + PR + cleanup, one command</span></div>
+        </div>
+
+        <!-- 5. Agent-friendly -->
+        <div class="feature-card featured reveal reveal-delay-2">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M16 18l2-2v-4l2-2-2-2V4l-2-2"/><path d="M8 6L6 8v4l-2 2 2 2v4l2 2"/></svg>
+          </div>
+          <h3>Built for agents</h3>
+          <p>
+            <code>--json</code> on every command. Structured error codes (E001–E013) for programmatic handling. <code>parsec log --export</code> emits JSONL with execution IDs and per-step timing. <code>--offline</code> and headless modes for CI / air-gapped environments. The config JSON Schema is published to <a href="https://schemastore.org">schemastore.org</a> for editor autocomplete.
+          </p>
+          <div class="feature-code">$ parsec log --export | jq 'select(.duration_ms > 1000)'</div>
+        </div>
+
+        <!-- 6. Build cache + ergonomics -->
+        <div class="feature-card featured reveal reveal-delay-3">
+          <div class="feature-icon">
+            <svg viewBox="0 0 24 24"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
+          </div>
+          <h3>Build cache + ergonomics</h3>
+          <p>
+            <code>[worktree].shared_cache</code> shares <code>target/</code>, <code>node_modules/</code>, <code>.venv/</code> from the main repo to new worktrees via symlink (default) or copy — eliminates cold-build cost on <code>parsec start</code>. Shell integration auto-cd's, tab completions ship for zsh / bash / fish / powershell, <code>parsec doctor</code> validates your setup.
+          </p>
+          <div class="feature-code">shared_cache = ["target", "node_modules", ".venv"]</div>
+        </div>
+      </div>
+
+      <!-- More features (collapsed) -->
+      <details class="more-features reveal" style="margin-top: 48px; padding: 24px 28px; background: rgba(255,255,255,0.02); border: 1px solid var(--border); border-radius: 12px;">
+        <summary style="cursor: pointer; font-weight: 600; font-size: 16px; color: var(--text-primary); list-style: none;">
+          <span style="display: inline-flex; align-items: center; gap: 8px;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" style="transition: transform .2s;"><polyline points="9 18 15 12 9 6"/></svg>
+            More features
+            <span style="color: var(--text-muted); font-weight: 400;">— 16 additional capabilities</span>
+          </span>
+        </summary>
+        <div style="margin-top: 20px; display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 14px 32px; color: var(--text-secondary); font-size: 14px; line-height: 1.7;">
+          <div><strong>Branch sync</strong> — <code>parsec sync</code> rebases or merges the latest base branch into one or all worktrees.</div>
+          <div><strong>Operation history</strong> — <code>parsec log</code> shows every action with timestamps; filter by ticket or last N.</div>
+          <div><strong>Undo</strong> — <code>parsec undo</code> reverses the last start / ship / clean. Use <code>--dry-run</code> to preview.</div>
+          <div><strong>Open in browser</strong> — <code>parsec open</code> launches the PR or ticket page (GitHub / GitLab / Jira / Bitbucket).</div>
+          <div><strong>Worktree diff</strong> — <code>parsec diff</code> compares any worktree to its base branch (<code>--stat</code>, <code>--name-only</code>).</div>
+          <div><strong>Compress branch</strong> — <code>parsec compress</code> squashes commits into one tidy commit before shipping.</div>
+          <div><strong>PR template auto-fill</strong> — <code>ship --template</code> reads <code>.github/PULL_REQUEST_TEMPLATE.md</code>.</div>
+          <div><strong>Reviewers + labels</strong> — <code>ship --reviewer</code> / <code>--label</code> at PR creation time, or set defaults in config.</div>
+          <div><strong>Draft-by-default</strong> — <code>[ship].draft = true</code> opens every PR as a draft for WIP review.</div>
+          <div><strong>Pre-ship hooks</strong> — run <code>cargo test</code>, <code>npm run lint</code>, etc. before <code>ship</code> via <code>[hooks].pre_ship</code>.</div>
+          <div><strong>Sprint board</strong> — <code>parsec board</code> renders the active Jira sprint as a Kanban board in the terminal.</div>
+          <div><strong>Issue creation</strong> — <code>parsec create</code> / <code>new-issue</code> opens tickets in your tracker; <code>--start</code> immediately creates a worktree.</div>
+          <div><strong>Release workflow</strong> — <code>parsec release</code> merges develop → main, tags, and creates a GitHub Release.</div>
+          <div><strong>Policy guard</strong> — <code>[policy]</code> blocks ships to protected branches and restricts allowed targets.</div>
+          <div><strong>Headless mode</strong> — <code>--yes</code> and TTY auto-detection skip prompts in CI / agent environments.</div>
+          <div><strong>Cross-platform</strong> — Linux / macOS / Windows. Windows UNC path handling via the <code>dunce</code> crate.</div>
+        </div>
+        <div style="margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--border); font-size: 14px; color: var(--text-muted);">
+          See the <a href="/git-parsec/v/0.4.0/reference/" style="color: var(--accent);">full command reference</a> for every flag and example, or read the <a href="/git-parsec/v/0.4.0/guide/" style="color: var(--accent);">getting started guide</a>.
+        </div>
+      </details>
+    </div>
+  </section>
+
+  <!-- ============ COMPARISON ============ -->
+  <section class="comparison-section" id="comparison">
+    <div class="container">
+      <div class="comparison-header reveal">
+        <div class="section-label">Comparison</div>
+        <div class="section-title">How parsec stacks up.</div>
+        <p class="section-desc">
+          parsec fills the gap between bare git worktree commands and tools that don't connect to your issue tracker.
+        </p>
+      </div>
+
+      <div class="comparison-table-wrapper reveal reveal-delay-1">
+        <table class="comparison-table">
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th class="highlight">parsec</th>
+              <th>worktrunk</th>
+              <th>git worktree</th>
+              <th>git-town</th>
+              <th>GitButler</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Ticket tracker integration</td>
+              <td class="highlight"><span class="check">Jira + GitHub Issues</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Physical isolation (worktrees)</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="partial">Virtual branches</span></td>
+            </tr>
+            <tr>
+              <td>Cross-worktree conflict detection</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>One-step ship (push + PR/MR + clean)</td>
+              <td class="highlight"><span class="check">GitHub + GitLab</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Operation history &amp; undo</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="check">Yes (undo)</span></td>
+              <td><span class="check">Yes</span></td>
+            </tr>
+            <tr>
+              <td>JSON output for AI agents</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="check">Yes</span></td>
+            </tr>
+            <tr>
+              <td>CI monitoring</td>
+              <td class="highlight"><span class="check">Yes (--watch)</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Stacked PRs</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="check">Yes</span></td>
+            </tr>
+            <tr>
+              <td>Post-create hooks</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Auto-cleanup merged worktrees</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="partial">Manual</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+            <tr>
+              <td>Forge support</td>
+              <td class="highlight"><span class="check">GitHub + GitLab</span></td>
+              <td><span class="partial">GitHub</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="check">GH, GL, Gitea, BB</span></td>
+              <td><span class="check">GitHub + GitLab</span></td>
+            </tr>
+            <tr>
+              <td>Zero config start</td>
+              <td class="highlight"><span class="check">Yes</span></td>
+              <td><span class="check">Yes</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+              <td><span class="cross">--</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ QUICK START ============ -->
+  <section class="quickstart-section" id="quickstart">
+    <div class="container">
+      <div class="quickstart-header reveal">
+        <div class="section-label">Quick Start</div>
+        <div class="section-title">Up and running in 60 seconds.</div>
+        <p class="section-desc">
+          Three commands from install to your first PR.
+        </p>
+      </div>
+
+      <div class="quickstart-steps">
+        <div class="step-card reveal reveal-delay-1">
+          <div class="step-number">01</div>
+          <h3>Install</h3>
+          <p>Install via cargo. A single binary, no runtime dependencies.</p>
+          <div class="step-code">cargo install git-parsec</div>
+        </div>
+        <div class="step-card reveal reveal-delay-2">
+          <div class="step-number">02</div>
+          <h3>Configure</h3>
+          <p>Run interactive setup. Enable shell integration for auto-cd and merge recovery.</p>
+          <div class="step-code">parsec config init<br>eval "$(parsec init zsh)"</div>
+        </div>
+        <div class="step-card reveal reveal-delay-3">
+          <div class="step-number">03</div>
+          <h3>Start building</h3>
+          <p>Create a worktree from any ticket. Code, commit, and ship when ready.</p>
+          <div class="step-code">parsec start PROJ-42</div>
+        </div>
+      </div>
+
+      <!-- Full demo terminal -->
+      <div class="hero-terminal reveal reveal-delay-2" style="max-width: 800px; margin: 0 auto;">
+        <div class="terminal-bar">
+          <div class="terminal-dot"></div>
+          <div class="terminal-dot"></div>
+          <div class="terminal-dot"></div>
+          <div class="terminal-title">full workflow demo</div>
+        </div>
+        <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Create isolated workspace from Jira ticket</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">CL-2283</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">Created worktree for CL-2283</span></span>
+<span class="terminal-line"><span class="info">  Branch: feature/CL-2283</span></span>
+<span class="terminal-line"><span class="info">  Path:   ../myproject.CL-2283</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Switch into the worktree</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec switch</span> <span class="arg">CL-2283</span></span>
+<span class="terminal-line"><span class="info">  cd ../myproject.CL-2283</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># ... do your work, commit as usual ...</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Check for conflicts with other worktrees</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec conflicts</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">No file conflicts across 3 active worktrees</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Ship it -- push, create PR, cleanup</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">CL-2283</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">Pushed feature/CL-2283 (4 commits)</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">PR #42 created: </span><span class="link">github.com/org/repo/pull/42</span></span>
+<span class="terminal-line"><span class="success">&#10003;</span> <span class="info">Worktree cleaned up</span></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ INSTALL ============ -->
+  <section class="install-section" id="install">
+    <div class="container">
+      <div class="install-wrapper">
+        <div class="reveal">
+          <div class="section-label">Installation</div>
+          <div class="section-title">Install parsec.</div>
+          <p class="section-desc">
+            A single Rust binary. No runtime dependencies, no node_modules, no Python virtualenvs.
+          </p>
+        </div>
+
+        <div class="install-options reveal reveal-delay-1">
+          <div class="install-option">
+            <span class="install-option-label">Cargo</span>
+            <span class="install-option-cmd">cargo install git-parsec</span>
+            <span class="install-option-badge available">Available</span>
+          </div>
+          <div class="install-option">
+            <span class="install-option-label">Homebrew</span>
+            <span class="install-option-cmd">brew install git-parsec</span>
+            <span class="install-option-badge soon">Coming soon</span>
+          </div>
+          <div class="install-option">
+            <span class="install-option-label">From source</span>
+            <span class="install-option-cmd">git clone &amp;&amp; cargo build --release</span>
+            <span class="install-option-badge available">Available</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ CTA ============ -->
+  <section class="cta-section">
+    <div class="container">
+      <div class="reveal">
+        <div class="cta-title">
+          Let your AI agents run.<br>
+          <span class="gradient-text" style="background: linear-gradient(135deg, var(--accent-cyan) 0%, var(--accent-teal) 40%, var(--accent-electric) 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">Zero conflicts. Zero wasted tokens.</span>
+        </div>
+        <p class="cta-desc">
+          Join developers and AI teams who use parsec to run parallel agents on the same repo — isolated worktrees, no <code style="font-size: 0.9em; opacity: 0.85;">index.lock</code> fights, fewer retries.
+        </p>
+        <div class="cta-actions">
+          <a href="https://github.com/erishforG/git-parsec" class="btn-primary" target="_blank" rel="noopener">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            Star on GitHub
+          </a>
+          <div class="cta-install-cmd">
+            <span class="dollar">$</span> cargo install git-parsec
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ FOOTER ============ -->
+  <footer>
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-left">
+          <span class="footer-brand">git-parsec</span>
+          <ul class="footer-links">
+            <li><a href="https://github.com/erishforG/git-parsec" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://github.com/erishforG/git-parsec/issues" target="_blank" rel="noopener">Issues</a></li>
+            <li><a href="https://github.com/erishforG/git-parsec/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
+          </ul>
+        </div>
+        <div class="footer-right">
+          Built with Rust. Designed for velocity.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <!-- ============ SCROLL REVEAL (minimal JS, no libraries) ============ -->
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const reveals = document.querySelectorAll('.reveal');
+
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+          }
+        });
+      }, {
+        threshold: 0.1,
+        rootMargin: '0px 0px -40px 0px'
+      });
+
+      reveals.forEach(el => observer.observe(el));
+    });
+  </script>
+
+  <script src="/git-parsec/version-switcher.js"></script>
+</body>
+</html>

--- a/docs/v/0.4.0/reference/index.html
+++ b/docs/v/0.4.0/reference/index.html
@@ -1,0 +1,2645 @@
+<!DOCTYPE html>
+<html lang="en" data-doc-version="0.4.0">
+<head>
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex, follow">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Command Reference — git-parsec | All 27 commands, every flag, with examples</title>
+  <meta name="description" content="Full command reference for git-parsec CLI. All 27 commands (start, ship, stack, ci, merge, compress, schema, board, …), every flag, every option, with end-to-end examples.">
+  <meta name="keywords" content="git-parsec, parsec, command reference, CLI documentation, git worktree, parsec start, parsec ship, parsec stack, parsec ci, parsec merge, parsec compress, parsec schema">
+  <meta name="author" content="erishforG">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://erishforg.github.io/git-parsec/reference/">
+  <meta property="og:title" content="Command Reference — git-parsec">
+  <meta property="og:description" content="All 27 commands of git-parsec, every flag, with examples.">
+  <meta property="og:site_name" content="git-parsec">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://erishforg.github.io/git-parsec/demo.gif">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Command Reference — git-parsec">
+  <meta name="twitter:description" content="All 27 commands, every flag, with examples.">
+  <meta name="twitter:image" content="https://erishforg.github.io/git-parsec/demo.gif">
+  <meta name="theme-color" content="#0a0e1a">
+  <link rel="canonical" href="https://erishforg.github.io/git-parsec/reference/">
+  <link rel="alternate" type="text/plain" href="/git-parsec/llms.txt" title="LLM-friendly summary">
+  <link rel="alternate" type="text/plain" href="/git-parsec/llms-full.txt" title="LLM-friendly full text">
+  <!-- Schema.org Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": "git-parsec Command Reference",
+    "description": "Complete reference for all 27 git-parsec commands. Every option, argument, and example for start, ship, stack, ci, merge, compress, schema, board, and more.",
+    "url": "https://erishforg.github.io/git-parsec/reference/",
+    "image": "https://erishforg.github.io/git-parsec/demo.gif",
+    "author": { "@type": "Person", "name": "erishforG", "url": "https://github.com/erishforG" },
+    "publisher": { "@type": "Person", "name": "erishforG" },
+    "datePublished": "2026-04-22",
+    "dateModified": "2026-05-04",
+    "inLanguage": "en",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "git-parsec",
+      "url": "https://erishforg.github.io/git-parsec/"
+    },
+    "about": {
+      "@type": "SoftwareApplication",
+      "name": "git-parsec",
+      "applicationCategory": "DeveloperApplication",
+      "softwareVersion": "0.4.0"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://erishforg.github.io/git-parsec/" },
+      { "@type": "ListItem", "position": 2, "name": "Reference", "item": "https://erishforg.github.io/git-parsec/reference/" }
+    ]
+  }
+  </script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@400;500;600;700;800;900&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    /* ================================================
+       RESET & BASE
+       ================================================ */
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg-deep: #060a14;
+      --bg-base: #0a0e1a;
+      --bg-raised: #0f1424;
+      --bg-card: #111828;
+      --bg-card-hover: #151d30;
+
+      --accent-cyan: #4FC3F7;
+      --accent-blue: #2196F3;
+      --accent-teal: #26C6DA;
+      --accent-electric: #40E0D0;
+      --accent-purple: #7C4DFF;
+      --accent-glow: rgba(79, 195, 247, 0.15);
+      --accent-glow-strong: rgba(79, 195, 247, 0.3);
+
+      --text-primary: #e8edf5;
+      --text-secondary: #8892a4;
+      --text-muted: #5a6577;
+      --text-code: #b4c7e7;
+
+      --border-subtle: rgba(79, 195, 247, 0.08);
+      --border-accent: rgba(79, 195, 247, 0.2);
+
+      --radius-sm: 6px;
+      --radius-md: 12px;
+      --radius-lg: 20px;
+      --radius-xl: 28px;
+
+      --font-display: 'Outfit', sans-serif;
+      --font-body: 'Source Sans 3', sans-serif;
+      --font-mono: 'JetBrains Mono', monospace;
+
+      --sidebar-width: 260px;
+      --nav-height: 65px;
+    }
+
+    html {
+      scroll-behavior: smooth;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    body {
+      font-family: var(--font-body);
+      background: var(--bg-deep);
+      color: var(--text-primary);
+      line-height: 1.6;
+      overflow-x: hidden;
+    }
+
+    /* ================================================
+       STARFIELD BACKGROUND
+       ================================================ */
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background:
+        radial-gradient(1.5px 1.5px at 20% 30%, rgba(79, 195, 247, 0.4) 50%, transparent 50%),
+        radial-gradient(1px 1px at 40% 70%, rgba(255, 255, 255, 0.3) 50%, transparent 50%),
+        radial-gradient(1.2px 1.2px at 60% 20%, rgba(38, 198, 218, 0.35) 50%, transparent 50%),
+        radial-gradient(1px 1px at 80% 50%, rgba(255, 255, 255, 0.25) 50%, transparent 50%),
+        radial-gradient(1.3px 1.3px at 10% 80%, rgba(79, 195, 247, 0.3) 50%, transparent 50%),
+        radial-gradient(0.8px 0.8px at 70% 85%, rgba(255, 255, 255, 0.2) 50%, transparent 50%),
+        radial-gradient(1px 1px at 90% 15%, rgba(64, 224, 208, 0.3) 50%, transparent 50%),
+        radial-gradient(1.1px 1.1px at 35% 45%, rgba(255, 255, 255, 0.15) 50%, transparent 50%),
+        radial-gradient(0.9px 0.9px at 55% 65%, rgba(79, 195, 247, 0.2) 50%, transparent 50%),
+        radial-gradient(1px 1px at 85% 35%, rgba(255, 255, 255, 0.2) 50%, transparent 50%),
+        radial-gradient(1.4px 1.4px at 15% 55%, rgba(38, 198, 218, 0.25) 50%, transparent 50%),
+        radial-gradient(0.7px 0.7px at 45% 90%, rgba(255, 255, 255, 0.15) 50%, transparent 50%),
+        radial-gradient(1px 1px at 75% 10%, rgba(79, 195, 247, 0.25) 50%, transparent 50%),
+        radial-gradient(0.9px 0.9px at 25% 75%, rgba(255, 255, 255, 0.18) 50%, transparent 50%),
+        radial-gradient(1.2px 1.2px at 95% 60%, rgba(64, 224, 208, 0.2) 50%, transparent 50%),
+        radial-gradient(0.8px 0.8px at 5% 40%, rgba(255, 255, 255, 0.12) 50%, transparent 50%),
+        radial-gradient(1px 1px at 50% 5%, rgba(79, 195, 247, 0.3) 50%, transparent 50%),
+        radial-gradient(1.1px 1.1px at 65% 50%, rgba(255, 255, 255, 0.1) 50%, transparent 50%);
+      pointer-events: none;
+      z-index: 0;
+      animation: starDrift 120s linear infinite;
+    }
+
+    @keyframes starDrift {
+      0% { transform: translateY(0); }
+      100% { transform: translateY(-30px); }
+    }
+
+    /* ================================================
+       NAV
+       ================================================ */
+    nav {
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      z-index: 100;
+      padding: 16px 0;
+      background: rgba(6, 10, 20, 0.85);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border-subtle);
+      height: var(--nav-height);
+    }
+
+    .nav-inner {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 0 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      text-decoration: none;
+      color: var(--text-primary);
+    }
+
+    .nav-brand-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      background: linear-gradient(135deg, var(--accent-cyan), var(--accent-teal));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+      font-weight: 700;
+      color: var(--bg-deep);
+      font-family: var(--font-mono);
+    }
+
+    .nav-brand span {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 18px;
+      letter-spacing: -0.02em;
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 32px;
+      list-style: none;
+    }
+
+    .nav-links a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    .nav-links a:hover {
+      color: var(--accent-cyan);
+    }
+
+    .nav-links a.active {
+      color: var(--accent-cyan);
+    }
+
+    .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 20px;
+      background: transparent;
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-sm);
+      color: var(--accent-cyan);
+      text-decoration: none;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all 0.25s;
+    }
+
+    .nav-cta:hover {
+      background: var(--accent-glow);
+      border-color: var(--accent-cyan);
+      box-shadow: 0 0 20px rgba(79, 195, 247, 0.15);
+    }
+
+    .nav-cta svg { width: 16px; height: 16px; }
+
+    /* ================================================
+       DOCS LAYOUT
+       ================================================ */
+    .docs-layout {
+      display: flex;
+      min-height: 100vh;
+      padding-top: var(--nav-height);
+      position: relative;
+      z-index: 1;
+    }
+
+    /* ================================================
+       SIDEBAR
+       ================================================ */
+    .sidebar {
+      width: var(--sidebar-width);
+      flex-shrink: 0;
+      position: fixed;
+      top: var(--nav-height);
+      left: 0;
+      bottom: 0;
+      overflow-y: auto;
+      background: var(--bg-card);
+      border-right: 1px solid var(--border-subtle);
+      padding: 32px 0 48px;
+      z-index: 10;
+    }
+
+    .sidebar::-webkit-scrollbar { width: 4px; }
+    .sidebar::-webkit-scrollbar-track { background: transparent; }
+    .sidebar::-webkit-scrollbar-thumb { background: var(--bg-raised); border-radius: 2px; }
+
+    .sidebar-header {
+      padding: 0 20px 20px;
+      border-bottom: 1px solid var(--border-subtle);
+      margin-bottom: 16px;
+    }
+
+    .sidebar-title {
+      font-family: var(--font-display);
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-muted);
+    }
+
+    .sidebar-section {
+      margin-bottom: 8px;
+    }
+
+    .sidebar-category {
+      padding: 8px 20px 6px;
+      font-family: var(--font-mono);
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-muted);
+      margin-top: 16px;
+    }
+
+    .sidebar-nav {
+      list-style: none;
+    }
+
+    .sidebar-nav li a {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 7px 20px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      transition: all 0.15s;
+      border-left: 2px solid transparent;
+    }
+
+    .sidebar-nav li a:hover {
+      color: var(--text-primary);
+      background: rgba(79, 195, 247, 0.04);
+      border-left-color: var(--border-accent);
+    }
+
+    .sidebar-nav li a.active {
+      color: var(--accent-cyan);
+      background: var(--accent-glow);
+      border-left-color: var(--accent-cyan);
+    }
+
+    .sidebar-nav li a .cmd-badge {
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-left: auto;
+      font-family: var(--font-mono);
+    }
+
+    /* ================================================
+       MAIN CONTENT
+       ================================================ */
+    .docs-main {
+      flex: 1;
+      margin-left: var(--sidebar-width);
+      min-width: 0;
+    }
+
+    .docs-content {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 56px 48px 120px;
+    }
+
+    /* Page header */
+    .page-header {
+      margin-bottom: 64px;
+      padding-bottom: 40px;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .page-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent-cyan);
+      margin-bottom: 16px;
+    }
+
+    .page-label::before {
+      content: '';
+      width: 20px;
+      height: 1px;
+      background: var(--accent-cyan);
+    }
+
+    .page-title {
+      font-family: var(--font-display);
+      font-size: clamp(32px, 4vw, 48px);
+      font-weight: 800;
+      line-height: 1.1;
+      letter-spacing: -0.03em;
+      margin-bottom: 16px;
+    }
+
+    .page-title .gradient-text {
+      background: linear-gradient(135deg, var(--accent-cyan) 0%, var(--accent-teal) 40%, var(--accent-electric) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .page-desc {
+      font-size: 17px;
+      color: var(--text-secondary);
+      line-height: 1.7;
+      max-width: 600px;
+    }
+
+    /* Global options callout */
+    .global-options-banner {
+      background: var(--accent-glow);
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-md);
+      padding: 20px 24px;
+      margin-bottom: 56px;
+    }
+
+    .global-options-banner h4 {
+      font-family: var(--font-display);
+      font-size: 14px;
+      font-weight: 700;
+      color: var(--accent-cyan);
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .global-options-banner h4::before {
+      content: '';
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--accent-cyan);
+    }
+
+    .global-options-banner .flag-list {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .flag-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 12px;
+      background: rgba(79, 195, 247, 0.08);
+      border: 1px solid var(--border-accent);
+      border-radius: 100px;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--text-code);
+    }
+
+    .flag-chip .flag-desc {
+      color: var(--text-muted);
+      font-size: 11px;
+    }
+
+    /* ================================================
+       COMMAND SECTIONS
+       ================================================ */
+    .cmd-section {
+      margin-bottom: 80px;
+      scroll-margin-top: calc(var(--nav-height) + 24px);
+    }
+
+    .cmd-section-divider {
+      margin-bottom: 48px;
+      padding-bottom: 20px;
+      border-bottom: 1px solid var(--border-subtle);
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .cmd-section-divider h2 {
+      font-family: var(--font-display);
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-muted);
+    }
+
+    .cmd-section-divider::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: var(--border-subtle);
+    }
+
+    /* Individual command block */
+    .cmd-block {
+      margin-bottom: 64px;
+      scroll-margin-top: calc(var(--nav-height) + 24px);
+    }
+
+    .cmd-heading {
+      display: flex;
+      align-items: baseline;
+      gap: 16px;
+      margin-bottom: 10px;
+      flex-wrap: wrap;
+    }
+
+    .cmd-name {
+      font-family: var(--font-mono);
+      font-size: 24px;
+      font-weight: 700;
+      color: var(--accent-cyan);
+    }
+
+    .cmd-short-desc {
+      font-size: 15px;
+      color: var(--text-secondary);
+    }
+
+    .cmd-anchor {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 18px;
+      opacity: 0;
+      transition: opacity 0.2s;
+      margin-left: 4px;
+    }
+
+    .cmd-heading:hover .cmd-anchor { opacity: 1; }
+
+    /* Usage block */
+    .usage-block {
+      background: var(--bg-raised);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      padding: 18px 22px;
+      margin: 16px 0 24px;
+      font-family: var(--font-mono);
+      font-size: 14px;
+      color: var(--text-code);
+      overflow-x: auto;
+    }
+
+    .usage-block .usage-label {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+      display: block;
+    }
+
+    .usage-block code {
+      color: var(--text-primary);
+    }
+
+    .usage-block .arg { color: #ffb74d; }
+    .usage-block .opt { color: var(--accent-purple); }
+    .usage-block .cmd-kw { color: var(--accent-cyan); }
+
+    /* Tables */
+    .ref-table-wrap {
+      margin: 20px 0;
+      overflow-x: auto;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--border-subtle);
+    }
+
+    .ref-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+
+    .ref-table thead th {
+      padding: 12px 16px;
+      text-align: left;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      background: var(--bg-raised);
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .ref-table tbody td {
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border-subtle);
+      vertical-align: top;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .ref-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .ref-table tbody tr:hover td {
+      background: rgba(79, 195, 247, 0.02);
+    }
+
+    .ref-table td:first-child {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--text-code);
+      white-space: nowrap;
+    }
+
+    .ref-table td .arg-type {
+      font-size: 11px;
+      color: var(--text-muted);
+      font-family: var(--font-mono);
+    }
+
+    .ref-table .req-badge {
+      display: inline-block;
+      padding: 1px 7px;
+      border-radius: 100px;
+      font-size: 10px;
+      font-family: var(--font-mono);
+      font-weight: 600;
+      background: rgba(255, 183, 77, 0.1);
+      color: #ffb74d;
+      border: 1px solid rgba(255, 183, 77, 0.2);
+      margin-left: 6px;
+    }
+
+    /* Terminal code blocks */
+    .terminal-wrap {
+      margin: 20px 0;
+      background: var(--bg-base);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow:
+        0 4px 6px rgba(0, 0, 0, 0.3),
+        0 12px 32px rgba(0, 0, 0, 0.35),
+        0 0 0 1px rgba(79, 195, 247, 0.04);
+    }
+
+    .terminal-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 16px;
+      background: var(--bg-raised);
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .terminal-dot {
+      width: 11px;
+      height: 11px;
+      border-radius: 50%;
+    }
+
+    .terminal-dot:nth-child(1) { background: #ff5f57; }
+    .terminal-dot:nth-child(2) { background: #febc2e; }
+    .terminal-dot:nth-child(3) { background: #28c840; }
+
+    .terminal-title-label {
+      flex: 1;
+      text-align: center;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-right: 30px;
+    }
+
+    .terminal-body {
+      padding: 20px 24px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.8;
+      overflow-x: auto;
+    }
+
+    .terminal-body .comment { color: var(--text-muted); }
+    .terminal-body .prompt { color: var(--accent-cyan); }
+    .terminal-body .command { color: var(--text-primary); }
+    .terminal-body .flag { color: var(--accent-purple); }
+    .terminal-body .success { color: #28c840; }
+    .terminal-body .info { color: var(--text-secondary); }
+    .terminal-body .link { color: var(--accent-teal); }
+    .terminal-body .arg { color: #ffb74d; }
+    .terminal-body .output { color: var(--text-secondary); }
+
+    .terminal-line {
+      display: block;
+      white-space: pre;
+    }
+
+    /* Section table of contents label */
+    .section-group-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent-cyan);
+      margin-bottom: 12px;
+    }
+
+    .section-group-label::before {
+      content: '';
+      width: 16px;
+      height: 1px;
+      background: var(--accent-cyan);
+    }
+
+    /* inline code */
+    code {
+      font-family: var(--font-mono);
+      font-size: 0.88em;
+      color: var(--text-code);
+      background: rgba(79, 195, 247, 0.07);
+      border: 1px solid rgba(79, 195, 247, 0.12);
+      border-radius: 4px;
+      padding: 1px 6px;
+    }
+
+    /* ================================================
+       FOOTER
+       ================================================ */
+    .docs-footer {
+      position: relative;
+      z-index: 1;
+      padding: 32px 0;
+      border-top: 1px solid var(--border-subtle);
+      margin-left: var(--sidebar-width);
+    }
+
+    .footer-inner {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 0 48px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .footer-left {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+    }
+
+    .footer-brand {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 15px;
+      color: var(--text-secondary);
+    }
+
+    .footer-links {
+      display: flex;
+      gap: 20px;
+      list-style: none;
+    }
+
+    .footer-links a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 13px;
+      transition: color 0.2s;
+    }
+
+    .footer-links a:hover { color: var(--accent-cyan); }
+
+    .footer-right {
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    /* ================================================
+       RESPONSIVE — Mobile sidebar
+       ================================================ */
+    @media (max-width: 900px) {
+      :root { --sidebar-width: 0px; }
+
+      .sidebar {
+        position: static;
+        width: 100%;
+        height: auto;
+        border-right: none;
+        border-bottom: 1px solid var(--border-subtle);
+        overflow-x: auto;
+        overflow-y: hidden;
+        white-space: nowrap;
+        padding: 12px 0;
+        display: flex;
+        flex-direction: row;
+        gap: 0;
+        background: var(--bg-card);
+      }
+
+      .sidebar-header { display: none; }
+
+      .sidebar-section {
+        display: inline-flex;
+        flex-direction: row;
+        margin-bottom: 0;
+      }
+
+      .sidebar-category { display: none; }
+
+      .sidebar-nav {
+        display: inline-flex;
+        flex-direction: row;
+      }
+
+      .sidebar-nav li a {
+        border-left: none;
+        border-bottom: 2px solid transparent;
+        padding: 8px 14px;
+        white-space: nowrap;
+        font-size: 12px;
+      }
+
+      .sidebar-nav li a.active {
+        border-left: none;
+        border-bottom-color: var(--accent-cyan);
+      }
+
+      .docs-layout {
+        flex-direction: column;
+      }
+
+      .docs-main {
+        margin-left: 0;
+      }
+
+      .docs-content {
+        padding: 32px 20px 80px;
+      }
+
+      .docs-footer {
+        margin-left: 0;
+      }
+
+      .footer-inner {
+        padding: 0 20px;
+        flex-direction: column;
+        gap: 16px;
+        text-align: center;
+      }
+
+      .footer-left {
+        flex-direction: column;
+        gap: 12px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav-links { display: none; }
+      .cmd-name { font-size: 20px; }
+      .terminal-body { font-size: 11px; padding: 14px 16px; }
+    }
+
+    /* ================================================
+       SCROLLBAR
+       ================================================ */
+    ::-webkit-scrollbar { width: 8px; height: 8px; }
+    ::-webkit-scrollbar-track { background: var(--bg-deep); }
+    ::-webkit-scrollbar-thumb { background: var(--bg-card); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--bg-card-hover); }
+
+    ::selection {
+      background: rgba(79, 195, 247, 0.25);
+      color: var(--text-primary);
+    }
+
+    /* Reveal animation */
+    .reveal {
+      opacity: 0;
+      transform: translateY(16px);
+      transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+    }
+    .reveal.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    /* ================================================
+       VERSION SWITCHER
+       ================================================ */
+    .version-switcher {
+      position: relative;
+      margin-left: 12px;
+    }
+    .version-btn {
+      background: var(--bg-raised);
+      color: var(--accent-cyan);
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-sm);
+      padding: 4px 10px;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: background 0.2s;
+      display: flex;
+      align-items: center;
+      gap: 2px;
+    }
+    .version-btn:hover { background: var(--bg-card); }
+    .version-arrow { font-size: 0.7rem; }
+    .version-dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 6px);
+      left: 0;
+      background: var(--bg-raised);
+      border: 1px solid var(--border-accent);
+      border-radius: var(--radius-sm);
+      min-width: 160px;
+      z-index: 1000;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    }
+    .version-dropdown.open { display: block; }
+    .version-dropdown a {
+      display: block;
+      padding: 8px 14px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      transition: background 0.15s, color 0.15s;
+    }
+    .version-dropdown a:hover {
+      background: var(--bg-card);
+      color: var(--text-primary);
+    }
+    .version-dropdown a.active {
+      color: var(--accent-cyan);
+      background: var(--accent-glow);
+    }
+    .version-banner {
+      background: rgba(255, 193, 7, 0.12);
+      border-bottom: 1px solid rgba(255, 193, 7, 0.3);
+      color: #ffd54f;
+      text-align: center;
+      padding: 8px 16px;
+      font-family: var(--font-body);
+      font-size: 0.9rem;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 10000;
+    }
+    .version-banner a {
+      color: #fff;
+      text-decoration: underline;
+      margin-left: 4px;
+    }
+    .version-banner a:hover { color: var(--accent-cyan); }
+  </style>
+</head>
+<body>
+
+  <!-- ============ NAV ============ -->
+  <nav>
+    <div class="nav-inner">
+      <a href="/git-parsec/v/0.4.0/" class="nav-brand">
+        <div class="nav-brand-icon">P</div>
+        <span>git-parsec</span>
+      </a>
+      <ul class="nav-links">
+        <li><a href="/git-parsec/v/0.4.0/#features">Features</a></li>
+        <li><a href="/git-parsec/v/0.4.0/#comparison">Compare</a></li>
+        <li><a href="/git-parsec/v/0.4.0/#quickstart">Quick Start</a></li>
+        <li><a href="/git-parsec/v/0.4.0/reference/" class="active">Docs</a></li>
+        <li><a href="/git-parsec/v/0.4.0/#install">Install</a></li>
+      </ul>
+      <a href="https://github.com/erishforG/git-parsec" class="nav-cta" target="_blank" rel="noopener">
+        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        GitHub
+      </a>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+
+    <!-- ============ SIDEBAR ============ -->
+    <aside class="sidebar" id="sidebar">
+      <div class="sidebar-header">
+        <div class="sidebar-title">Command Reference</div>
+      </div>
+
+      <!-- Core Workflow -->
+      <div class="sidebar-section">
+        <div class="sidebar-category">Core Workflow</div>
+        <ul class="sidebar-nav">
+          <li><a href="#start">start</a></li>
+          <li><a href="#list">list</a></li>
+          <li><a href="#switch">switch</a></li>
+          <li><a href="#ship">ship</a></li>
+          <li><a href="#merge">merge</a></li>
+          <li><a href="#clean">clean</a></li>
+          <li><a href="#create">create</a></li>
+          <li><a href="#new-issue">new-issue</a></li>
+          <li><a href="#rename">rename</a></li>
+          <li><a href="#compress">compress</a></li>
+          <li><a href="#release">release</a></li>
+        </ul>
+      </div>
+
+      <!-- Inspection -->
+      <div class="sidebar-section">
+        <div class="sidebar-category">Inspection</div>
+        <ul class="sidebar-nav">
+          <li><a href="#status">status</a></li>
+          <li><a href="#ticket">ticket</a></li>
+          <li><a href="#diff">diff</a></li>
+          <li><a href="#conflicts">conflicts</a></li>
+          <li><a href="#pr-status">pr-status</a></li>
+          <li><a href="#ci">ci</a></li>
+        </ul>
+      </div>
+
+      <!-- Advanced -->
+      <div class="sidebar-section">
+        <div class="sidebar-category">Advanced</div>
+        <ul class="sidebar-nav">
+          <li><a href="#sync">sync</a></li>
+          <li><a href="#open">open</a></li>
+          <li><a href="#adopt">adopt</a></li>
+          <li><a href="#stack">stack</a></li>
+          <li><a href="#inbox">inbox</a></li>
+          <li><a href="#board">board</a></li>
+        </ul>
+      </div>
+
+      <!-- History -->
+      <div class="sidebar-section">
+        <div class="sidebar-category">History</div>
+        <ul class="sidebar-nav">
+          <li><a href="#log">log</a></li>
+          <li><a href="#undo">undo</a></li>
+        </ul>
+      </div>
+
+      <!-- Setup -->
+      <div class="sidebar-section">
+        <div class="sidebar-category">Setup</div>
+        <ul class="sidebar-nav">
+          <li><a href="#root">root</a></li>
+          <li><a href="#init">init</a></li>
+          <li><a href="#config">config</a></li>
+          <li><a href="#doctor">doctor</a></li>
+        </ul>
+      </div>
+
+      <!-- Reference -->
+      <div class="sidebar-section">
+        <div class="sidebar-category">Reference</div>
+        <ul class="sidebar-nav">
+          <li><a href="#error-codes">Error Codes</a></li>
+          <li><a href="#policy-config">Policy Config</a></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- ============ MAIN CONTENT ============ -->
+    <main class="docs-main">
+      <div class="docs-content">
+
+        <!-- Page Header -->
+        <div class="page-header reveal">
+          <div class="page-label">Documentation</div>
+          <h1 class="page-title">Command <span class="gradient-text">Reference</span></h1>
+          <p class="page-desc">
+            Complete reference for all <code>parsec</code> commands. Every option, argument, and example in one place.
+          </p>
+        </div>
+
+        <!-- Global Options Banner -->
+        <div class="global-options-banner reveal">
+          <h4>Global Options — available on every command</h4>
+          <div class="flag-list">
+            <div class="flag-chip"><code>--json</code> <span class="flag-desc">machine-readable output</span></div>
+            <div class="flag-chip"><code>-q</code> / <code>--quiet</code> <span class="flag-desc">suppress non-essential output</span></div>
+            <div class="flag-chip"><code>--repo &lt;PATH&gt;</code> <span class="flag-desc">target repository path</span></div>
+            <div class="flag-chip"><code>--dry-run</code> <span class="flag-desc">preview changes without executing</span></div>
+            <div class="flag-chip"><code>--offline</code> <span class="flag-desc">skip all network ops (tracker, PR, fetch)</span></div>
+          </div>
+        </div>
+
+        <!-- ==============================
+             CORE WORKFLOW
+             ============================== -->
+        <div class="cmd-section" id="core-workflow">
+          <div class="cmd-section-divider">
+            <h2>Core Workflow</h2>
+          </div>
+
+          <!-- start -->
+          <div class="cmd-block reveal" id="start">
+            <div class="cmd-heading">
+              <span class="cmd-name">start</span>
+              <span class="cmd-short-desc">Create a new worktree for a ticket</span>
+              <a href="#start" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Creates a new git worktree tied to a ticket ID. Fetches the ticket title from your configured tracker (Jira, GitHub Issues, or GitLab), names the branch consistently, and sets up an isolated workspace directory alongside your main repo.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec start</span> <span class="arg">&lt;TICKET&gt;</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Argument</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><code>&lt;TICKET&gt;</code> <span class="req-badge">required</span></td>
+                    <td>Ticket ID to create a worktree for (e.g. <code>PROJ-123</code>, <code>42</code>).</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--base &lt;BRANCH&gt;</code></td><td>Base branch to create the worktree from. Defaults to the repo's default branch.</td></tr>
+                  <tr><td><code>--title &lt;TEXT&gt;</code></td><td>Override the ticket title (useful when offline or using an unsupported tracker).</td></tr>
+                  <tr><td><code>--on &lt;TICKET&gt;</code></td><td>Set this worktree's base to another ticket's branch, creating a stacked PR dependency.</td></tr>
+                  <tr><td><code>--branch &lt;NAME&gt;</code></td><td>Override the generated branch name.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec start</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Create workspace from a Jira ticket</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created worktree for </span><span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  Title:  Add user authentication flow</span></span>
+<span class="terminal-line"><span class="info">  Branch: </span><span class="link">feature/PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  Path:   ../myrepo.PROJ-123</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Stack on another ticket (for dependent PRs)</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">PROJ-124</span> <span class="flag">--on</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created worktree, base: </span><span class="link">feature/PROJ-123</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Offline — override title manually</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">PROJ-125</span> <span class="flag">--title</span> <span class="arg">"Fix login redirect"</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- list -->
+          <div class="cmd-block reveal" id="list">
+            <div class="cmd-heading">
+              <span class="cmd-name">list</span>
+              <span class="cmd-short-desc">List all active worktrees</span>
+              <a href="#list" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Displays all active parsec-managed worktrees with their ticket IDs, branch names, PR status, and paths. Use <code>--full</code> to include unpushed commit counts, ahead/behind divergence, and last commit metadata per worktree.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec list</span> <span class="opt">[--full] [--no-pr]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--full</code></td><td>Show extended metadata: unpushed commits, ahead/behind divergence, last commit message and age.</td></tr>
+                  <tr><td><code>--no-pr</code></td><td>Skip fetching PR status from GitHub/GitLab (faster output, works offline).</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec list</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec list</span></span>
+<span class="terminal-line"><span class="output">  TICKET     BRANCH               STATUS    PATH</span></span>
+<span class="terminal-line"><span class="output">  ─────────────────────────────────────────────────────────────</span></span>
+<span class="terminal-line"><span class="arg">  PROJ-123</span>   <span class="link">feature/PROJ-123</span>     <span class="success">open PR</span>  <span class="info">../myrepo.PROJ-123</span></span>
+<span class="terminal-line"><span class="arg">  PROJ-125</span>   <span class="link">feature/PROJ-125</span>     <span class="info">no PR</span>    <span class="info">../myrepo.PROJ-125</span></span>
+<span class="terminal-line"><span class="arg">  PROJ-130</span>   <span class="link">feature/PROJ-130</span>     <span class="success">merged</span>   <span class="info">../myrepo.PROJ-130</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Extended metadata per worktree</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec list</span> <span class="flag">--full</span></span>
+<span class="terminal-line"><span class="output">  TICKET   BRANCH            STATUS  AHEAD/BEHIND  UNPUSHED  LAST COMMIT          AGE</span></span>
+<span class="terminal-line"><span class="output">  ──────────────────────────────────────────────────────────────────────────────────────</span></span>
+<span class="terminal-line"><span class="arg">  PROJ-123</span> <span class="link">feature/PROJ-123</span> <span class="success">open PR</span> <span class="info">+3 / -0</span>      <span class="info">1</span>         <span class="info">Add rate limiting</span>    <span class="info">2h ago</span></span>
+<span class="terminal-line"><span class="arg">  PROJ-125</span> <span class="link">feature/PROJ-125</span> <span class="info">no PR</span>   <span class="info">+1 / -2</span>      <span class="info">0</span>         <span class="info">Fix auth redirect</span>    <span class="info">30m ago</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- switch -->
+          <div class="cmd-block reveal" id="switch">
+            <div class="cmd-heading">
+              <span class="cmd-name">switch</span>
+              <span class="cmd-short-desc">Print workspace path (auto-cd with shell integration)</span>
+              <a href="#switch" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Prints the path to a ticket's worktree. With shell integration active (<code>eval "$(parsec init zsh)"</code>), your shell automatically <code>cd</code>s into that directory. Without shell integration it prints the path for use in scripts.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec switch</span> <span class="arg">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Argument</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><code>[TICKET]</code></td>
+                    <td>Ticket ID to switch to. If omitted, shows an interactive picker.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec switch</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># With shell integration — auto-cd into the worktree</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec switch</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  ~/projects/myrepo.PROJ-123</span></span>
+<span class="terminal-line"><span class="comment"># shell: cd ~/projects/myrepo.PROJ-123</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Without shell integration — use in a subshell</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">cd</span> $(<span class="command">parsec switch</span> <span class="arg">PROJ-123</span>)</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- ship -->
+          <div class="cmd-block reveal" id="ship">
+            <div class="cmd-heading">
+              <span class="cmd-name">ship</span>
+              <span class="cmd-short-desc">Push, create PR/MR, and clean up</span>
+              <a href="#ship" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              The one-command shipping workflow. Pushes your branch to the remote, creates a Pull Request (or Merge Request on GitLab) with the ticket title pre-filled, and removes the worktree. All in a single step.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec ship</span> <span class="arg">&lt;TICKET&gt;</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Argument</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>&lt;TICKET&gt;</code> <span class="req-badge">required</span></td><td>Ticket ID of the worktree to ship.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--draft</code></td><td>Open the PR as a draft (GitHub only).</td></tr>
+                  <tr><td><code>--no-pr</code></td><td>Push the branch but skip creating a PR/MR.</td></tr>
+                  <tr><td><code>--base &lt;BRANCH&gt;</code></td><td>Override the target base branch for the PR.</td></tr>
+                  <tr><td><code>--skip-hooks</code></td><td>Skip pre-ship hooks defined in <code>[hooks]</code> config.</td></tr>
+                  <tr><td><code>-r, --reviewer &lt;USER&gt;</code></td><td>Request review from a GitHub user (repeatable).</td></tr>
+                  <tr><td><code>-l, --label &lt;NAME&gt;</code></td><td>Add a label to the PR (repeatable).</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec ship</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Pushed </span><span class="link">feature/PROJ-123</span><span class="info"> (7 commits)</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR #42 created: </span><span class="link">github.com/org/myrepo/pull/42</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Worktree cleaned up</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Open as draft PR</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-125</span> <span class="flag">--draft</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Draft PR created: </span><span class="link">github.com/org/myrepo/pull/43</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Ship with reviewers and labels</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-126</span> <span class="flag">--reviewer alice --reviewer bob --label needs-review</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR #44 created with reviewers and labels</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- merge -->
+          <div class="cmd-block reveal" id="merge">
+            <div class="cmd-heading">
+              <span class="cmd-name">merge</span>
+              <span class="cmd-short-desc">Merge PR on GitHub and clean up</span>
+              <a href="#merge" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Merges the PR associated with a ticket via the GitHub API, waits for the merge to complete, deletes the remote branch, and removes the local worktree. Returns you to the main repository.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec merge</span> <span class="arg">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--rebase</code></td><td>Use rebase strategy instead of merge commit.</td></tr>
+                  <tr><td><code>--no-wait</code></td><td>Trigger the merge and return immediately without waiting.</td></tr>
+                  <tr><td><code>--no-delete-branch</code></td><td>Keep the remote branch after merging.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec merge</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec merge</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">PR #42 merged into </span><span class="link">main</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Remote branch deleted</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Worktree removed</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- clean -->
+          <div class="cmd-block reveal" id="clean">
+            <div class="cmd-heading">
+              <span class="cmd-name">clean</span>
+              <span class="cmd-short-desc">Remove merged or stale worktrees</span>
+              <a href="#clean" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Scans all parsec-managed worktrees and removes those whose PRs have been merged or whose branches no longer exist on the remote. Use <code>--dry-run</code> to preview what would be removed.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec clean</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--all</code></td><td>Remove ALL parsec worktrees regardless of PR status.</td></tr>
+                  <tr><td><code>--dry-run</code></td><td>Preview what would be removed without deleting anything.</td></tr>
+                  <tr><td><code>--orphans</code></td><td>Also remove worktrees not tracked by parsec.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec clean</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Preview first</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec clean</span> <span class="flag">--dry-run</span></span>
+<span class="terminal-line"><span class="info">  Would remove: ../myrepo.PROJ-123 (merged)</span></span>
+<span class="terminal-line"><span class="info">  Would remove: ../myrepo.PROJ-130 (merged)</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec clean</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Removed 2 merged worktrees</span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ==============================
+             INSPECTION
+             ============================== -->
+        <div class="cmd-section" id="inspection">
+          <div class="cmd-section-divider">
+            <h2>Inspection</h2>
+          </div>
+
+          <!-- status -->
+          <div class="cmd-block reveal" id="status">
+            <div class="cmd-heading">
+              <span class="cmd-name">status</span>
+              <span class="cmd-short-desc">Show detailed workspace status</span>
+              <a href="#status" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Shows the full status of a worktree: uncommitted changes, commits ahead of base, PR state, CI checks, and ticket metadata.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec status</span> <span class="arg">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec status</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec status</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  Ticket:   PROJ-123 — Add user authentication flow</span></span>
+<span class="terminal-line"><span class="info">  Branch:   </span><span class="link">feature/PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  Ahead:    3 commits ahead of main</span></span>
+<span class="terminal-line"><span class="info">  Changed:  2 files modified, 1 untracked</span></span>
+<span class="terminal-line"><span class="info">  PR:       </span><span class="success">#42 open — 1 review approved</span></span>
+<span class="terminal-line"><span class="info">  CI:       </span><span class="success">passing (3/3 checks)</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- ticket -->
+          <div class="cmd-block reveal" id="ticket">
+            <div class="cmd-heading">
+              <span class="cmd-name">ticket</span>
+              <span class="cmd-short-desc">View ticket details from tracker</span>
+              <a href="#ticket" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Fetches and displays full ticket details from your configured issue tracker (Jira, GitHub Issues, or GitLab). Optionally shows comments.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec ticket</span> <span class="arg">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--comment</code></td><td>Include comments in the output.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec ticket</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ticket</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  [PROJ-123] Add user authentication flow</span></span>
+<span class="terminal-line"><span class="info">  Status:   In Progress</span></span>
+<span class="terminal-line"><span class="info">  Priority: High</span></span>
+<span class="terminal-line"><span class="info">  Assignee: you</span></span>
+<span class="terminal-line"><span class="info">  ...</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- diff -->
+          <div class="cmd-block reveal" id="diff">
+            <div class="cmd-heading">
+              <span class="cmd-name">diff</span>
+              <span class="cmd-short-desc">View changes vs base branch</span>
+              <a href="#diff" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Shows the diff between the worktree's current state and its base branch. Defaults to full diff output; use <code>--stat</code> or <code>--name-only</code> for a summary.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec diff</span> <span class="arg">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--stat</code></td><td>Show diffstat summary (files changed, insertions, deletions).</td></tr>
+                  <tr><td><code>--name-only</code></td><td>Show only the names of changed files.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec diff</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec diff</span> <span class="arg">PROJ-123</span> <span class="flag">--stat</span></span>
+<span class="terminal-line"><span class="info">  src/auth/mod.rs        | 84 ++++++++++++++++++++++</span></span>
+<span class="terminal-line"><span class="info">  src/auth/session.rs    | 42 +++++++++++</span></span>
+<span class="terminal-line"><span class="info">  tests/auth_test.rs     | 28 ++++++++</span></span>
+<span class="terminal-line"><span class="info">  3 files changed, 154 insertions(+)</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- conflicts -->
+          <div class="cmd-block reveal" id="conflicts">
+            <div class="cmd-heading">
+              <span class="cmd-name">conflicts</span>
+              <span class="cmd-short-desc">Detect file conflicts across worktrees</span>
+              <a href="#conflicts" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Scans all active worktrees and reports files modified by more than one of them. Surfaces potential merge conflicts <em>before</em> you open a PR — essential when running multiple parallel agents.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec conflicts</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec conflicts</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec conflicts</span></span>
+<span class="terminal-line"><span class="info">  Checking 4 active worktrees...</span></span>
+<span class="terminal-line"><span class="flag">  ⚠ src/config.rs  modified in PROJ-123 and PROJ-130</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">No other conflicts found</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- pr-status -->
+          <div class="cmd-block reveal" id="pr-status">
+            <div class="cmd-heading">
+              <span class="cmd-name">pr-status</span>
+              <span class="cmd-short-desc">Check PR CI and review status</span>
+              <a href="#pr-status" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Fetches the current PR state: review approvals, requested changes, CI check results, and merge readiness. Useful in agent scripts to poll before triggering a merge.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec pr-status</span> <span class="arg">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec pr-status</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec pr-status</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  PR #42  Add user authentication flow</span></span>
+<span class="terminal-line"><span class="info">  Reviews:  </span><span class="success">2 approved</span></span>
+<span class="terminal-line"><span class="info">  CI:       </span><span class="success">all checks passing</span></span>
+<span class="terminal-line"><span class="info">  Mergeable: </span><span class="success">yes</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Machine-readable for agent scripts</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec pr-status</span> <span class="arg">PROJ-123</span> <span class="flag">--json</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- ci -->
+          <div class="cmd-block reveal" id="ci">
+            <div class="cmd-heading">
+              <span class="cmd-name">ci</span>
+              <span class="cmd-short-desc">Check CI/CD status</span>
+              <a href="#ci" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Shows CI/CD pipeline status for a ticket's branch. With <code>--watch</code> it polls continuously until all checks complete or fail.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec ci</span> <span class="arg">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--watch</code></td><td>Poll CI status until completion (useful in scripts).</td></tr>
+                  <tr><td><code>--all</code></td><td>Show CI status for all active worktrees.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec ci</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ci</span> <span class="arg">PROJ-123</span> <span class="flag">--watch</span></span>
+<span class="terminal-line"><span class="info">  Watching CI for feature/PROJ-123...</span></span>
+<span class="terminal-line"><span class="info">  [  5s] build        </span><span class="arg">running</span></span>
+<span class="terminal-line"><span class="info">  [ 32s] build        </span><span class="success">passed</span></span>
+<span class="terminal-line"><span class="info">  [ 38s] test         </span><span class="success">passed</span></span>
+<span class="terminal-line"><span class="info">  [ 41s] lint         </span><span class="success">passed</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">All CI checks passed</span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ==============================
+             ADVANCED
+             ============================== -->
+        <div class="cmd-section" id="advanced">
+          <div class="cmd-section-divider">
+            <h2>Advanced</h2>
+          </div>
+
+          <!-- sync -->
+          <div class="cmd-block reveal" id="sync">
+            <div class="cmd-heading">
+              <span class="cmd-name">sync</span>
+              <span class="cmd-short-desc">Sync worktree with base branch</span>
+              <a href="#sync" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Updates a worktree by fetching and merging (or rebasing) changes from its base branch. Keeps long-running feature branches current without manually switching contexts.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec sync</span> <span class="arg">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--all</code></td><td>Sync all active worktrees at once.</td></tr>
+                  <tr><td><code>--strategy &lt;merge|rebase&gt;</code></td><td>Integration strategy. Defaults to <code>merge</code>.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec sync</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Sync one worktree</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec sync</span> <span class="arg">PROJ-123</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Synced feature/PROJ-123 with main (fast-forward)</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Sync all worktrees with rebase strategy</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec sync</span> <span class="flag">--all</span> <span class="flag">--strategy</span> <span class="arg">rebase</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Synced 3 worktrees</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- open -->
+          <div class="cmd-block reveal" id="open">
+            <div class="cmd-heading">
+              <span class="cmd-name">open</span>
+              <span class="cmd-short-desc">Open PR or ticket in browser</span>
+              <a href="#open" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Opens the associated PR or ticket page in your default browser. By default opens the PR; use <code>--ticket-page</code> to open the issue tracker instead.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec open</span> <span class="arg">&lt;TICKET&gt;</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--pr</code></td><td>Open the PR/MR page (default).</td></tr>
+                  <tr><td><code>--ticket-page</code></td><td>Open the issue tracker page instead.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec open</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec open</span> <span class="arg">PROJ-123</span>             <span class="comment"># opens PR</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec open</span> <span class="arg">PROJ-123</span> <span class="flag">--ticket-page</span>  <span class="comment"># opens Jira</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- adopt -->
+          <div class="cmd-block reveal" id="adopt">
+            <div class="cmd-heading">
+              <span class="cmd-name">adopt</span>
+              <span class="cmd-short-desc">Import existing branch into parsec</span>
+              <a href="#adopt" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Registers an existing git branch as a parsec-managed worktree, linking it to a ticket ID. Use this when you've already started work on a branch outside of parsec.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec adopt</span> <span class="arg">&lt;TICKET&gt;</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--branch &lt;NAME&gt;</code></td><td>Branch name to adopt (if different from the ticket-derived name).</td></tr>
+                  <tr><td><code>--title &lt;TEXT&gt;</code></td><td>Override ticket title for display.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec adopt</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec adopt</span> <span class="arg">PROJ-123</span> <span class="flag">--branch</span> <span class="arg">my-old-branch</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Adopted branch </span><span class="link">my-old-branch</span><span class="info"> as PROJ-123</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- stack -->
+          <div class="cmd-block reveal" id="stack">
+            <div class="cmd-heading">
+              <span class="cmd-name">stack</span>
+              <span class="cmd-short-desc">Show or manage stacked PR dependencies</span>
+              <a href="#stack" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Displays the dependency graph of stacked PRs created with <code>parsec start --on</code>. With <code>--sync</code>, updates all PRs in the stack to use their correct base branches after an upstream merge.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec stack</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--sync</code></td><td>Re-target stacked PRs after an upstream PR was merged.</td></tr>
+                  <tr><td><code>--submit</code></td><td>Ship the entire stack in topological order (root first). Stops on first failure.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec stack</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec stack</span></span>
+<span class="terminal-line"><span class="info">  main</span></span>
+<span class="terminal-line"><span class="info">  └── </span><span class="link">feature/PROJ-123</span><span class="info">  (PROJ-123) PR #42 open</span></span>
+<span class="terminal-line"><span class="info">      └── </span><span class="link">feature/PROJ-124</span><span class="info">  (PROJ-124) PR #43 open</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Ship the entire stack at once</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec stack</span> <span class="flag">--submit</span></span>
+<span class="terminal-line"><span class="info">Submitting stack (2 worktrees):</span></span>
+<span class="terminal-line"><span class="info">  1. PROJ-123</span></span>
+<span class="terminal-line"><span class="info">  2. PROJ-124</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Stack submit complete: 2/2 shipped</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- inbox -->
+          <div class="cmd-block reveal" id="inbox">
+            <div class="cmd-heading">
+              <span class="cmd-name">inbox</span>
+              <span class="cmd-short-desc">List assigned tickets without worktrees</span>
+              <a href="#inbox" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Fetches tickets assigned to you from the configured tracker that don't yet have a parsec worktree. Use <code>--pick</code> to interactively select and immediately run <code>parsec start</code> on one.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec inbox</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--pick</code></td><td>Interactive mode: select a ticket to immediately start a worktree.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec inbox</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec inbox</span></span>
+<span class="terminal-line"><span class="info">  PROJ-128  Fix pagination bug in search results</span></span>
+<span class="terminal-line"><span class="info">  PROJ-131  Upgrade dependency: serde 1.0.195</span></span>
+<span class="terminal-line"><span class="info">  PROJ-135  Add dark mode toggle</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- board -->
+          <div class="cmd-block reveal" id="board">
+            <div class="cmd-heading">
+              <span class="cmd-name">board</span>
+              <span class="cmd-short-desc">Sprint board Kanban view</span>
+              <a href="#board" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Renders a Kanban-style sprint board in the terminal, pulling data from your configured tracker. Shows ticket titles, statuses, and assignees.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec board</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--board-id &lt;ID&gt;</code></td><td>Target a specific board by ID.</td></tr>
+                  <tr><td><code>--project &lt;KEY&gt;</code></td><td>Filter by project key.</td></tr>
+                  <tr><td><code>--assignee &lt;USER&gt;</code></td><td>Filter tickets by assignee.</td></tr>
+                  <tr><td><code>--all</code></td><td>Show tickets for all assignees.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec board</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec board</span></span>
+<span class="terminal-line"><span class="info">  TODO           IN PROGRESS       REVIEW          DONE</span></span>
+<span class="terminal-line"><span class="info">  ─────────────────────────────────────────────────────</span></span>
+<span class="terminal-line"><span class="info">  PROJ-128       </span><span class="arg">PROJ-123</span><span class="info">          PROJ-119        PROJ-111</span></span>
+<span class="terminal-line"><span class="info">  PROJ-131       </span><span class="arg">PROJ-125</span><span class="info">                          PROJ-112</span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ==============================
+             HISTORY
+             ============================== -->
+        <div class="cmd-section" id="history">
+          <div class="cmd-section-divider">
+            <h2>History</h2>
+          </div>
+
+          <!-- log -->
+          <div class="cmd-block reveal" id="log">
+            <div class="cmd-heading">
+              <span class="cmd-name">log</span>
+              <span class="cmd-short-desc">Show operation history</span>
+              <a href="#log" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Displays a chronological log of all parsec operations: start, ship, merge, clean, undo, etc. Use <code>--last N</code> to limit output.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec log</span> <span class="arg">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--last &lt;N&gt;</code></td><td>Show only the last N operations.</td></tr>
+                  <tr><td><code>--export</code></td><td>Emit the log as JSONL (one JSON object per line). Each entry includes <code>execution_id</code> and per-step timing for observability/debugging by tooling and AI agents.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec log</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec log</span> <span class="flag">--last</span> <span class="arg">5</span></span>
+<span class="terminal-line"><span class="info">  2024-01-15 14:32  </span><span class="success">merge</span>   <span class="arg">PROJ-119</span><span class="info">  PR #38 merged</span></span>
+<span class="terminal-line"><span class="info">  2024-01-15 11:20  </span><span class="success">ship</span>    <span class="arg">PROJ-123</span><span class="info">  PR #42 created</span></span>
+<span class="terminal-line"><span class="info">  2024-01-15 09:05  </span><span class="success">start</span>   <span class="arg">PROJ-123</span><span class="info">  worktree created</span></span>
+<span class="terminal-line"><span class="info">  2024-01-14 17:44  </span><span class="success">start</span>   <span class="arg">PROJ-125</span><span class="info">  worktree created</span></span>
+<span class="terminal-line"><span class="info">  2024-01-14 16:30  </span><span class="success">clean</span>   <span class="info">  3 worktrees removed</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># JSONL export — one JSON object per line, with execution_id and per-step timing</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec log</span> <span class="flag">--export</span></span>
+<span class="terminal-line"><span class="info">{"execution_id":"01HQ3D8R2K8...","op":"start","ticket":"PROJ-123","steps":[{"name":"fetch_title","ms":214},{"name":"create_worktree","ms":98}],"duration_ms":312}</span></span>
+<span class="terminal-line"><span class="info">{"execution_id":"01HQ3D9V7Z2...","op":"ship","ticket":"PROJ-123","steps":[{"name":"push","ms":820},{"name":"create_pr","ms":1305},{"name":"cleanup","ms":42}],"duration_ms":2167}</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- undo -->
+          <div class="cmd-block reveal" id="undo">
+            <div class="cmd-heading">
+              <span class="cmd-name">undo</span>
+              <span class="cmd-short-desc">Undo last operation</span>
+              <a href="#undo" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Rolls back the most recent parsec operation. For example, undoing a <code>ship</code> removes the PR and restores the worktree. Use <code>--dry-run</code> to see what would happen without committing.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec undo</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--dry-run</code></td><td>Preview what undo would do without making any changes.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec undo</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec undo</span> <span class="flag">--dry-run</span></span>
+<span class="terminal-line"><span class="info">  Would undo: ship PROJ-123</span></span>
+<span class="terminal-line"><span class="info">    - Close PR #42</span></span>
+<span class="terminal-line"><span class="info">    - Restore worktree ../myrepo.PROJ-123</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec undo</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Undid: ship PROJ-123</span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ==============================
+             SETUP
+             ============================== -->
+        <div class="cmd-section" id="setup">
+          <div class="cmd-section-divider">
+            <h2>Setup</h2>
+          </div>
+
+          <!-- root -->
+          <div class="cmd-block reveal" id="root">
+            <div class="cmd-heading">
+              <span class="cmd-name">root</span>
+              <span class="cmd-short-desc">Print main repo root path</span>
+              <a href="#root" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Prints the absolute path of the main (non-worktree) repository root. Useful in scripts to navigate back to the primary workspace from any worktree.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec root</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec root</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec root</span></span>
+<span class="terminal-line"><span class="info">  /Users/you/projects/myrepo</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Navigate back from a worktree</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">cd</span> $(<span class="command">parsec root</span>)</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- init -->
+          <div class="cmd-block reveal" id="init">
+            <div class="cmd-heading">
+              <span class="cmd-name">init</span>
+              <span class="cmd-short-desc">Output or install shell integration</span>
+              <a href="#init" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Prints a shell integration script that enables automatic <code>cd</code> when using <code>parsec switch</code>, and automatic working-directory recovery after <code>parsec merge</code> removes a worktree you were inside. Use <code>--install</code> to auto-append the integration to your shell config file instead of managing it manually.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec init</span> <span class="arg">[SHELL]</span> <span class="opt">[--install] [--yes]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Argument / Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>[SHELL]</code></td><td>Shell to generate integration for. Supported: <code>zsh</code>, <code>bash</code>, <code>fish</code>. Defaults to <code>zsh</code>.</td></tr>
+                  <tr><td><code>--install</code></td><td>Auto-append <code>eval "$(parsec init &lt;shell&gt;)"</code> to your shell config file with a confirmation prompt.</td></tr>
+                  <tr><td><code>-y, --yes</code></td><td>Skip the confirmation prompt. Useful for scripted or non-interactive environments.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec init</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Preferred: auto-install into ~/.zshrc</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec init</span> <span class="flag">--install</span></span>
+<span class="terminal-line"><span class="info">  Add shell integration to /home/user/.zshrc? [Y/n] </span><span class="arg">y</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Shell integration added. Run </span><span class="link">source ~/.zshrc</span><span class="info"> or restart your shell.</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Non-interactive install (scripted setup)</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec init</span> <span class="flag">--install</span> <span class="flag">--yes</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Manual: print and eval yourself</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">eval</span> "$(<span class="command">parsec init</span> <span class="arg">zsh</span>)"</span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># bash users</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">eval</span> "$(<span class="command">parsec init</span> <span class="arg">bash</span>)"</span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># fish users</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec init</span> <span class="arg">fish</span> | <span class="command">source</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- config -->
+          <div class="cmd-block reveal" id="config">
+            <div class="cmd-heading">
+              <span class="cmd-name">config</span>
+              <span class="cmd-short-desc">Configure parsec</span>
+              <a href="#config" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Top-level configuration command with subcommands for initial setup, showing current config, generating shell completions, and reading the manual.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec config</span> <span class="arg">&lt;SUBCOMMAND&gt;</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Subcommand</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>init</code></td><td>Run interactive first-time setup (tracker URL, API tokens, default branch).</td></tr>
+                  <tr><td><code>show</code></td><td>Display current configuration (redacts sensitive tokens).</td></tr>
+                  <tr><td><code>man</code></td><td>Open the parsec manual in your pager.</td></tr>
+                  <tr><td><code>completions &lt;SHELL&gt;</code></td><td>Generate shell completion script for <code>zsh</code>, <code>bash</code>, or <code>fish</code>.</td></tr>
+                  <tr><td><code>schema</code></td><td>Output the JSON Schema for <code>config.toml</code>. The schema is also published to <a href="https://schemastore.org">schemastore.org</a> so editors auto-complete configuration files.</td></tr>
+                  <tr><td><code>shell</code></td><td><em>Deprecated.</em> Use <code>parsec init &lt;SHELL&gt;</code> instead.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec config</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># First-time setup wizard</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config init</span></span>
+<span class="terminal-line"><span class="info">  ? Tracker type: </span><span class="arg">jira</span></span>
+<span class="terminal-line"><span class="info">  ? Jira base URL: </span><span class="arg">https://myorg.atlassian.net</span></span>
+<span class="terminal-line"><span class="info">  ? Jira API token: </span><span class="arg">***</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Config saved to ~/.config/parsec/config.toml</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Install shell completions (zsh)</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config completions</span> <span class="arg">zsh</span> > ~/.zsh/completions/_parsec</span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Show current config</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config show</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Output the JSON Schema (also at https://json.schemastore.org/parsec.json)</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec config schema</span> > parsec-schema.json</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- doctor -->
+          <div class="cmd-block reveal" id="doctor">
+            <div class="cmd-heading">
+              <span class="cmd-name">doctor</span>
+              <span class="cmd-short-desc">Validate environment and configuration</span>
+              <a href="#doctor" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Checks your environment and prints ✓/✗ for each item with actionable fix instructions. Verifies git version, config file, API tokens, tracker connectivity, shell integration, tab completions, and remote access.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec doctor</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--json</code></td><td>Output results as JSON (<code>{"checks":[...],"all_ok":bool}</code>).</td></tr>
+                  <tr><td><code>--ai</code></td><td>Include AI-powered diagnostic suggestions for failed checks.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec doctor</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec doctor</span></span>
+<span class="terminal-line"><span class="success">  ✓</span> <span class="info">git version 2.43.0 (worktree support ok)</span></span>
+<span class="terminal-line"><span class="success">  ✓</span> <span class="info">config file found at ~/.config/parsec/config.toml</span></span>
+<span class="terminal-line"><span class="success">  ✓</span> <span class="info">GitHub token configured (github.com) via gh auth token</span></span>
+<span class="terminal-line"><span class="error">  ✗</span> <span class="info">shell integration not found in shell config</span></span>
+<span class="terminal-line"><span class="info">      Add to ~/.zshrc:  </span><span class="command">eval "$(parsec init zsh)"</span></span>
+<span class="terminal-line"><span class="error">  ✗</span> <span class="info">tab completions not configured</span></span>
+<span class="terminal-line"><span class="info">      Add to ~/.zshrc:  </span><span class="command">eval "$(parsec config completions zsh)"</span></span>
+<span class="terminal-line"><span class="success">  ✓</span> <span class="info">remote origin accessible</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="error">2 check(s) failed.</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Machine-readable output</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec doctor</span> <span class="flag">--json</span></span>
+<span class="terminal-line"><span class="output">{"checks":[...],"all_ok":false}</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- create -->
+          <div class="cmd-block reveal" id="create">
+            <div class="cmd-heading">
+              <span class="cmd-name">create</span>
+              <span class="cmd-short-desc">Create a new issue on the tracker</span>
+              <a href="#create" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Creates a new ticket on GitHub Issues or Jira and optionally starts a worktree for it immediately. Auto-detects the tracker from your config.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec create</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--title &lt;TEXT&gt;</code> <span class="req-badge">required</span></td><td>Issue title.</td></tr>
+                  <tr><td><code>--body &lt;TEXT&gt;</code></td><td>Issue body / description.</td></tr>
+                  <tr><td><code>--label &lt;A,B&gt;</code></td><td>Comma-separated labels to apply.</td></tr>
+                  <tr><td><code>-p, --project &lt;KEY&gt;</code></td><td>Jira project key (auto-detected from config if omitted).</td></tr>
+                  <tr><td><code>--start</code></td><td>Start a worktree for the new issue immediately after creation.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec create</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec create</span> <span class="flag">--title</span> <span class="arg">"Fix login redirect"</span> <span class="flag">--label</span> <span class="arg">"bug"</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created #145: Fix login redirect</span></span>
+<span class="terminal-line"><span class="link">  https://github.com/org/repo/issues/145</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Create and immediately start working</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec create</span> <span class="flag">--title</span> <span class="arg">"Add caching"</span> <span class="flag">--start</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created #146: Add caching</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created workspace at </span><span class="link">~/myrepo.146</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- new-issue -->
+          <div class="cmd-block reveal" id="new-issue">
+            <div class="cmd-heading">
+              <span class="cmd-name">new-issue</span>
+              <span class="cmd-short-desc">Create a new issue (extended)</span>
+              <a href="#new-issue" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Extended issue creation with multi-label support and Jira issue type control. Auto-detects GitHub or Jira from config.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec new-issue</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--title &lt;TEXT&gt;</code> <span class="req-badge">required</span></td><td>Issue title.</td></tr>
+                  <tr><td><code>--body &lt;TEXT&gt;</code></td><td>Issue body / description.</td></tr>
+                  <tr><td><code>--label &lt;LABEL&gt;</code></td><td>Label (can be specified multiple times).</td></tr>
+                  <tr><td><code>-p, --project &lt;KEY&gt;</code></td><td>Jira project key (auto-detected from config if omitted).</td></tr>
+                  <tr><td><code>--issue-type &lt;TYPE&gt;</code></td><td>Jira issue type (default: <code>Task</code>).</td></tr>
+                  <tr><td><code>--start</code></td><td>Auto-start a worktree for the new issue.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec new-issue</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec new-issue</span> <span class="flag">--title</span> <span class="arg">"Implement caching"</span> <span class="flag">--issue-type</span> <span class="arg">Story</span> <span class="flag">--project</span> <span class="arg">CL</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created CL-42: Implement caching</span></span>
+<span class="terminal-line"><span class="link">  https://jira.example.com/browse/CL-42</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Multiple labels on GitHub</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec new-issue</span> <span class="flag">--title</span> <span class="arg">"Fix auth"</span> <span class="flag">--label</span> <span class="arg">bug</span> <span class="flag">--label</span> <span class="arg">priority</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Created #147: Fix auth</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- rename -->
+          <div class="cmd-block reveal" id="rename">
+            <div class="cmd-heading">
+              <span class="cmd-name">rename</span>
+              <span class="cmd-short-desc">Re-ticket an existing workspace</span>
+              <a href="#rename" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Reassigns an existing worktree to a different ticket ID. Updates the branch name, directory symlink, and internal state — useful when a ticket is split, renumbered, or moved between trackers.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec rename</span> <span class="arg">&lt;OLD-TICKET&gt;</span> <span class="arg">&lt;NEW-TICKET&gt;</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Argument</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>&lt;OLD-TICKET&gt;</code> <span class="req-badge">required</span></td><td>The current ticket ID of the workspace to rename.</td></tr>
+                  <tr><td><code>&lt;NEW-TICKET&gt;</code> <span class="req-badge">required</span></td><td>The new ticket ID to assign to the workspace.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--dry-run</code></td><td>Preview what would be renamed without making changes.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec rename</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec rename</span> <span class="arg">PROJ-123</span> <span class="arg">PROJ-456</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Branch renamed: feature/PROJ-123-fix-login → feature/PROJ-456-fix-login</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Workspace directory updated</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">State updated for PROJ-456</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Preview changes first</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec rename</span> <span class="arg">OLD-99</span> <span class="arg">NEW-100</span> <span class="flag">--dry-run</span></span>
+<span class="terminal-line"><span class="info">Would rename branch feature/OLD-99-… → feature/NEW-100-…</span></span>
+<span class="terminal-line"><span class="info">Would update workspace directory and state file</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- compress -->
+          <div class="cmd-block reveal" id="compress">
+            <div class="cmd-heading">
+              <span class="cmd-name">compress</span>
+              <span class="cmd-short-desc">Squash all branch commits into one</span>
+              <a href="#compress" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Resets the branch to the merge-base with the base branch and re-commits all changes as a single commit. Co-author trailers from squashed commits are preserved. Useful before <code>parsec ship</code> to keep PR history tidy.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec compress</span> <span class="opt">[TICKET]</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Argument</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>[TICKET]</code></td><td>Optional. Auto-detects the current worktree's ticket if omitted.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>-m, --message &lt;TEXT&gt;</code></td><td>Custom commit message. Default: combines all squashed commit messages.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec compress</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="comment"># Compress current worktree's branch</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Compressed 7 commits into one on feature/PROJ-1234</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Compress with custom message</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span> <span class="arg">PROJ-1234</span> <span class="flag">-m</span> <span class="arg">"feat: add user authentication"</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Combine with ship</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec compress</span> &amp;&amp; <span class="command">parsec ship</span></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- release -->
+          <div class="cmd-block reveal" id="release">
+            <div class="cmd-heading">
+              <span class="cmd-name">release</span>
+              <span class="cmd-short-desc">Create a versioned release</span>
+              <a href="#release" class="cmd-anchor">#</a>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 12px; line-height: 1.7;">
+              Merges the develop branch into the release branch (default: main), creates a version tag, and creates a GitHub Release with auto-generated changelog from commit messages since the last tag.
+            </p>
+            <div class="usage-block">
+              <span class="usage-label">Usage</span>
+              <code><span class="cmd-kw">parsec release</span> <span class="arg">&lt;VERSION&gt;</span> <span class="opt">[OPTIONS]</span></code>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Argument</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>&lt;VERSION&gt;</code> <span class="req-badge">required</span></td><td>Version string (e.g., <code>0.3.0</code>).</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Option</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>--from &lt;BRANCH&gt;</code></td><td>Source branch to release from (default: develop).</td></tr>
+                  <tr><td><code>--no-github-release</code></td><td>Skip creating a GitHub Release.</td></tr>
+                  <tr><td><code>--dry-run</code></td><td>Show what would happen without making changes.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">parsec release</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec release</span> <span class="arg">0.3.0</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Merged develop → main</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">Tagged </span><span class="link">v0.3.0</span></span>
+<span class="terminal-line"><span class="success">✓</span> <span class="info">GitHub Release: </span><span class="link">github.com/org/repo/releases/tag/v0.3.0</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Preview first</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec release</span> <span class="arg">0.4.0</span> <span class="flag">--dry-run</span></span>
+<span class="terminal-line"><span class="info">Would merge develop → main</span></span>
+<span class="terminal-line"><span class="info">Would tag v0.4.0</span></span>
+<span class="terminal-line"><span class="info">Would create GitHub Release</span></span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+        <!-- end setup section -->
+
+        <!-- ==============================
+             ERROR CODES
+             ============================== -->
+        <div class="cmd-section" id="error-codes">
+          <div class="cmd-section-divider">
+            <h2>Error Codes</h2>
+          </div>
+
+          <div class="cmd-block reveal">
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 16px; line-height: 1.7;">
+              All <code>parsec</code> commands exit with a structured exit code. Use these in scripts to handle failures precisely. JSON output (<code>--json</code>) also includes an <code>"error_code"</code> field on failure.
+            </p>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Exit Code</th><th>Name</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>0</code></td><td>Success</td><td>Command completed successfully.</td></tr>
+                  <tr><td><code>1</code></td><td>GeneralError</td><td>Unspecified error — check stderr for details.</td></tr>
+                  <tr><td><code>2</code></td><td>ConfigError</td><td>Missing or invalid configuration (run <code>parsec config init</code>).</td></tr>
+                  <tr><td><code>3</code></td><td>TrackerError</td><td>Could not reach or authenticate with the issue tracker.</td></tr>
+                  <tr><td><code>4</code></td><td>GitError</td><td>Git operation failed (merge conflict, missing remote, etc.).</td></tr>
+                  <tr><td><code>5</code></td><td>WorktreeError</td><td>Worktree already exists, is missing, or is in a bad state.</td></tr>
+                  <tr><td><code>6</code></td><td>NotFound</td><td>Ticket or workspace not found.</td></tr>
+                  <tr><td><code>7</code></td><td>AuthError</td><td>API token missing or insufficient permissions.</td></tr>
+                  <tr><td><code>8</code></td><td>PolicyViolation</td><td>Operation blocked by an active policy rule.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">exit code in scripts</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec ship</span> <span class="arg">PROJ-123</span> <span class="flag">--json</span></span>
+<span class="terminal-line"><span class="output">{"error_code":3,"message":"Could not reach Jira: connection refused"}</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="info">echo $?</span></span>
+<span class="terminal-line"><span class="output">3</span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- end error-codes section -->
+
+        <!-- ==============================
+             POLICY CONFIG
+             ============================== -->
+        <div class="cmd-section" id="policy-config">
+          <div class="cmd-section-divider">
+            <h2>Policy Config</h2>
+          </div>
+
+          <div class="cmd-block reveal">
+            <p style="color: var(--text-secondary); font-size: 15px; margin-bottom: 16px; line-height: 1.7;">
+              The <code>[policy]</code> table in <code>~/.config/parsec/config.toml</code> lets teams enforce guardrails on parsec operations. Violations exit with code <code>8</code> (PolicyViolation) and print an actionable message.
+            </p>
+
+            <div class="ref-table-wrap">
+              <table class="ref-table">
+                <thead>
+                  <tr><th>Key</th><th>Type</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><code>require_ticket_prefix</code></td><td><code>String</code></td><td>All ticket IDs must match this prefix (e.g., <code>"PROJ-"</code>). Prevents freeform branch names.</td></tr>
+                  <tr><td><code>max_open_workspaces</code></td><td><code>u32</code></td><td>Block <code>parsec start</code> when open workspace count reaches this limit.</td></tr>
+                  <tr><td><code>protected_branches</code></td><td><code>[String]</code></td><td>Branches that <code>parsec ship</code> and <code>parsec merge</code> will refuse to target (e.g., <code>["main", "production"]</code>).</td></tr>
+                  <tr><td><code>require_pr_review</code></td><td><code>bool</code></td><td>When <code>true</code>, <code>parsec ship</code> checks that at least one review is approved before merging.</td></tr>
+                  <tr><td><code>allow_force_push</code></td><td><code>bool</code></td><td>When <code>false</code> (default), <code>parsec ship</code> refuses to push with <code>--force</code>.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="terminal-wrap">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+                <span class="terminal-title-label">~/.config/parsec/config.toml</span>
+              </div>
+              <div class="terminal-body">
+<span class="terminal-line"><span class="comment">[policy]</span></span>
+<span class="terminal-line"><span class="info">require_ticket_prefix = </span><span class="arg">"PROJ-"</span></span>
+<span class="terminal-line"><span class="info">max_open_workspaces = </span><span class="arg">5</span></span>
+<span class="terminal-line"><span class="info">protected_branches = </span><span class="arg">["main", "production"]</span></span>
+<span class="terminal-line"><span class="info">require_pr_review = </span><span class="arg">true</span></span>
+<span class="terminal-line"><span class="info">allow_force_push = </span><span class="arg">false</span></span>
+<span class="terminal-line">&nbsp;</span>
+<span class="terminal-line"><span class="comment"># Policy violation example</span></span>
+<span class="terminal-line"><span class="prompt">$</span> <span class="command">parsec start</span> <span class="arg">my-feature</span></span>
+<span class="terminal-line"><span class="error">✗ Policy violation: ticket ID must start with "PROJ-"</span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- end policy-config section -->
+
+      </div>
+      <!-- end docs-content -->
+    </main>
+  </div>
+  <!-- end docs-layout -->
+
+  <!-- ============ FOOTER ============ -->
+  <footer class="docs-footer">
+    <div class="footer-inner">
+      <div class="footer-left">
+        <span class="footer-brand">git-parsec</span>
+        <ul class="footer-links">
+          <li><a href="https://github.com/erishforG/git-parsec" target="_blank" rel="noopener">GitHub</a></li>
+          <li><a href="https://github.com/erishforG/git-parsec/issues" target="_blank" rel="noopener">Issues</a></li>
+          <li><a href="https://github.com/erishforG/git-parsec/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
+          <li><a href="/git-parsec/v/0.4.0/guide/">Guide</a></li>
+        </ul>
+      </div>
+      <div class="footer-right">Built with Rust. Designed for velocity.</div>
+    </div>
+  </footer>
+
+  <script>
+    // Scroll reveal
+    document.addEventListener('DOMContentLoaded', () => {
+      const reveals = document.querySelectorAll('.reveal');
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('visible'); });
+      }, { threshold: 0.05, rootMargin: '0px 0px -20px 0px' });
+      reveals.forEach(el => observer.observe(el));
+
+      // Active sidebar link on scroll
+      const cmdBlocks = document.querySelectorAll('.cmd-block[id]');
+      const sidebarLinks = document.querySelectorAll('.sidebar-nav a');
+
+      const markActive = (id) => {
+        sidebarLinks.forEach(a => {
+          a.classList.toggle('active', a.getAttribute('href') === '#' + id);
+        });
+      };
+
+      const scrollObserver = new IntersectionObserver((entries) => {
+        entries.forEach(e => {
+          if (e.isIntersecting) markActive(e.target.id);
+        });
+      }, { threshold: 0, rootMargin: '-65px 0px -70% 0px' });
+
+      cmdBlocks.forEach(el => scrollObserver.observe(el));
+    });
+  </script>
+  <script src="/git-parsec/version-switcher.js"></script>
+</body>
+</html>

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,11 @@
 {
-  "latest": "0.3.3",
+  "latest": "0.4.0",
   "versions": [
+    {
+      "version": "0.4.0",
+      "date": "2026-05-04",
+      "path": "/git-parsec/v/0.4.0/"
+    },
     {
       "version": "0.3.3",
       "date": "2026-04-23",


### PR DESCRIPTION
Brings the manually-generated \`docs/v/0.4.0/\` snapshot from develop to main.

## Why
The v0.4.0 release workflow's \`snapshot-versioned-docs\` job [failed at \`git push origin main\`](https://github.com/erishforG/git-parsec/actions/runs/25316597167) because main is now protected and rejects direct pushes (even from the github-actions bot). All other release jobs (Tag & Publish, 4-OS binaries, GitHub Release) succeeded — v0.4.0 is on crates.io and the Releases page is fine. Only the versioned docs archive at \`/v/0.4.0/\` is missing.

PR #287 added the snapshot to develop (locally reproducing the workflow's sed transformations). This PR ships it to main.

## On merge
The release.yml workflow will fire again on push to main. Both Tag & Publish and Snapshot Versioned Docs jobs are gated on \`needs.release.outputs.created == 'true'\` — and since v0.4.0 tag already exists, both will be skipped. So this PR is purely a docs-only delta, no re-publish, no double-tag.

## What lands
- \`docs/v/0.4.0/index.html\`, \`docs/v/0.4.0/guide/index.html\`, \`docs/v/0.4.0/reference/index.html\`
- \`docs/versions.json\` updated (latest = "0.4.0", new entry prepended)
- \`docs/sitemap.xml\` 3 new \`/v/0.4.0/\` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)