### PR TITLE
docs(commands): stack·ci 모듈 RustDoc 추가

### DIFF
--- a/src/cli/commands/ci.rs
+++ b/src/cli/commands/ci.rs
@@ -1,3 +1,17 @@
+//! `parsec ci` — forge-agnostic CI status for shipped PRs.
+//!
+//! Queries GitHub Actions check runs or Bitbucket Pipelines for PRs that were
+//! created by `parsec ship`.  The forge backend is selected automatically from
+//! the `origin` remote URL; GitHub takes priority when both tokens are set.
+//!
+//! ## Commands
+//! - **`parsec ci [ticket…]`** — print the current CI status for one or more
+//!   tickets.
+//! - **`parsec ci --all`** — check every ticket that has a shipped PR in the
+//!   oplog.
+//! - **`parsec ci --watch`** — poll every 5 s and redraw the terminal until all
+//!   checks reach a terminal state (human mode only).
+
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -16,6 +30,20 @@ enum Forge {
     Bitbucket(bitbucket::BitbucketClient),
 }
 
+/// Show CI check status for one or more worktrees' shipped PRs.
+///
+/// # Resolution order
+/// 1. `--all` → every `Ship` oplog entry.
+/// 2. `tickets` (non-empty) → look up the most recent `Ship` entry per ticket,
+///    falling back to a live PR search by branch name.
+/// 3. Neither → auto-detect from `cwd`.
+///
+/// # Watch mode
+/// When `watch = true` (and `mode == Human`) the terminal is cleared every 5 s
+/// and CI statuses are redrawn until all checks reach a terminal state.
+/// Watch mode is silently disabled for JSON output to allow piping.
+///
+/// Exits with [`ErrorCode::E002`] when any check is in a failing state.
 pub async fn ci(repo: &Path, tickets: &[&str], watch: bool, all: bool, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let repo_root = git::get_main_repo_root(repo).or_else(|_| git::get_repo_root(repo))?;
@@ -193,6 +221,10 @@ pub async fn ci(repo: &Path, tickets: &[&str], watch: bool, all: bool, mode: Mod
 
 /// Fetch the latest pipeline for the PR's source branch and shape it into the
 /// same `CiStatus` struct GitHub emits, so the renderer stays forge-agnostic.
+///
+/// Returns an empty [`CiStatus`] (overall = `"no checks"`) when the PR's
+/// source branch cannot be resolved — matching the behaviour of GitHub's
+/// "no checks" path rather than propagating an error.
 async fn fetch_bitbucket_ci(
     bb: &bitbucket::BitbucketClient,
     pr_id: u64,

--- a/src/cli/commands/stack.rs
+++ b/src/cli/commands/stack.rs
@@ -1,3 +1,18 @@
+//! `parsec stack` / `parsec stack sync` / `parsec stack submit` — stacked worktree management.
+//!
+//! A *stack* is a chain of worktrees where each child is based on its parent's
+//! branch instead of the shared base branch.  Stacks are created via
+//! `parsec start <ticket> --on <parent_ticket>` and allow dependent changes to
+//! be developed in parallel without waiting for parent PRs to land.
+//!
+//! ## Commands
+//! - **`parsec stack`** — list all worktrees that participate in at least one
+//!   stack (have a `parent_ticket` or are themselves a parent).
+//! - **`parsec stack sync`** — rebase every stack from root to leaves so that
+//!   each child always sits on top of its parent's latest commit.
+//! - **`parsec stack submit`** — ship the entire stack in topological order
+//!   (root first, leaves last) by calling [`super::ship`] for each member.
+
 use std::path::Path;
 
 use anyhow::Result;
@@ -7,6 +22,14 @@ use crate::git;
 use crate::output::{self, Mode};
 use crate::worktree::WorktreeManager;
 
+/// List all worktrees that are part of a stack.
+///
+/// A worktree participates in a stack when it either:
+/// - has a `parent_ticket` (it is a child), **or**
+/// - is referenced as the parent of another worktree.
+///
+/// Outputs nothing (human) or an empty JSON array when no stacks exist,
+/// with a hint message in human mode.
 pub async fn stack(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
@@ -38,6 +61,17 @@ pub async fn stack(repo: &Path, mode: Mode) -> Result<()> {
     Ok(())
 }
 
+/// Synchronise a stack by rebasing every worktree onto its dependency.
+///
+/// Traversal order (BFS from each root):
+/// 1. Root worktrees (no parent) are rebased onto `origin/<base_branch>`.
+/// 2. Each child is then rebased onto its parent's local branch tip.
+///
+/// A failed rebase is automatically aborted (`git rebase --abort`) so the
+/// worktree is left in a clean state.  The failed ticket is recorded in
+/// `failed` and processing continues with the next root.
+///
+/// Returns a summary of synced and failed tickets via [`output::print_sync`].
 pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;
@@ -118,6 +152,13 @@ pub async fn stack_sync(repo: &Path, mode: Mode) -> Result<()> {
 }
 
 /// Ship the entire stack in topological order (#235).
+///
+/// Determines the topological order (BFS from roots) and calls
+/// [`super::ship`] for each worktree.  Processing stops at the first failure
+/// to avoid creating PRs with a broken dependency chain.
+///
+/// `mode` is forwarded to `ship` for consistent output formatting.
+/// Returns an error when one or more tickets could not be shipped.
 pub async fn stack_submit(repo: &Path, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
     let manager = WorktreeManager::new(repo, &config)?;


### PR DESCRIPTION
## 무엇
`src/cli/commands/stack.rs`와 `src/cli/commands/ci.rs`에 module-level `//!` 및 function-level `///` RustDoc 추가.

## 왜
- 인접 모듈(`diff.rs`, `history.rs`, `smartlog.rs`, `complete.rs`)은 모두 문서화된 상태
- `stack`/`stack_sync`/`stack_submit`/`ci`/`fetch_bitbucket_ci` 5개 함수가 설명 없이 노출 → 신규 기여자 진입 장벽
- 일관성 확보 및 `cargo doc` 품질 개선

## 변경

| 파일 | 추가 내용 |
|------|-----------|
| `stack.rs` | `//!` 모듈 헤더 (3개 커맨드 역할·스택 개념 설명) + `stack`·`stack_sync`·`stack_submit` 함수 doc |
| `ci.rs` | `//!` 모듈 헤더 (forge 선택 로직·`--watch` 동작 설명) + `ci`·`fetch_bitbucket_ci` 함수 doc |

프로덕션 코드 변경 없음 — 주석 73줄 추가만.

## 리스크
없음. 주석 전용 변경.

## 롤백
브랜치 drop 또는 `git revert HEAD`.

## Test plan
- `cargo build --quiet` ✅
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅

Closes #322

@erishforG 검토 부탁드립니다 🖤