### PR TITLE
ci(windows): VS2026 pre-validation job (#307)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo install cargo-audit --locked
       - run: cargo audit
+
+  # Pre-validation for GitHub Actions Windows runner migration to VS 2026
+  # (windows-latest / windows-2025 labels move to VS2026 default between
+  # 2026-06-08 and 2026-06-15). Informational until migration completes.
+  # Tracked in issue #307 — remove after migration window closes.
+  windows-vs2026-prevalidation:
+    name: Windows VS2026 Pre-Validation
+    runs-on: windows-2025-vs2026
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo build --release
+      - run: cargo test


### PR DESCRIPTION
## Summary
- Adds advisory \`windows-vs2026-prevalidation\` job using \`windows-2025-vs2026\` runner label
- Runs \`cargo build --release\` + \`cargo test\` on the new VS 2026 image
- \`continue-on-error: true\` keeps it informational — existing \`windows-latest\` matrix still gates

## Context
GitHub Actions migrates the \`windows-latest\` / \`windows-2025\` labels to VS 2026 default during **2026-06-08 ~ 06-15**. parsec's CI/release workflows currently depend on VS 2022 (MSVC link.exe, C/C++ runtime, aws-lc-sys native build).

Picking option B from #307 — pre-test the new image now so the migration window is a no-op.

## Plan
1. Open as draft → run once → observe whether the new runner label is provisioned and whether build/test passes.
2. If pass: keep the job until 2026-06-15, then delete (gated matrix already covers it).
3. If fail: pin existing matrix to \`windows-2022\` and open a follow-up issue for the actual VS 2026 compatibility fix.

## Test plan
- [ ] CI run completes (regardless of pass/fail) — confirms runner label is accepted
- [ ] If pass: collect log → mark #307 done, delete job around 2026-06-15
- [ ] If fail: capture failing step, open follow-up, pin \`windows-2022\` in matrix

Closes #307 once the validation result is recorded.