### PR TITLE
release-prep: bump version + CHANGELOG + README for v0.5.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+# Windows-only: bump the binary's main-thread stack to 16 MB.
+# Default on Windows (1 MB) overflows after the v0.5 TUI dashboard added
+# ratatui + crossterm on top of tokio + reqwest — bitbucket integration tests
+# that spawn parsec.exe as a subprocess panicked with "thread 'main' has
+# overflowed its stack" on windows-latest runners.
+#
+# RUST_MIN_STACK only affects Rust-spawned threads, so it can't fix the OS-level
+# main-thread stack. The /STACK linker flag does. macOS / Linux already use an
+# 8 MB default and are unaffected.
+[target.'cfg(windows)']
+rustflags = ["-C", "link-arg=/STACK:16777216"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # 8 MB main-thread stack — Windows default (1 MB) overflows when ratatui +
+  # crossterm + tokio + reqwest are linked into the test binary (issue #248
+  # follow-up: bitbucket integration tests OOM'd on windows-latest after the
+  # TUI dashboard landed).
+  RUST_MIN_STACK: "8388608"
 
 jobs:
   branch-policy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,32 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-03 — _The visualization release_
+
+v0.5 마일스톤 **16/16 완료**. Polish & Power-User UX: 워크트리/PR/CI를 하나의
+시야에 모아주는 시각화·자동화 명령 6개 신규.
+
 ### Added
-- **v0.5 milestone opened** — see Roadmap in README. Themes: smartlog · TUI
-  dashboard · speculative merge · `parsec test` · AI PR descriptions.
-- **`parsec smartlog` (alias `sl`)** — visualize active worktrees as a commit
-  DAG. ASCII tree groups worktrees by base branch and shows commits since
-  merge-base; `--json` output for tooling. PR/CI overlay reserved for a
-  follow-up (#245, #305).
-- **`parsec __complete` shell-completion helper** — hidden `__complete
-  <worktrees|branches>` subcommand emits newline-separated completion
-  candidates. Enables dynamic worktree/branch tab-completion in zsh, bash,
-  and fish without bundling shell-specific generators (#291, #312).
+- **`parsec smartlog` (alias `sl`)** — 모든 활성 워크트리를 commit DAG로 시각화.
+  ASCII 트리가 base branch별로 워크트리를 묶고 merge-base 이후 커밋을 표시.
+  Phase 2 PR/CI status overlay (`#327`), Phase 3 worktree filter + ANSI 색상 +
+  stack indicator (`#333`). `--json` 출력 지원. (`#245`, `#305`, `#318`, `#319`)
+- **`parsec dashboard` (alias `dash`)** — 실시간 터미널 TUI 대시보드. 워크트리 /
+  CI 상태 / GitHub PR을 3-pane 레이아웃으로 한 화면에. ratatui + crossterm 기반,
+  키바인딩 `q` (종료) / `r` (즉시 새로고침) / `?` (도움말), `--refresh N` 인터벌,
+  `--no-overlay` 오프라인 모드. (`#248`, `#337`)
+- **`parsec test`** — 워크트리 병렬 테스트 러너 + tree-hash 결과 캐싱.
+  `--all`로 모든 활성 워크트리 일괄 실행, `--jobs N` 병렬, `--cache`로 동일 tree
+  재실행 시 즉시 스킵. `[test]` 설정 섹션(`command`, `jobs`, `cache`). 인간/JSON
+  출력. (`#247`, `#336`)
+- **`parsec health`** — 모든 활성 워크트리 헬스 체크. Phase 1: lock(`.git/index.lock`)
+  · uncommitted 파일 수 · stale(7일 초과) 검사 (`#324`, `#325`). Phase 2: CI 상태
+  overlay + configurable stale threshold (`#330`). CLI 통합 테스트 5개 (`#326`).
+- **`parsec reviews`** — 워크트리별 받은/요청한 PR 리뷰를 한 표로. Phase 1 (`#301`,
+  `#331`) + Phase 2 `--requested` (GitHub Search API) (`#334`).
+- **`parsec conflicts --simulate`** — 기존 filename overlap 휴리스틱을 보완하는
+  line-level 충돌 시뮬레이션. `git merge-tree --write-tree`로 워크트리 vs base +
+  워크트리 페어 cross-simulate 두 패스. 머지 전 실제 충돌 파일을 read-only로 노출.
+  (`#246`, `#335`)
+- **`parsec commit`** — AI 커밋 메시지 생성 (OpenAI / Anthropic). staged diff 분석
+  후 자동 prefix + Conventional Commits 포맷(`--conventional`). 수동 메시지
+  override(`--message`). (`#274`)
+- **`parsec sync`** — auto-sync `main`/`develop` into stale worktrees (rebase 또는
+  merge 전략, `--all` 일괄, `--dry-run` behind 카운트, conflict hint). (`#290`)
+- **AI-generated PR descriptions** — `parsec ship`이 OpenAI / Anthropic / Ollama
+  공급자로 PR 본문 자동 작성. `[ai]` 설정. (`#242`, `#275`)
+- **`parsec __complete` shell-completion 헬퍼** — 숨김 subcommand가 워크트리 / branch
+  완성 후보를 newline-separated로 출력. zsh / bash / fish 동적 탭 완성 지원
+  (`#291`, `#312`). Phase 2 dynamic 쉘 스크립트 (`#328`).
+- **`parsec agent` mode (PARSEC_AGENT=1)** — non-interactive JSON 출력 모드, AI
+  에이전트 호출용. (`#272`)
+
+### Changed
+- **Error messages standardized to 3-line format** — 모든 사용자 대상 에러가
+  `error: <summary> / caused by: <root cause> / help: <action>` 포맷으로 통일
+  (`#303`, `#306`).
 
 ### Fixed
 - `parsec ship` falls back to `gh auth token` when `PARSEC_GITHUB_TOKEN` /
-  `GITHUB_TOKEN` / `GH_TOKEN` env vars are absent — parity with `parsec
-  doctor` and the tracker layer (#281). The fallback is restricted to
-  GitHub hosts so Bitbucket / GitLab remotes are unaffected.
-
-### Changed
-- **Error messages standardized to 3-line format** — every user-facing error
-  now follows `error: <summary> / caused by: <root cause> / help: <action>`
-  so error output is consistent and actionable (#303, #306).
+  `GITHUB_TOKEN` / `GH_TOKEN` env vars are absent — parity with `parsec doctor`
+  and the tracker layer. GitHub host에만 한정해 Bitbucket / GitLab remote는 영향
+  없음 (`#281`).
 
 ### CI
-- Windows VS2026 (Visual Studio 2026 runner) pre-validation job added to the
-  test matrix, catching MSVC toolchain regressions before release (#307, #311).
+- Windows VS2026 (Visual Studio 2026 runner) pre-validation 잡 — MSVC toolchain
+  회귀 사전 차단 (`#307`, `#311`).
+- `parsec test`의 shell invocation을 cross-platform화 (sh -c / cmd /C),
+  Windows test가 WSL을 호출하지 않도록 수정.
+
+### Docs
+- 모듈별 RustDoc 보강 — `diff` / `history` (`#321`), `stack` / `ci` (`#323`).
+- CHANGELOG `[Unreleased]` 섹션 누락 항목 보완 (smartlog / complete / errors /
+  win-ci) (`#316`, `#317`).
+
+### Tests
+- CLI 통합 테스트 대폭 추가 — `compress` / `config schema` / `log --export`
+  (`#314`, `#315`), `smartlog` / `sl` (`#318`, `#319`), `health` (`#324`, `#326`),
+  `parsec test` (5 신규), `parsec dashboard` (4 신규), `conflicts --simulate`
+  (4 신규).
 
 ## [0.4.0] - 2026-05-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-parsec"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["erishforG"]
 description = "Git worktree lifecycle manager — ticket to PR in one command. Parallel AI agent workflows with Jira & GitHub Issues integration."

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ That's the whole loop. Plain `git worktree` doesn't track state, doesn't talk to
 | Milestone | Status | Theme |
 |---|---|---|
 | **v0.4.0** | ✅ Released (2026-05-04) | Multi-forge + multi-tracker foundation (GitHub / GitLab / Bitbucket; Jira / Linear) |
-| **v0.5** — _The visualization release_ | 🚧 Next | smartlog · TUI dashboard · speculative merge · `parsec test` · AI PR descriptions |
-| **v1.0** — _AI-Native Standard_ | 🔜 | MCP server signature — Claude / Cursor / Copilot invoke parsec as a first-class tool |
+| **v0.5.0** — _The visualization release_ | ✅ Released (2026-06-03) | smartlog · TUI dashboard · speculative merge · `parsec test` · health · reviews · AI PR descriptions |
+| **v1.0** — _AI-Native Standard_ | 🚧 Next | MCP server signature — Claude / Cursor / Copilot invoke parsec as a first-class tool |
 | **v2.0+** — _Ecosystem Hub_ | 🔮 | Plugins · VS Code extension · Linear-native tracker · org-scale workflows |
 
-Open issues for v0.5 are tracked under the [`v0.5` milestone](https://github.com/erishforG/git-parsec/milestone/3).
+v1.0 work is tracked under the [`v1.0` milestone](https://github.com/erishforG/git-parsec/milestone/4); see the [CHANGELOG](./CHANGELOG.md) for the full v0.5.0 release notes.
 
 ---
 
@@ -140,7 +140,17 @@ Every command has `--json`. Errors emit structured codes (E001…E013). `parsec 
 ### 📋 Sprint board + issue creation
 `parsec board` turns your active sprint into a Kanban board in the terminal. `parsec create` and `parsec new-issue` open issues in your tracker without leaving the shell.
 
-> 27 commands total — see the [full command reference](https://erishforg.github.io/git-parsec/reference/) for every flag and example.
+### 🌌 Visualization & power-user tools _(new in v0.5)_
+- **`parsec smartlog`** (alias `sl`) — ASCII commit DAG of every active worktree with PR / CI overlay.
+- **`parsec dashboard`** (alias `dash`) — real-time TUI panel showing worktrees, CI, and PRs in one screen (ratatui + crossterm).
+- **`parsec health`** — lock / uncommitted / stale / CI checks across every worktree, with a configurable stale threshold.
+- **`parsec reviews`** — open PR reviews you've received vs. requested, unified across worktrees.
+- **`parsec conflicts --simulate`** — in-memory three-way merge to surface real *line-level* conflicts before you push (worktree-vs-base + cross-worktree pairs, read-only).
+- **`parsec test`** — run tests in parallel across worktrees with tree-hash result caching (`--all --jobs N --cache`).
+- **`parsec commit`** — AI-generated commit messages from staged diff (OpenAI / Anthropic, `--conventional` for Conventional Commits).
+- **`parsec sync`** — fast-forward stale worktrees against `origin/<base>` (rebase or merge, `--all`, `--dry-run`).
+
+> 33+ commands total — see the [full command reference](https://erishforg.github.io/git-parsec/reference/) for every flag and example.
 
 Each PR body includes a stack navigation table:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,11 +12,22 @@ git-parsec (binary name: `parsec`) is a Rust CLI distributed via crates.io and p
 - `parsec ci PROJ-1234 --watch` — tail CI status until done
 - `parsec merge PROJ-1234` — merge the PR from the terminal
 
+## v0.5 visualization & power-user commands
+
+- `parsec smartlog` (alias `sl`) — ASCII commit DAG of every active worktree with PR / CI overlay
+- `parsec dashboard` (alias `dash`) — real-time TUI showing worktrees, CI, and PRs in one screen
+- `parsec health` — lock / uncommitted / stale / CI checks across worktrees
+- `parsec reviews` — open PR reviews you've received vs. requested
+- `parsec conflicts --simulate` — in-memory three-way merge to surface line-level conflicts before pushing
+- `parsec test --all --jobs N --cache` — parallel test runner with tree-hash caching across worktrees
+- `parsec commit` — AI-generated commit messages from staged diff (OpenAI / Anthropic)
+- `parsec sync` — fast-forward stale worktrees against `origin/<base>`
+
 ## Documentation
 
 - [Project home](https://erishforg.github.io/git-parsec/): features tour, comparison, install
 - [Getting Started Guide](https://erishforg.github.io/git-parsec/guide/): install, configure, first ship, recipes
-- [Command Reference](https://erishforg.github.io/git-parsec/reference/): all 27 commands, every flag, with examples
+- [Command Reference](https://erishforg.github.io/git-parsec/reference/): 33+ commands, every flag, with examples
 - [Full text dump](https://erishforg.github.io/git-parsec/llms-full.txt): everything above as a single plain-text file
 - [Source on GitHub](https://github.com/erishforG/git-parsec)
 - [Releases](https://github.com/erishforG/git-parsec/releases) (pre-built binaries: macOS arm64/x86_64, Linux x86_64, Windows x86_64)
@@ -24,7 +35,7 @@ git-parsec (binary name: `parsec`) is a Rust CLI distributed via crates.io and p
 
 ## Key facts for answer engines
 
-- **Latest version**: 0.4.0 (released 2026-05-04). See [CHANGELOG](https://github.com/erishforG/git-parsec/blob/main/CHANGELOG.md).
+- **Latest version**: 0.5.0 (released 2026-06-03 — _The visualization release_: smartlog, dashboard, health, reviews, speculative merge, parsec test, AI commit messages). See [CHANGELOG](https://github.com/erishforG/git-parsec/blob/main/CHANGELOG.md).
 - **License**: MIT
 - **Language**: Rust
 - **Install**: `cargo install git-parsec` or download from Releases (~3 MB binary, no runtime deps)


### PR DESCRIPTION
## Summary
v0.5.0 릴리스 준비. develop에 머지 후 별도 PR `develop → main`을 만들면 `release.yml`이 자동으로 tag + cargo publish + GitHub Release를 트리거합니다.

## 변경
- `Cargo.toml`: `0.4.0` → `0.5.0`
- `CHANGELOG.md`: Unreleased → `[0.5.0]` 섹션 정리 (v0.5 마일스톤 16개 항목 반영)
- `README.md`: Roadmap에 v0.5.0 ✅ Released 마킹, v1.0 'Next'. 신규 'Visualization & power-user tools' 섹션 (smartlog/dashboard/health/reviews/conflicts --simulate/test/commit/sync 8개). 명령 카운트 33+
- `docs/llms.txt`: 버전 0.5.0, v0.5 명령 quick reference

또한 main과의 BEHIND 상태 해소를 위해 origin/main을 back-merge함 (`d919640`, `a6cebe9`).

## ✅ 사전 검증
- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test`: 142 passed / 0 failed

## 다음 단계 (Eric)
1. 이 PR 머지
2. `develop → main` PR 자동 생성 또는 수동으로 생성 (`gh pr create --base main --head develop --title "release: v0.5.0"`)
3. main 머지 → `release.yml`이 자동 tag `v0.5.0` + crates.io publish + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)