### PR TITLE
feat(completion): __complete subcommand foundation (#291)

### DIFF
--- a/src/cli/commands/complete.rs
+++ b/src/cli/commands/complete.rs
@@ -1,0 +1,55 @@
+//! `parsec __complete <kind>` — hidden helper for dynamic shell completion (#291).
+//!
+//! Emits newline-separated candidates to stdout. Shell completion scripts
+//! (zsh/bash/fish) call this from inside the generated completion function
+//! whenever the cursor is on a worktree- or branch-shaped argument.
+//!
+//! Failures are silent (empty output, exit 0) so that completion never
+//! interrupts the user when, e.g., the cwd is not a git repo.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::cli::CompleteKind;
+use crate::config::ParsecConfig;
+use crate::git;
+use crate::worktree::WorktreeManager;
+
+pub async fn complete(repo_path: &Path, kind: CompleteKind) -> Result<()> {
+    match kind {
+        CompleteKind::Worktrees => emit_worktrees(repo_path),
+        CompleteKind::Branches => emit_branches(repo_path),
+    }
+    Ok(())
+}
+
+fn emit_worktrees(repo_path: &Path) {
+    let Ok(repo_root) = git::get_main_repo_root(repo_path) else {
+        return;
+    };
+    let Ok(config) = ParsecConfig::load() else {
+        return;
+    };
+    let Ok(manager) = WorktreeManager::new(&repo_root, &config) else {
+        return;
+    };
+    let Ok(workspaces) = manager.list() else {
+        return;
+    };
+    for ws in workspaces {
+        println!("{}", ws.ticket);
+    }
+}
+
+fn emit_branches(repo_path: &Path) {
+    let Ok(repo_root) = git::get_main_repo_root(repo_path) else {
+        return;
+    };
+    let Ok(branches) = git::list_local_branches(&repo_root) else {
+        return;
+    };
+    for b in branches {
+        println!("{}", b);
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,4 +1,5 @@
 mod ci;
+mod complete;
 mod compress;
 mod config;
 mod diff;
@@ -13,6 +14,7 @@ mod tracker_cmds;
 mod workspace;
 
 pub use ci::*;
+pub use complete::complete;
 pub use compress::*;
 pub use config::*;
 pub use diff::*;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -512,6 +512,25 @@ pub enum Command {
         #[arg(long, short)]
         depth: Option<usize>,
     },
+
+    /// Internal: emit dynamic completion candidates (issue #291).
+    ///
+    /// Used by shell completion scripts to enumerate worktrees / branches /
+    /// tickets at completion time. Not intended for direct user invocation.
+    #[command(name = "__complete", hide = true)]
+    Complete {
+        #[command(subcommand)]
+        kind: CompleteKind,
+    },
+}
+
+/// Candidate sets the dynamic completion subcommand can emit.
+#[derive(Subcommand)]
+pub enum CompleteKind {
+    /// Print active worktree ticket identifiers, one per line.
+    Worktrees,
+    /// Print local branch names, one per line.
+    Branches,
 }
 
 #[derive(Subcommand)]
@@ -608,6 +627,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Rename { .. } => "rename",
         Command::Compress { .. } => "compress",
         Command::Smartlog { .. } => "smartlog",
+        Command::Complete { .. } => "__complete",
     };
     let exec_id = crate::execlog::new_execution_id();
     let exec_started_at = chrono::Utc::now();
@@ -895,6 +915,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             commands::compress(&repo_path, ticket.as_deref(), message, output_mode).await
         }
         Command::Smartlog { depth } => commands::smartlog(&repo_path, depth, output_mode).await,
+        Command::Complete { kind } => commands::complete(&repo_path, kind).await,
     };
 
     // Record execution entry (best-effort, never fail the command)

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -165,6 +165,20 @@ pub fn get_current_branch(repo: &Path) -> Result<String> {
     run_output(repo, &["rev-parse", "--abbrev-ref", "HEAD"])
 }
 
+/// Return all local branch names (no `refs/heads/` prefix, no leading `*`).
+pub fn list_local_branches(repo: &Path) -> Result<Vec<String>> {
+    let out = run_output(
+        repo,
+        &["for-each-ref", "--format=%(refname:short)", "refs/heads/"],
+    )?;
+    Ok(out
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
 /// Create a new worktree at `path` on a new branch `branch` based on `base`.
 pub fn worktree_add(repo: &Path, path: &Path, branch: &str, base: &str) -> Result<()> {
     let path_str = path

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1167,6 +1167,87 @@ cache_strategy = "symlink"
 }
 
 // ---------------------------------------------------------------------------
+// __complete (hidden dynamic-completion helper, #291)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_complete_is_hidden_from_help() {
+    let assertion = parsec().arg("--help").assert().success();
+    let stdout = String::from_utf8(assertion.get_output().stdout.clone()).unwrap();
+    assert!(
+        !stdout.contains("__complete"),
+        "__complete should be hidden from --help, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_complete_branches_lists_local_branches() {
+    let repo = setup_repo();
+    let repo_path = repo.path().to_str().unwrap();
+
+    // Add a second local branch on top of the default main.
+    StdCommand::new("git")
+        .args(["branch", "feature/x"])
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+
+    let assertion = parsec()
+        .args(["__complete", "branches", "--repo", repo_path])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assertion.get_output().stdout.clone()).unwrap();
+
+    assert!(stdout.contains("main"), "expected 'main', got:\n{stdout}");
+    assert!(
+        stdout.contains("feature/x"),
+        "expected 'feature/x', got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_complete_worktrees_lists_tickets() {
+    let (repo, _bare) = setup_repo_with_remote();
+    let repo_path = repo.path().to_str().unwrap();
+
+    parsec()
+        .args(["start", "COMP-001", "--repo", repo_path])
+        .assert()
+        .success();
+
+    let assertion = parsec()
+        .args(["__complete", "worktrees", "--repo", repo_path])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assertion.get_output().stdout.clone()).unwrap();
+
+    assert!(
+        stdout.contains("COMP-001"),
+        "expected 'COMP-001', got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_complete_outside_git_repo_is_silent_success() {
+    // Empty temp dir, no git repo — completion must not error or print noise.
+    let dir = TempDir::new().unwrap();
+    let assertion = parsec()
+        .args([
+            "__complete",
+            "branches",
+            "--repo",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assertion.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.trim().is_empty(),
+        "expected empty stdout outside repo, got:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // JSON error format
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- New hidden subcommand: \`parsec __complete <worktrees|branches>\`
- Emits newline-separated candidates; silent on failure so completion never errors at the prompt
- Adds \`git::list_local_branches\` helper
- 4 new integration tests (hidden-from-help / branches / worktrees / silent-outside-repo)

## Scope of this PR (foundation only)

This is **step 1 of 2** for #291. It lands the data-emission half:

\`\`\`
$ parsec __complete worktrees
PROJ-101
PROJ-102

$ parsec __complete branches
develop
feature/x
main
\`\`\`

## What's NOT in this PR (follow-up)

Step 2 — making the existing \`parsec config completions <shell>\` output **call** \`__complete\` from inside the generated zsh/bash/fish functions. The post-processing approach (replace \`_files\` with shell-specific \`compadd \"\$(parsec __complete worktrees)\"\` blocks at known argument positions) belongs in its own PR so this one stays reviewable.

Filing as draft so we can agree on the foundation shape (hidden command name, candidate format, silent-failure policy) before wiring the shell scripts.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -- -D warnings\`
- [x] \`cargo test\` — 102/102 pass
- [x] Manual: \`parsec __complete branches\` / \`parsec __complete worktrees\` on this repo

## Open questions for review
1. Hidden subcommand name — \`__complete\` (cargo-style) vs \`_completion\` vs nested under \`config\`?
2. Should we emit a header like \`# worktree-tickets\` so shell scripts can sanity-check? (Currently no — keeps parsing trivial.)

Refs: #291