### PR TITLE
feat(completion): Phase 2 — dynamic zsh/bash/fish shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ cargo install git-parsec
 
 Other targets (macOS arm64/x86_64, Windows x86_64) ship on every release — see [Releases](https://github.com/erishforG/git-parsec/releases). After install, run `parsec config init` for the interactive first-time setup, then `parsec doctor` to validate.
 
+### Shell completion
+
+`parsec` ships dynamic completion scripts that suggest **live worktrees and branches** as you type (e.g. `parsec switch <Tab>` lists your active tickets).
+
+```bash
+# zsh — copy to a site fpath dir, or add the repo path to fpath:
+cp completions/_parsec ~/.zsh/completions/      # then: fpath=(~/.zsh/completions $fpath)
+
+# bash:
+source completions/parsec.bash                  # or symlink into /etc/bash_completion.d/
+
+# fish:
+cp completions/parsec.fish ~/.config/fish/completions/
+```
+
+A purely static fallback (no live candidates) is also available via `parsec config completions <shell>` if you'd rather not source the dynamic scripts.
+
 ---
 
 ## 60-second tour

--- a/completions/_parsec
+++ b/completions/_parsec
@@ -1,0 +1,111 @@
+#compdef parsec
+# zsh completion for git-parsec — dynamic worktree/branch candidates.
+#
+# Issue #291 Phase 2. Source this file from ~/.zshrc:
+#
+#   fpath=(/path/to/git-parsec/completions $fpath)
+#   autoload -U compinit && compinit
+#
+# Or run once to install into a site fpath dir:
+#
+#   cp completions/_parsec /usr/local/share/zsh/site-functions/
+#
+# Companion to the static structure emitted by `parsec config completions zsh`;
+# this file replaces it with dynamic completion that calls
+# `parsec __complete worktrees|branches` for ticket and branch arguments.
+
+# -- Dynamic candidate fetchers ------------------------------------------------
+_parsec_worktrees() {
+    local -a tickets
+    tickets=("${(@f)$(parsec __complete worktrees 2>/dev/null)}")
+    _describe -t tickets 'parsec worktree' tickets
+}
+
+_parsec_branches() {
+    local -a branches
+    branches=("${(@f)$(parsec __complete branches 2>/dev/null)}")
+    _describe -t branches 'git branch' branches
+}
+
+# -- Top-level subcommand list -------------------------------------------------
+_parsec_subcommands() {
+    local -a subs
+    subs=(
+        'start:Create new worktree for ticket'
+        'switch:Print path to a worktree'
+        'ship:Open or update PR for current worktree'
+        'open:Open ticket/PR in browser'
+        'list:List all active worktrees'
+        'status:Show ticket status'
+        'ticket:Show current ticket'
+        'clean:Remove merged worktree'
+        'pr-status:Show PR status'
+        'ci:Show CI status'
+        'merge:Merge one or more PRs'
+        'diff:Diff against base'
+        'sync:Rebase/merge from base'
+        'log:Audit log of recent ops'
+        'compress:Squash worktree commits'
+        'rename:Rename a ticket'
+        'adopt:Adopt existing branch as ticket'
+        'smartlog:Visualize worktrees as DAG'
+        'sl:Alias of smartlog'
+        'config:Configuration commands'
+        'doctor:Diagnose environment'
+        'health:Check worktree health'
+        'conflicts:Detect file overlap'
+        'history:Show command history'
+        'stack:Stack-aware operations'
+        'release:Cut a release'
+    )
+    _describe -t commands 'parsec subcommand' subs
+}
+
+# -- Main dispatcher -----------------------------------------------------------
+_parsec() {
+    local context state state_descr line
+    typeset -A opt_args
+
+    _arguments -C \
+        '1: :_parsec_subcommands' \
+        '*::arg:->args' \
+        '--json[Emit JSON output]' \
+        '--quiet[Suppress output]'
+
+    case $state in
+        (args)
+            case $line[1] in
+                start)
+                    _arguments \
+                        '1:ticket:_parsec_worktrees' \
+                        '--base[Base branch]:branch:_parsec_branches' \
+                        '--on[Stack on ticket]:ticket:_parsec_worktrees' \
+                        '--branch[Use existing branch]:branch:_parsec_branches' \
+                        '--title[Title for PR]:title:'
+                    ;;
+                switch|ship|open|clean|status|ticket|pr-status|diff|sync|compress|log|adopt)
+                    _arguments '1:ticket:_parsec_worktrees'
+                    ;;
+                merge|ci)
+                    _arguments '*:ticket:_parsec_worktrees'
+                    ;;
+                rename)
+                    _arguments \
+                        '1:old-ticket:_parsec_worktrees' \
+                        '2:new-ticket:'
+                    ;;
+                smartlog|sl)
+                    _arguments \
+                        '--depth[Max commits per worktree]:n:' \
+                        '--no-overlay[Skip GitHub PR/CI lookup]'
+                    ;;
+                *)
+                    # Defer to default file completion for unknown commands.
+                    _default
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_parsec "$@"

--- a/completions/parsec.bash
+++ b/completions/parsec.bash
@@ -1,0 +1,98 @@
+# bash completion for git-parsec — dynamic worktree/branch candidates.
+#
+# Issue #291 Phase 2. Source this file from ~/.bashrc:
+#
+#   source /path/to/git-parsec/completions/parsec.bash
+#
+# Or install to the bash-completion directory:
+#
+#   cp completions/parsec.bash /etc/bash_completion.d/parsec
+#
+# Companion to the static structure emitted by `parsec config completions bash`;
+# this file replaces it with dynamic completion calling
+# `parsec __complete worktrees|branches` for ticket and branch arguments.
+
+_parsec_subcommands="start switch ship open list status ticket clean pr-status \
+ci merge diff sync log compress rename adopt smartlog sl config doctor health \
+conflicts history stack release"
+
+_parsec_worktrees() {
+    parsec __complete worktrees 2>/dev/null
+}
+
+_parsec_branches() {
+    parsec __complete branches 2>/dev/null
+}
+
+_parsec() {
+    local cur prev words cword
+    _init_completion || return
+
+    # Find the subcommand (first non-flag word after `parsec`).
+    local sub=""
+    local i=1
+    while [ $i -lt $cword ]; do
+        case "${words[i]}" in
+            --json|--quiet) ;;
+            -*) ;;
+            *) sub="${words[i]}"; break ;;
+        esac
+        ((i++))
+    done
+
+    # Completing the subcommand itself.
+    if [ -z "$sub" ]; then
+        COMPREPLY=( $(compgen -W "$_parsec_subcommands" -- "$cur") )
+        return
+    fi
+
+    # Option arguments first (only --base / --on / --branch take dynamic values).
+    case "$prev" in
+        --base|--branch)
+            COMPREPLY=( $(compgen -W "$(_parsec_branches)" -- "$cur") )
+            return
+            ;;
+        --on)
+            COMPREPLY=( $(compgen -W "$(_parsec_worktrees)" -- "$cur") )
+            return
+            ;;
+        --depth|--title)
+            return # free text
+            ;;
+    esac
+
+    # Don't complete option flag values, defer to default.
+    if [[ "$cur" == -* ]]; then
+        case "$sub" in
+            start)
+                COMPREPLY=( $(compgen -W "--base --on --branch --title" -- "$cur") )
+                ;;
+            ship)
+                COMPREPLY=( $(compgen -W "--base --reviewer" -- "$cur") )
+                ;;
+            smartlog|sl)
+                COMPREPLY=( $(compgen -W "--depth --no-overlay --json" -- "$cur") )
+                ;;
+            *)
+                COMPREPLY=( $(compgen -W "--json --quiet" -- "$cur") )
+                ;;
+        esac
+        return
+    fi
+
+    # Positional argument by subcommand.
+    case "$sub" in
+        start|switch|ship|open|clean|status|ticket|pr-status|diff|sync|compress|log|adopt|rename)
+            COMPREPLY=( $(compgen -W "$(_parsec_worktrees)" -- "$cur") )
+            ;;
+        merge|ci)
+            COMPREPLY=( $(compgen -W "$(_parsec_worktrees)" -- "$cur") )
+            ;;
+        *)
+            # Fall back to filename completion for unknown subcommands.
+            _filedir
+            ;;
+    esac
+}
+
+complete -F _parsec parsec

--- a/completions/parsec.fish
+++ b/completions/parsec.fish
@@ -1,0 +1,84 @@
+# fish completion for git-parsec — dynamic worktree/branch candidates.
+#
+# Issue #291 Phase 2. Install:
+#
+#   cp completions/parsec.fish ~/.config/fish/completions/
+#
+# Companion to the static structure emitted by `parsec config completions fish`;
+# this file replaces it with dynamic completion calling
+# `parsec __complete worktrees|branches` for ticket and branch arguments.
+
+# -- Dynamic candidate providers ----------------------------------------------
+function __parsec_worktrees
+    parsec __complete worktrees 2>/dev/null
+end
+
+function __parsec_branches
+    parsec __complete branches 2>/dev/null
+end
+
+# -- Top-level subcommand list ------------------------------------------------
+complete -c parsec -f -n __fish_use_subcommand -a start       -d 'Create new worktree'
+complete -c parsec -f -n __fish_use_subcommand -a switch      -d 'Print worktree path'
+complete -c parsec -f -n __fish_use_subcommand -a ship        -d 'Open or update PR'
+complete -c parsec -f -n __fish_use_subcommand -a open        -d 'Open ticket/PR in browser'
+complete -c parsec -f -n __fish_use_subcommand -a list        -d 'List all worktrees'
+complete -c parsec -f -n __fish_use_subcommand -a status      -d 'Show ticket status'
+complete -c parsec -f -n __fish_use_subcommand -a ticket      -d 'Show current ticket'
+complete -c parsec -f -n __fish_use_subcommand -a clean       -d 'Remove merged worktree'
+complete -c parsec -f -n __fish_use_subcommand -a pr-status   -d 'Show PR status'
+complete -c parsec -f -n __fish_use_subcommand -a ci          -d 'Show CI status'
+complete -c parsec -f -n __fish_use_subcommand -a merge       -d 'Merge PRs'
+complete -c parsec -f -n __fish_use_subcommand -a diff        -d 'Diff against base'
+complete -c parsec -f -n __fish_use_subcommand -a sync        -d 'Rebase/merge from base'
+complete -c parsec -f -n __fish_use_subcommand -a log         -d 'Audit log'
+complete -c parsec -f -n __fish_use_subcommand -a compress    -d 'Squash worktree commits'
+complete -c parsec -f -n __fish_use_subcommand -a rename      -d 'Rename a ticket'
+complete -c parsec -f -n __fish_use_subcommand -a adopt       -d 'Adopt existing branch'
+complete -c parsec -f -n __fish_use_subcommand -a smartlog    -d 'Visualize worktrees as DAG'
+complete -c parsec -f -n __fish_use_subcommand -a sl          -d 'Alias of smartlog'
+complete -c parsec -f -n __fish_use_subcommand -a config      -d 'Configuration'
+complete -c parsec -f -n __fish_use_subcommand -a doctor      -d 'Diagnose environment'
+complete -c parsec -f -n __fish_use_subcommand -a health      -d 'Check worktree health'
+complete -c parsec -f -n __fish_use_subcommand -a conflicts   -d 'Detect file overlap'
+complete -c parsec -f -n __fish_use_subcommand -a history     -d 'Command history'
+complete -c parsec -f -n __fish_use_subcommand -a stack       -d 'Stack-aware operations'
+complete -c parsec -f -n __fish_use_subcommand -a release     -d 'Cut a release'
+
+# -- Per-subcommand positional: worktree ticket -------------------------------
+set -l ticket_cmds start switch ship open clean status ticket pr-status \
+    ci merge diff sync log compress adopt rename
+
+for cmd in $ticket_cmds
+    complete -c parsec -f -n "__fish_seen_subcommand_from $cmd" \
+        -a '(__parsec_worktrees)'
+end
+
+# -- Per-subcommand option flags ----------------------------------------------
+# start: --base / --on / --branch / --title
+complete -c parsec -f -n '__fish_seen_subcommand_from start' \
+    -l base   -d 'Base branch' -a '(__parsec_branches)'
+complete -c parsec -f -n '__fish_seen_subcommand_from start' \
+    -l on     -d 'Stack on ticket' -a '(__parsec_worktrees)'
+complete -c parsec -f -n '__fish_seen_subcommand_from start' \
+    -l branch -d 'Use existing branch' -a '(__parsec_branches)'
+complete -c parsec -n '__fish_seen_subcommand_from start' \
+    -l title  -d 'Title for PR'
+
+# ship: --base
+complete -c parsec -f -n '__fish_seen_subcommand_from ship' \
+    -l base   -d 'Base branch for PR' -a '(__parsec_branches)'
+
+# smartlog: --depth / --no-overlay
+complete -c parsec -n '__fish_seen_subcommand_from smartlog sl' \
+    -l depth -d 'Max commits per worktree'
+complete -c parsec -f -n '__fish_seen_subcommand_from smartlog sl' \
+    -l no-overlay -d 'Skip GitHub PR/CI overlay'
+
+# adopt: --branch
+complete -c parsec -f -n '__fish_seen_subcommand_from adopt' \
+    -l branch -d 'Branch to adopt' -a '(__parsec_branches)'
+
+# -- Global flags --------------------------------------------------------------
+complete -c parsec -f -l json  -d 'Emit JSON output'
+complete -c parsec -f -l quiet -d 'Suppress output'

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1722,9 +1722,8 @@ fn test_health_json_one_worktree() {
     );
 
     // A fresh worktree must NOT have a lock file
-    assert_eq!(
-        entry["has_lock"].as_bool().unwrap(),
-        false,
+    assert!(
+        !entry["has_lock"].as_bool().unwrap(),
         "fresh worktree must not have index.lock"
     );
 
@@ -1779,4 +1778,88 @@ fn test_health_exit_zero_with_issues() {
 
     // Clean up
     std::fs::remove_file(&lock_path).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Shell completion scripts (issue #291 Phase 2)
+//
+// Sanity tests only — verify the scripts ship in the repo and reference the
+// __complete subcommand from PR #312. We cannot exercise real shell behavior
+// (zsh/bash/fish parsers in the test sandbox is too fragile / heavy), so the
+// scripts themselves stand in for the "would this complete?" question.
+// ---------------------------------------------------------------------------
+
+fn read_completion(name: &str) -> String {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("completions")
+        .join(name);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("completion script {} should exist: {}", path.display(), e))
+}
+
+#[test]
+fn completion_zsh_present_and_dynamic() {
+    let s = read_completion("_parsec");
+    assert!(s.contains("#compdef parsec"), "must start with #compdef");
+    assert!(
+        s.contains("parsec __complete worktrees"),
+        "zsh script must call __complete worktrees"
+    );
+    assert!(
+        s.contains("parsec __complete branches"),
+        "zsh script must call __complete branches"
+    );
+    // Confirm we wire ticket-shaped subcommands.
+    for sub in ["start", "switch", "ship", "open", "clean", "merge", "ci"] {
+        assert!(s.contains(sub), "zsh script must mention {}", sub);
+    }
+}
+
+#[test]
+fn completion_bash_present_and_dynamic() {
+    let s = read_completion("parsec.bash");
+    assert!(s.contains("complete -F _parsec parsec"));
+    assert!(s.contains("parsec __complete worktrees"));
+    assert!(s.contains("parsec __complete branches"));
+    for sub in ["start", "switch", "ship", "open", "clean", "merge", "ci"] {
+        assert!(s.contains(sub), "bash script must mention {}", sub);
+    }
+}
+
+#[test]
+fn completion_fish_present_and_dynamic() {
+    let s = read_completion("parsec.fish");
+    assert!(s.contains("__parsec_worktrees"));
+    assert!(s.contains("__parsec_branches"));
+    assert!(s.contains("parsec __complete worktrees"));
+    assert!(s.contains("parsec __complete branches"));
+    for sub in ["start", "switch", "ship", "open", "clean", "merge", "ci"] {
+        assert!(s.contains(sub), "fish script must mention {}", sub);
+    }
+}
+
+#[test]
+fn completion_scripts_reference_phase1_subcommand_signature() {
+    // The __complete subcommand only accepts `worktrees` and `branches` kinds
+    // today (PR #312). Phase 2 scripts must not use any other kind name or
+    // they'll silently emit nothing.
+    for name in ["_parsec", "parsec.bash", "parsec.fish"] {
+        let s = read_completion(name);
+        let valid_kinds = ["worktrees", "branches"];
+        for line in s.lines() {
+            if let Some(rest) = line.find("parsec __complete ").map(|i| &line[i + 18..]) {
+                let kind: String = rest
+                    .chars()
+                    .take_while(|c| c.is_ascii_alphanumeric())
+                    .collect();
+                assert!(
+                    valid_kinds.contains(&kind.as_str()),
+                    "{}: unknown __complete kind '{}' (allowed: {:?})",
+                    name,
+                    kind,
+                    valid_kinds
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 무엇

Issue #291 (shell completion) Phase 2: 실제 zsh/bash/fish 스크립트 3개를 \`completions/\` 디렉터리에 추가. PR #312 가 만든 \`parsec __complete <kind>\` 내부 명령을 호출해서 **live worktree 와 branch 후보를 동적으로 자동완성**.

이번 PR 후 사용자가 \`parsec switch <Tab>\` 누르면 본인이 작업 중인 티켓 목록이 바로 나옴.

## 왜

Phase 1 (#312) 의 \`__complete\` 는 candidate emitter 만 만들었지 실제 shell hook 이 없었음. clap_complete 의 정적 completion 으로는 ticket/branch 인자가 모두 \`_default\` (파일명) 로 떨어져서 실용성이 낮음.

issue #291 의 핵심 가치 (\"실제로 입력하는 동안 내 worktree 가 보임\") 가 이번 PR 로 동작:
```
$ parsec switch <Tab>
CL-2283  CL-2284  CL-2291
```

## 변경

### 신규 파일 (3개 shell)
- \`completions/_parsec\` (zsh, \`#compdef parsec\`) — \`_parsec_worktrees\` / \`_parsec_branches\` helper + 주요 subcommand 의 positional / option 자동완성
- \`completions/parsec.bash\` — bash-completion 기반 (\`complete -F _parsec parsec\`). prev word 기반 dispatch + \`compgen -W\`
- \`completions/parsec.fish\` — \`__fish_seen_subcommand_from\` 기반. per-subcommand 옵션 (\`--base\`, \`--on\`, \`--branch\`) 도 동적 branch/worktree 후보 연결

### 커버 범위 (Tier 1 + 2)
| 카테고리 | 커맨드 |
|---|---|
| 단일 ticket positional | start, switch, ship, open, clean, status, ticket, pr-status, diff, sync, log, compress, adopt |
| 가변 ticket | merge, ci |
| 2개 ticket | rename |
| branch 옵션 | \`start --base/--on/--branch\`, \`ship --base\`, \`adopt --branch\` |
| smartlog | \`--depth\`, \`--no-overlay\` (PR #327 호환) |

### README
\`Install\` 섹션 아래에 \`Shell completion\` 서브섹션 추가 (3개 shell 설치 명령 1줄씩).

## \`__complete\` kind 추가
**없음**. Phase 1 의 \`worktrees\` / \`branches\` 두 개로 충분. 추후 Phase 3 에서 필요 시 추가 (예: \`tickets\` 트래커, \`reviewers\` GitHub 사용자).

## 드라이브-바이
PR #327 (smartlog Phase 2) 에서도 같이 잡았던 \`tests/cli_tests.rs:1725\` clippy 경고 (#326 회귀) 재적용. PR #327 머지되면 충돌 자동 해소.

## 다음 Phase 힌트
- Phase 3: \`__complete tickets\` (트래커 미해결 티켓), \`__complete reviewers\` (GitHub mention)
- Phase 4: shell auto-install hook (\`parsec init\` 에서 자동 설치 옵션)

## 리스크
**low** — 신규 파일 3개 + README 추가. 기존 \`parsec config completions <shell>\` 정적 path 그대로 작동, 사용자가 dynamic 원하면 sourcing 만 선택.

## 롤백
\`completions/\` 디렉터리 삭제 + README diff revert.

## Test plan
- [x] cargo build --quiet 통과
- [x] cargo fmt --check 통과
- [x] cargo clippy --all-targets -- -D warnings 통과 (#326 회귀 함께 수정)
- [x] cargo test 전체 통과
- [x] 신규 4개 integration 테스트 (zsh/bash/fish + cross-script kind 검증)

Refs #291

@erishforG

🤖 Generated with [Claude Code](https://claude.com/claude-code)