### PR TITLE
feat(reviews): Phase 2 — --requested flag via GitHub Search API

### DIFF
--- a/src/cli/commands/reviews.rs
+++ b/src/cli/commands/reviews.rs
@@ -1,20 +1,16 @@
 //! `parsec reviews` — unified PR review status across all active worktrees (#301).
 //!
-//! Phase 1 (this PR):
+//! Phase 1 (PR #331):
 //! - Scan every active worktree via [`WorktreeManager`].
 //! - For each worktree, resolve its open GitHub PR by branch name.
 //! - Fetch the PR's review + CI status and collect into a [`ReviewEntry`].
 //! - Render a table (human) or JSON array.
 //!
-//! Scope is intentionally the "author" view: PRs that the current user opened
-//! and that have a pending review request from others. Both pending and
-//! approved/changes-requested states are shown so that nothing falls through.
-//!
-//! Phase 2 hint:
-//! - Add `--requested` flag: use GitHub Search API
+//! Phase 2 (this PR):
+//! - Add `--requested` flag: uses GitHub Search API
 //!   (`/search/issues?q=review-requested:{login}`) to show PRs *from others*
 //!   where the current user is a requested reviewer.
-//! - Add `--all` to include closed/merged PRs.
+//! - Both views (author + requested) share the same `ReviewEntry` table output.
 
 use std::path::Path;
 
@@ -28,26 +24,18 @@ use crate::worktree::WorktreeManager;
 
 /// Entry point for the `parsec reviews` subcommand.
 ///
-/// Iterates all active worktrees, resolves their associated open GitHub PRs,
-/// and prints the aggregated review table.
+/// When `requested` is `false` (default): iterates all active worktrees,
+/// resolves their associated open GitHub PRs, and prints the aggregated
+/// review table (author view).
+///
+/// When `requested` is `true`: uses the GitHub Search API to find open PRs
+/// *in this repo* where the authenticated user is a requested reviewer.
 ///
 /// # Errors
 /// Returns an error if GitHub credentials are missing. Individual per-worktree
-/// failures (e.g. no PR for the branch) are silently skipped so that the rest
-/// of the table still renders.
-pub async fn reviews(repo: &Path, mode: Mode) -> Result<()> {
+/// failures (e.g. no PR for the branch) are silently skipped.
+pub async fn reviews(repo: &Path, requested: bool, mode: Mode) -> Result<()> {
     let config = ParsecConfig::load()?;
-    let manager = WorktreeManager::new(repo, &config)?;
-    let workspaces = manager.list()?;
-
-    if workspaces.is_empty() {
-        match mode {
-            Mode::Human => println!("No active worktrees — nothing to review."),
-            Mode::Json => println!("[]"),
-            Mode::Quiet => {}
-        }
-        return Ok(());
-    }
 
     let remote_url = git::get_remote_url(repo).unwrap_or_default();
     let gh = match GitHubClient::new(&remote_url, &config)? {
@@ -61,27 +49,57 @@ pub async fn reviews(repo: &Path, mode: Mode) -> Result<()> {
         }
     };
 
-    let mut entries: Vec<ReviewEntry> = Vec::new();
+    let entries = if requested {
+        collect_requested_reviews(&gh).await?
+    } else {
+        collect_authored_reviews(repo, &config, &gh).await?
+    };
+
+    if entries.is_empty() {
+        match mode {
+            Mode::Human => {
+                if requested {
+                    println!("No open PRs where you are a requested reviewer.");
+                } else {
+                    println!("No open PRs found in active worktrees.");
+                }
+            }
+            Mode::Json => println!("[]"),
+            Mode::Quiet => {}
+        }
+        return Ok(());
+    }
+
+    output::print_reviews(&entries, mode);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/// Collect PRs authored by the user — one per active worktree (Phase 1 logic).
+async fn collect_authored_reviews(
+    repo: &Path,
+    config: &ParsecConfig,
+    gh: &GitHubClient,
+) -> Result<Vec<ReviewEntry>> {
+    let manager = WorktreeManager::new(repo, config)?;
+    let workspaces = manager.list()?;
+    let mut entries = Vec::new();
 
     for ws in &workspaces {
-        // Resolve PR number from branch name — skip worktrees without an open PR.
         let pr_number = match gh.find_pr_by_branch(&ws.branch).await {
             Ok(Some(n)) => n,
-            Ok(None) => continue,
-            Err(_) => continue,
+            Ok(None) | Err(_) => continue,
         };
-
-        // Fetch PR status (title, state, ci_status, review_status, url).
         let status = match gh.get_pr_status(pr_number).await {
             Ok(s) => s,
             Err(_) => continue,
         };
-
-        // Phase 1 shows open + draft PRs only; closed/merged are filtered out.
         if status.state == "closed" {
             continue;
         }
-
         entries.push(ReviewEntry {
             ticket: ws.ticket.clone(),
             pr_number: status.number,
@@ -92,9 +110,36 @@ pub async fn reviews(repo: &Path, mode: Mode) -> Result<()> {
             url: status.url.clone(),
         });
     }
+    Ok(entries)
+}
 
-    output::print_reviews(&entries, mode);
-    Ok(())
+/// Collect PRs from *others* where the current user is a requested reviewer
+/// (Phase 2 — uses GitHub Search API).
+async fn collect_requested_reviews(gh: &GitHubClient) -> Result<Vec<ReviewEntry>> {
+    let login = gh.get_authenticated_user().await?;
+    let found = gh.search_review_requested_prs(&login).await?;
+
+    let mut entries = Vec::new();
+    for (pr_number, title, url, state) in found {
+        // Fetch full PR status to get CI + review data.
+        // Fall back to "–" on individual fetch failure rather than aborting.
+        let (review_status, ci_status) = match gh.get_pr_status(pr_number).await {
+            Ok(s) => (s.review_status, s.ci_status),
+            Err(_) => ("–".to_string(), "–".to_string()),
+        };
+
+        // No worktree is associated with reviewer-mode PRs.
+        entries.push(ReviewEntry {
+            ticket: "–".to_string(),
+            pr_number,
+            title,
+            state,
+            review_status,
+            ci_status,
+            url,
+        });
+    }
+    Ok(entries)
 }
 
 // ---------------------------------------------------------------------------
@@ -139,5 +184,13 @@ mod tests {
         let e = mk_entry("CL-300", 55, "changes_requested", "failure");
         assert_eq!(e.review_status, "changes_requested");
         assert_eq!(e.ci_status, "failure");
+    }
+
+    #[test]
+    fn review_entry_requested_mode_ticket_placeholder() {
+        // In --requested mode, ticket is set to "–" because no worktree is associated.
+        let e = mk_entry("–", 77, "pending", "success");
+        assert_eq!(e.ticket, "–");
+        assert_eq!(e.pr_number, 77);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -553,10 +553,17 @@ pub enum Command {
     /// Scans each active worktree, finds its associated open GitHub PR, and
     /// prints a unified review table showing review decisions and CI status.
     ///
-    /// Phase 2 will add `--requested` to show PRs from *others* where you are
-    /// a requested reviewer (uses GitHub Search API).
+    /// Use `--requested` to show PRs from *others* where you are a requested
+    /// reviewer (Phase 2 — uses GitHub Search API).
     #[command(name = "reviews", alias = "rv")]
-    Reviews,
+    Reviews {
+        /// Show PRs from others where you are a requested reviewer.
+        ///
+        /// Uses the GitHub Search API to find open PRs in this repo where
+        /// the authenticated user (`gh auth status`) is listed as a reviewer.
+        #[arg(long, short = 'r')]
+        requested: bool,
+    },
 
     /// Internal: emit dynamic completion candidates (issue #291).
     ///
@@ -674,7 +681,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Compress { .. } => "compress",
         Command::Smartlog { .. } => "smartlog",
         Command::Complete { .. } => "__complete",
-        Command::Reviews => "reviews",
+        Command::Reviews { .. } => "reviews",
     };
     let exec_id = crate::execlog::new_execution_id();
     let exec_started_at = chrono::Utc::now();
@@ -977,7 +984,9 @@ pub async fn run(cli: Cli) -> Result<()> {
             )
             .await
         }
-        Command::Reviews => commands::reviews(&repo_path, output_mode).await,
+        Command::Reviews { requested } => {
+            commands::reviews(&repo_path, requested, output_mode).await
+        }
         Command::Complete { kind } => commands::complete(&repo_path, kind).await,
     };
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -306,6 +306,30 @@ struct ApiPrListItem {
     number: Option<u64>,
 }
 
+#[derive(Deserialize)]
+struct ApiUserResponse {
+    #[serde(default)]
+    login: String,
+}
+
+#[derive(Deserialize)]
+struct ApiSearchItem {
+    #[serde(default)]
+    number: u64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    html_url: String,
+    #[serde(default)]
+    state: String,
+}
+
+#[derive(Deserialize)]
+struct ApiSearchResponse {
+    #[serde(default)]
+    items: Vec<ApiSearchItem>,
+}
+
 // ---------------------------------------------------------------------------
 // GitHubClient
 // ---------------------------------------------------------------------------
@@ -535,6 +559,45 @@ impl GitHubClient {
         let resp: Vec<ApiPrListItem> = send_with_retry(self.get(&url)).await?.json().await?;
 
         Ok(resp.first().and_then(|pr| pr.number))
+    }
+
+    /// Return the login of the authenticated GitHub user.
+    ///
+    /// Used by `parsec reviews --requested` to build the search query.
+    pub async fn get_authenticated_user(&self) -> Result<String> {
+        let resp: ApiUserResponse = send_with_retry(self.get("/user")).await?.json().await?;
+        if resp.login.is_empty() {
+            anyhow::bail!("GitHub API returned empty login; is the token valid?");
+        }
+        Ok(resp.login)
+    }
+
+    /// Search for open PRs in *this repo* where `login` is a requested reviewer.
+    ///
+    /// Uses the GitHub Search Issues API:
+    /// `GET /search/issues?q=repo:{owner}/{repo}+type:pr+state:open+review-requested:{login}`
+    ///
+    /// Returns a list of `(pr_number, title, html_url, state)` tuples.
+    /// Up to 30 results (GitHub Search default page size).
+    pub async fn search_review_requested_prs(
+        &self,
+        login: &str,
+    ) -> Result<Vec<(u64, String, String, String)>> {
+        let q = format!(
+            "repo:{}/{} type:pr state:open review-requested:{}",
+            self.remote.owner, self.remote.repo, login
+        );
+        // Use reqwest's .query() so the value is properly percent-encoded.
+        let resp: ApiSearchResponse =
+            send_with_retry(self.get("/search/issues").query(&[("q", &q)]))
+                .await?
+                .json()
+                .await?;
+        Ok(resp
+            .items
+            .into_iter()
+            .map(|item| (item.number, item.title, item.html_url, item.state))
+            .collect())
     }
 
     /// Merge a GitHub PR.


### PR DESCRIPTION
## 무엇

`parsec reviews --requested` (alias `rv -r`) 플래그 추가.

GitHub Search API를 통해 *이 저장소에서* 현재 인증된 사용자가 리뷰어로 지정된 오픈 PR 목록을 표시한다. 기존 Phase 1 (작성자 뷰)와 동일한 `ReviewEntry` 테이블 렌더러를 공유하므로 출력 형식이 일관된다.

Refs #301

## 왜

v0.5 epic #301 'parsec reviews'의 Phase 2.
PR #331에서 Phase 1 skeleton이 머지될 때 Phase 2 힌트로 명시된 기능:
> Phase 2: `--requested` flag 추가 — GitHub Search API `review-requested:{login}` 쿼리

## 변경

| 파일 | 변경 내용 |
|------|----------|
| `src/github/mod.rs` | `get_authenticated_user()` (GET /user) + `search_review_requested_prs(login)` (GET /search/issues) 추가. reqwest `.query()`로 URL 인코딩 — 새 외부 dep 없음. |
| `src/cli/commands/reviews.rs` | `collect_authored_reviews()` (Phase 1) / `collect_requested_reviews()` (Phase 2) 분리. 각각 `Vec<ReviewEntry>` 반환. |
| `src/cli/mod.rs` | `Reviews` variant에 `requested: bool` 필드 추가 + dispatch 업데이트. |

새 unit test: 리뷰어 모드 ticket placeholder (`"–"`) 검증 1개 추가 (기존 3개 유지).

## 다음 Phase 힌트

Phase 3:
- `--all` 플래그: closed/merged PR 포함
- `--author <login>` 필터: 특정 작성자 좁히기
- 두 뷰 통합 (`--authored + --requested` 동시 표시)

## 리스크

low — 신규 GitHub 메서드 2개 추가 (기존 메서드 패턴과 동일). 기존 명령/로직 무변경.

## 롤백

`git revert 1b04cd4` — 새로 추가된 메서드/필드만 되돌아감.

## Test plan

```
cargo build --quiet        # ✓ clean
cargo fmt --check          # ✓ clean
cargo clippy --all-targets -- -D warnings  # ✓ clean
cargo test --quiet         # ✓ 67 unit + 5 CLI + 67 integration = 139 tests all pass
```

@erishforG 검토 부탁드립니다!