### PR TITLE
feat(smartlog): Phase 3 — worktree filter, ANSI color, stack indicator

### DIFF
--- a/src/cli/commands/smartlog.rs
+++ b/src/cli/commands/smartlog.rs
@@ -7,15 +7,26 @@
 //! - Read each worktree's commits since its base branch (`base..branch`)
 //! - Render as ASCII tree, or emit JSON
 //!
-//! Phase 2 (this PR — PR/CI overlay):
+//! Phase 2 (PR #327 — PR/CI overlay):
 //! - For each worktree, look up the GitHub PR by branch name and attach a
 //!   compact overlay ([`SmartlogPrOverlay`]) describing the PR number, state,
 //!   CI status and review status.
 //! - Overlay is best-effort: missing token / no PR / network errors all
 //!   degrade gracefully to "no overlay" without failing the command.
 //! - Users can opt out with `--no-overlay` for a fully offline run.
+//!
+//! Phase 3 (this PR — filter · color · stack indicators):
+//! - `--worktree <pattern>`: show only worktrees whose ticket or branch contains
+//!   the pattern (case-insensitive substring match).
+//! - ANSI color in the PR/CI badge: green=success, red=failure, yellow=pending,
+//!   blue=open PR, dim=draft. Automatically disabled when `NO_COLOR` is set or
+//!   stdout is not a TTY.
+//! - Stack indicator: when a worktree's base branch is itself another active
+//!   worktree's branch, annotate it with `⤷ stacked on <ticket>` so stacked-PR
+//!   flows are immediately visible.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::io::IsTerminal as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -82,6 +93,7 @@ pub async fn smartlog(
     repo: &Path,
     depth: Option<usize>,
     no_overlay: bool,
+    worktree_filter: Option<&str>,
     mode: Mode,
 ) -> Result<()> {
     let depth = depth.unwrap_or(DEFAULT_DEPTH);
@@ -107,16 +119,27 @@ pub async fn smartlog(
         });
     }
 
+    // Phase 3: apply --worktree filter (case-insensitive substring match on
+    // ticket or branch name).
+    if let Some(pat) = worktree_filter {
+        let pat_lower = pat.to_lowercase();
+        nodes.retain(|n| {
+            n.ticket.to_lowercase().contains(&pat_lower)
+                || n.branch.to_lowercase().contains(&pat_lower)
+        });
+    }
+
     if !no_overlay {
         attach_pr_overlay(repo, &config, &mut nodes).await;
     }
 
+    let color = color_enabled();
     match mode {
         Mode::Json => {
             println!("{}", serde_json::to_string_pretty(&nodes)?);
         }
         _ => {
-            print!("{}", render_text(&nodes));
+            print!("{}", render_text(&nodes, color));
         }
     }
     Ok(())
@@ -199,27 +222,44 @@ fn collect_commits(
 /// Glyphs match `parsec pr status` / `parsec ci` conventions so users see the
 /// same vocabulary across commands:
 /// - state: `open` → `●`, `merged`/`closed` → `✓`, `draft` → `○`, other → `?`
-/// - CI: `success` → `✓ CI`, `failure` → `✗ CI`, `pending` → `● CI`, else `? CI`
-/// - review: `approved` → `✓ approved`, `changes_requested` → `✗ changes`,
-///   `pending` → `● review`, `no reviews` → omitted
-fn format_pr_badge(pr: &SmartlogPrOverlay) -> String {
-    let state_glyph = match pr.state.as_str() {
-        "open" => "●",
-        "merged" | "closed" => "✓",
-        "draft" => "○",
-        _ => "?",
+/// - CI: `success` → `✓ CI` (green), `failure` → `✗ CI` (red),
+///   `pending` → `● CI` (yellow), else `? CI`
+/// - review: `approved` → `✓ approved` (green), `changes_requested` → `✗ changes` (red),
+///   `pending` → `● review` (yellow), `no reviews` → omitted
+///
+/// `color` enables ANSI SGR codes. Pass `false` in tests / piped output.
+fn format_pr_badge(pr: &SmartlogPrOverlay, color: bool) -> String {
+    // ANSI SGR codes used:  32=green  31=red  33=yellow  34=blue  2=dim
+    let (state_glyph, state_str) = match pr.state.as_str() {
+        "open" => (
+            ansi_wrap(34, "●", color), // blue
+            ansi_wrap(34, &pr.state, color),
+        ),
+        "merged" => (
+            ansi_wrap(32, "✓", color), // green
+            ansi_wrap(32, &pr.state, color),
+        ),
+        "closed" => (
+            ansi_wrap(2, "✓", color), // dim
+            ansi_wrap(2, &pr.state, color),
+        ),
+        "draft" => (
+            ansi_wrap(2, "○", color), // dim
+            ansi_wrap(2, &pr.state, color),
+        ),
+        _ => ("?".to_string(), pr.state.clone()),
     };
     let ci = match pr.ci_status.as_str() {
-        "success" => "✓ CI",
-        "failure" => "✗ CI",
-        "pending" => "● CI",
-        _ => "? CI",
+        "success" => ansi_wrap(32, "✓ CI", color), // green
+        "failure" => ansi_wrap(31, "✗ CI", color), // red
+        "pending" => ansi_wrap(33, "● CI", color), // yellow
+        _ => "? CI".to_string(),
     };
-    let mut out = format!("[PR #{} {} {} {}]", pr.number, state_glyph, pr.state, ci);
+    let mut out = format!("[PR #{} {} {} {}]", pr.number, state_glyph, state_str, ci);
     let review = match pr.review_status.as_str() {
-        "approved" => Some("✓ approved"),
-        "changes_requested" => Some("✗ changes"),
-        "pending" => Some("● review"),
+        "approved" => Some(ansi_wrap(32, "✓ approved", color)),
+        "changes_requested" => Some(ansi_wrap(31, "✗ changes", color)),
+        "pending" => Some(ansi_wrap(33, "● review", color)),
         _ => None, // "no reviews" or unknown → omit
     };
     if let Some(r) = review {
@@ -260,10 +300,19 @@ fn parse_commit_line(line: &str) -> Option<CommitSummary> {
 ///
 /// Returns the rendered string (instead of printing) so it's testable. Empty
 /// node list returns a single explanatory line.
-pub fn render_text(nodes: &[SmartlogNode]) -> String {
+///
+/// `color` enables ANSI escape codes in the PR/CI badge. Pass `false` in tests
+/// or when `NO_COLOR` is set to keep output predictable.
+pub fn render_text(nodes: &[SmartlogNode], color: bool) -> String {
     if nodes.is_empty() {
         return "No active worktrees. Run `parsec start <ticket>` to create one.\n".to_string();
     }
+
+    // Phase 3: build branch → ticket lookup for stack indicator.
+    let branch_to_ticket: HashMap<&str, &str> = nodes
+        .iter()
+        .map(|n| (n.branch.as_str(), n.ticket.as_str()))
+        .collect();
 
     let mut by_base: BTreeMap<String, Vec<&SmartlogNode>> = BTreeMap::new();
     for n in nodes {
@@ -273,7 +322,13 @@ pub fn render_text(nodes: &[SmartlogNode]) -> String {
     let mut out = String::new();
     let base_count = by_base.len();
     for (base_idx, (base, group)) in by_base.iter().enumerate() {
-        out.push_str(&format!("○ {} (base)\n", base));
+        // Phase 3: if the base branch is itself a worktree branch, mark it as
+        // a stacked group rather than a plain base label.
+        if let Some(parent_ticket) = branch_to_ticket.get(base.as_str()) {
+            out.push_str(&format!("○ {} (stacked on {})\n", base, parent_ticket));
+        } else {
+            out.push_str(&format!("○ {} (base)\n", base));
+        }
         let last_idx = group.len().saturating_sub(1);
         for (i, node) in group.iter().enumerate() {
             let is_last = i == last_idx;
@@ -287,10 +342,9 @@ pub fn render_text(nodes: &[SmartlogNode]) -> String {
 
             let prefix = if is_last { "   " } else { "│  " };
             // PR overlay (Phase 2): one line above commits when overlay set.
-            // Always uses `├─` so it visually attaches to the ticket above and
-            // the commits below; the actual tree closes on the last commit.
+            // Phase 3: badge is now optionally colorized.
             if let Some(pr) = &node.pr {
-                out.push_str(&format!("{}├─ {}\n", prefix, format_pr_badge(pr)));
+                out.push_str(&format!("{}├─ {}\n", prefix, format_pr_badge(pr, color)));
             }
             if node.commits.is_empty() {
                 out.push_str(&format!("{}└─ (no commits since {})\n", prefix, base));
@@ -310,6 +364,38 @@ pub fn render_text(nodes: &[SmartlogNode]) -> String {
         }
     }
     out
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 helpers: color support
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when ANSI color output is appropriate.
+///
+/// Rules (first-match):
+/// 1. `NO_COLOR` env var set (any value) → false (XDG spec).
+/// 2. `PARSEC_COLOR=always` → true (force-on override).
+/// 3. Stdout is not a TTY → false (piped / redirected output).
+/// 4. Otherwise → true.
+fn color_enabled() -> bool {
+    if std::env::var_os("NO_COLOR").is_some() {
+        return false;
+    }
+    if std::env::var("PARSEC_COLOR").as_deref() == Ok("always") {
+        return true;
+    }
+    std::io::stdout().is_terminal()
+}
+
+/// Wrap `text` in the given ANSI SGR code when `color` is true.
+///
+/// Always appends SGR reset (0) after the text so colors don't bleed.
+fn ansi_wrap(code: u8, text: &str, color: bool) -> String {
+    if color {
+        format!("\x1b[{}m{}\x1b[0m", code, text)
+    } else {
+        text.to_string()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -380,7 +466,7 @@ mod tests {
 
     #[test]
     fn render_text_empty() {
-        let s = render_text(&[]);
+        let s = render_text(&[], false);
         assert!(s.contains("No active worktrees"));
     }
 
@@ -392,7 +478,7 @@ mod tests {
             "feature/CL-2283",
             vec![mk_commit("a1b2c3d", "Implement rate limiter")],
         )];
-        let s = render_text(&nodes);
+        let s = render_text(&nodes, false);
         assert!(s.contains("○ main (base)"));
         assert!(s.contains("CL-2283"));
         assert!(s.contains("Add rate limiting"));
@@ -403,7 +489,7 @@ mod tests {
     #[test]
     fn render_text_no_commits_shows_placeholder() {
         let nodes = vec![mk_node("CL-2291", None, "scratch/CL-2291", vec![])];
-        let s = render_text(&nodes);
+        let s = render_text(&nodes, false);
         assert!(s.contains("(no commits since main)"));
         assert!(s.contains("(no title)"));
     }
@@ -424,7 +510,7 @@ mod tests {
             vec![mk_commit("bbbbbbb", "second commit")],
         );
         b.base_branch = "develop".to_string();
-        let s = render_text(&[a, b]);
+        let s = render_text(&[a, b], false);
         assert!(s.contains("○ main (base)"));
         assert!(s.contains("○ develop (base)"));
         // Both nodes should render their commits.
@@ -455,20 +541,20 @@ mod tests {
 
     #[test]
     fn format_pr_badge_open_passing_approved() {
-        let badge = format_pr_badge(&mk_overlay("open", "success", "approved"));
+        let badge = format_pr_badge(&mk_overlay("open", "success", "approved"), false);
         assert!(badge.starts_with("[PR #42 ● open ✓ CI"));
         assert!(badge.ends_with("✓ approved]"));
     }
 
     #[test]
     fn format_pr_badge_no_reviews_drops_review_segment() {
-        let badge = format_pr_badge(&mk_overlay("open", "pending", "no reviews"));
+        let badge = format_pr_badge(&mk_overlay("open", "pending", "no reviews"), false);
         assert_eq!(badge, "[PR #42 ● open ● CI]");
     }
 
     #[test]
     fn format_pr_badge_merged_pr() {
-        let badge = format_pr_badge(&mk_overlay("merged", "success", "approved"));
+        let badge = format_pr_badge(&mk_overlay("merged", "success", "approved"), false);
         // `merged` carries no special CI semantics — render the API-reported CI as-is.
         assert!(badge.contains("✓ merged"));
         assert!(badge.contains("✓ CI"));
@@ -484,7 +570,7 @@ mod tests {
             vec![mk_commit("a1b2c3d", "Implement rate limiter")],
         );
         node.pr = Some(mk_overlay("open", "success", "approved"));
-        let s = render_text(&[node]);
+        let s = render_text(&[node], false);
         assert!(s.contains("CL-2283"), "ticket line still present");
         assert!(s.contains("[PR #42"), "PR badge rendered");
         assert!(s.contains("✓ approved"), "review badge rendered");
@@ -516,5 +602,90 @@ mod tests {
         );
         // ci field still omitted — Phase 2 folds CI into the overlay.
         assert!(v.get("ci").is_none(), "ci field stays omitted in Phase 2");
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3 tests: filter, color, stack indicator
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn worktree_filter_matches_ticket_substring() {
+        // Only PROJ-1 should survive a "PROJ-1" filter applied before render.
+        let nodes = vec![
+            mk_node("PROJ-10", Some("Ten"), "feat/PROJ-10", vec![]),
+            mk_node("PROJ-20", Some("Twenty"), "feat/PROJ-20", vec![]),
+        ];
+        let pat = "proj-1";
+        let pat_lower = pat.to_lowercase();
+        let filtered: Vec<_> = nodes
+            .into_iter()
+            .filter(|n| {
+                n.ticket.to_lowercase().contains(&pat_lower)
+                    || n.branch.to_lowercase().contains(&pat_lower)
+            })
+            .collect();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].ticket, "PROJ-10");
+    }
+
+    #[test]
+    fn worktree_filter_branch_fallback() {
+        // Pattern matches branch name even when ticket differs.
+        let mut node = mk_node("CL-99", Some("T"), "feat/special-ui", vec![]);
+        node.base_branch = "main".to_string();
+        let nodes = vec![node];
+        let pat_lower = "special".to_lowercase();
+        let filtered: Vec<_> = nodes
+            .into_iter()
+            .filter(|n| {
+                n.ticket.to_lowercase().contains(&pat_lower)
+                    || n.branch.to_lowercase().contains(&pat_lower)
+            })
+            .collect();
+        assert_eq!(filtered.len(), 1);
+    }
+
+    #[test]
+    fn stack_indicator_appears_when_base_is_sibling_branch() {
+        // PROJ-2 stacks on top of PROJ-1's branch.
+        let parent = mk_node("PROJ-1", Some("Parent"), "feat/PROJ-1", vec![]);
+        let mut child = mk_node("PROJ-2", Some("Child"), "feat/PROJ-2", vec![]);
+        child.base_branch = "feat/PROJ-1".to_string(); // base = parent's branch
+
+        let nodes = vec![parent, child];
+        let s = render_text(&nodes, false);
+        assert!(
+            s.contains("stacked on PROJ-1"),
+            "stack indicator missing in:\n{}",
+            s
+        );
+    }
+
+    #[test]
+    fn color_badge_contains_ansi_codes_when_enabled() {
+        let overlay = mk_overlay("open", "success", "approved");
+        let badge_color = format_pr_badge(&overlay, true);
+        let badge_plain = format_pr_badge(&overlay, false);
+        // Color badge should contain ESC character; plain should not.
+        assert!(
+            badge_color.contains('\x1b'),
+            "colored badge should contain ANSI escape"
+        );
+        assert!(
+            !badge_plain.contains('\x1b'),
+            "plain badge should not contain ANSI escape"
+        );
+    }
+
+    #[test]
+    fn color_badge_failure_ci_is_red() {
+        let overlay = mk_overlay("open", "failure", "pending");
+        let badge = format_pr_badge(&overlay, true);
+        // Red = ESC[31m before "✗ CI"
+        assert!(
+            badge.contains("\x1b[31m"),
+            "failure CI should use red (31) ANSI code, got: {:?}",
+            badge
+        );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -540,6 +540,12 @@ pub enum Command {
         /// Overlay is also auto-skipped when no GitHub token is configured.
         #[arg(long)]
         no_overlay: bool,
+
+        /// Show only worktrees whose ticket or branch name contains this
+        /// pattern (case-insensitive substring match).
+        /// Example: `parsec sl --worktree PROJ-4` shows all PROJ-4* tickets.
+        #[arg(long, short = 'w', value_name = "PATTERN")]
+        worktree: Option<String>,
     },
 
     /// Show PR review status across all active worktrees (issue #301).
@@ -957,8 +963,19 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Compress { ticket, message } => {
             commands::compress(&repo_path, ticket.as_deref(), message, output_mode).await
         }
-        Command::Smartlog { depth, no_overlay } => {
-            commands::smartlog(&repo_path, depth, no_overlay, output_mode).await
+        Command::Smartlog {
+            depth,
+            no_overlay,
+            worktree,
+        } => {
+            commands::smartlog(
+                &repo_path,
+                depth,
+                no_overlay,
+                worktree.as_deref(),
+                output_mode,
+            )
+            .await
         }
         Command::Reviews => commands::reviews(&repo_path, output_mode).await,
         Command::Complete { kind } => commands::complete(&repo_path, kind).await,


### PR DESCRIPTION
## 무엇

Phase 3 of smartlog epic (#245): three focused UX improvements on top of the Phase 2 PR/CI overlay.

### `--worktree <pattern>` / `-w` filter
Case-insensitive substring match on ticket ID or branch name. Lets users focus on a single ticket family without scrolling past unrelated worktrees.

```
parsec sl -w PROJ-4        # show only PROJ-4* worktrees
parsec sl --worktree auth  # show only branches containing 'auth'
```

### ANSI color in PR/CI badge
Status symbols now carry ANSI SGR colors for instant triage:
| Condition | Color |
|---|---|
| CI success / approved / merged | 🟢 green (32) |
| CI failure / changes-requested | 🔴 red (31) |
| pending / open review | 🟡 yellow (33) |
| Open PR | 🔵 blue (34) |
| Draft / closed | dim (2) |

Auto-disabled when `NO_COLOR` env is set (XDG spec) or stdout is not a TTY.  
Force-enable with `PARSEC_COLOR=always`.

### Stack indicator
When a worktree's base branch matches another active worktree's branch name, the base-group header changes from `○ <branch> (base)` to `○ <branch> (stacked on <ticket>)`.  Stacked-PR workflows are now visible without running `parsec pr status` separately.

## 왜

Refs #245 (v0.5 milestone). Phase 1 (#305) built the skeleton, Phase 2 (#327) added the GitHub overlay. Phase 3 addresses the three remaining UX gaps in the table:
- per-worktree filtering (reduce signal/noise for large multi-worktree repos)
- color emphasis (critical for quick triage in the terminal)
- stack relationship visualization (multi-step PR stacks are common in worktree workflows)

## 변경

| File | Change |
|---|---|
| `src/cli/commands/smartlog.rs` | `--worktree` filter in `smartlog()`, `color_enabled()`, `ansi_wrap()`, updated `render_text()` + `format_pr_badge()`, 5 new tests |
| `src/cli/mod.rs` | `worktree: Option<String>` arg on `Smartlog` variant, destructure + pass-through |

2 files · +224/-36

## 다음 Phase 힌트 (Phase 4)

- `--since <date>` filter: show only worktrees with commits newer than N days
- Stacked PR tree re-ordering: render child worktrees indented under their parent instead of as a sibling group
- `--json` output for `worktree` filter field (for scripting)

## 리스크

low — additive only (new flag + color codes + label change). `render_text` signature changed (added `color: bool`) but the function is `pub` only for tests; no external callers outside this module.

## 롤백

`git revert <sha>` — no config/state changes.

## Test plan

```
cargo build --quiet      ✓
cargo fmt --check        ✓
cargo clippy --all-targets -- -D warnings  ✓
cargo test --quiet       ✓  138 tests (66 unit + 5 integration + 67 CLI)
```

5 new unit tests cover: ticket filter, branch filter, stack indicator label, ANSI escape presence, and red-code for failure CI.

@erishforG 검토 부탁드립니다.