### PR TITLE
docs(changelog): [Unreleased] 섹션에 smartlog·complete·errors·win-ci 항목 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **v0.5 milestone opened** — see Roadmap in README. Themes: smartlog · TUI
   dashboard · speculative merge · `parsec test` · AI PR descriptions.
+- **`parsec smartlog` (alias `sl`)** — visualize active worktrees as a commit
+  DAG. ASCII tree groups worktrees by base branch and shows commits since
+  merge-base; `--json` output for tooling. PR/CI overlay reserved for a
+  follow-up (#245, #305).
+- **`parsec __complete` shell-completion helper** — hidden `__complete
+  <worktrees|branches>` subcommand emits newline-separated completion
+  candidates. Enables dynamic worktree/branch tab-completion in zsh, bash,
+  and fish without bundling shell-specific generators (#291, #312).
 
 ### Fixed
 - `parsec ship` falls back to `gh auth token` when `PARSEC_GITHUB_TOKEN` /
   `GITHUB_TOKEN` / `GH_TOKEN` env vars are absent — parity with `parsec
   doctor` and the tracker layer (#281). The fallback is restricted to
   GitHub hosts so Bitbucket / GitLab remotes are unaffected.
+
+### Changed
+- **Error messages standardized to 3-line format** — every user-facing error
+  now follows `error: <summary> / caused by: <root cause> / help: <action>`
+  so error output is consistent and actionable (#303, #306).
+
+### CI
+- Windows VS2026 (Visual Studio 2026 runner) pre-validation job added to the
+  test matrix, catching MSVC toolchain regressions before release (#307, #311).
 
 ## [0.4.0] - 2026-05-04
 


### PR DESCRIPTION
## 무엇

CHANGELOG.md의 `[Unreleased]` 섹션에 develop 브랜치에 머지됐지만 누락된 항목 4개를 추가합니다.

| 추가 항목 | 이슈/PR | 섹션 |
|---|---|---|
| `parsec smartlog` (alias `sl`) — commit DAG 시각화, ASCII + JSON | #245, #305 | Added |
| `parsec __complete` — 동적 shell completion 헬퍼 | #291, #312 | Added |
| 에러 메시지 3줄 표준화 (error / caused by / help) | #303, #306 | Changed |
| Windows VS2026 pre-validation CI job | #307, #311 | CI |

## 왜

릴리즈 시 CHANGELOG 기반으로 Release Notes를 생성하는데, 누락된 항목이 있으면 v0.5 Release Notes가 불완전해집니다. 특히 `parsec smartlog`는 v0.5 마일스톤 핵심 기능이므로 추적이 필요합니다.

## 변경

- `CHANGELOG.md` +17줄 (문서 전용, 프로덕션 코드 무변경)

## 리스크

없음 — CHANGELOG.md 편집만, 소스코드 변경 없음.

## 롤백

`git revert HEAD` 한 줄이면 됩니다.

## Test plan

- `cargo build --quiet` ✅
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- CHANGELOG.md 내용 육안 검토 ✅

Closes #316

@erishforG 검토 부탁드립니다. 문서만 바꾼 안전한 PR입니다.