### PR TITLE
fix(release): snapshot-docs via PR instead of direct push to protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,23 @@ jobs:
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - name: Only develop can merge into main
+      - name: Only develop or auto-snapshot branches can merge into main
         run: |
-          if [ "${{ github.head_ref }}" != "develop" ]; then
-            echo "::error::Only the 'develop' branch can be merged into 'main'. Got '${{ github.head_ref }}'."
-            exit 1
+          HEAD='${{ github.head_ref }}'
+          if [ "$HEAD" = "develop" ]; then
+            echo "OK — develop → main"
+            exit 0
           fi
+          # release.yml's snapshot-docs job opens PRs from docs/snapshot-vX.Y.Z
+          # because direct push to protected main is blocked. These are
+          # data-only changes (docs/v/, docs/versions.json, docs/sitemap.xml).
+          case "$HEAD" in
+            docs/snapshot-v*)
+              echo "OK — auto-snapshot branch (release docs versioning)"
+              exit 0 ;;
+          esac
+          echo "::error::Only 'develop' or 'docs/snapshot-v*' branches can be merged into 'main'. Got '$HEAD'."
+          exit 1
 
   check:
     name: Check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -162,10 +163,27 @@ jobs:
           sed -i '/<\/urlset>/i \
             <url>\n    <loc>https://erishforg.github.io/git-parsec/v/'"${VERSION}"'/</loc>\n    <lastmod>'"${DATE}"'</lastmod>\n    <changefreq>never</changefreq>\n    <priority>0.3</priority>\n  </url>\n  <url>\n    <loc>https://erishforg.github.io/git-parsec/v/'"${VERSION}"'/guide/</loc>\n    <lastmod>'"${DATE}"'</lastmod>\n    <changefreq>never</changefreq>\n    <priority>0.3</priority>\n  </url>\n  <url>\n    <loc>https://erishforg.github.io/git-parsec/v/'"${VERSION}"'/reference/</loc>\n    <lastmod>'"${DATE}"'</lastmod>\n    <changefreq>never</changefreq>\n    <priority>0.3</priority>\n  </url>' docs/sitemap.xml
 
-      - name: Commit and push versioned docs
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/v/ docs/versions.json docs/sitemap.xml
-          git commit -m "docs: snapshot versioned docs for v${VERSION}"
-          git push origin main
+      - name: Open snapshot PR (main is protected — push direct is blocked)
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          base: main
+          branch: docs/snapshot-v${{ needs.release.outputs.version }}
+          commit-message: "docs: snapshot versioned docs for v${{ needs.release.outputs.version }}"
+          title: "docs: snapshot versioned docs for v${{ needs.release.outputs.version }}"
+          body: |
+            Automated docs snapshot for **v${{ needs.release.outputs.version }}** (release run #${{ github.run_id }}).
+
+            Produced by `.github/workflows/release.yml` → `snapshot-docs` job.
+
+            ## Files
+            - `docs/v/${{ needs.release.outputs.version }}/{index,guide/index,reference/index}.html` — versioned docs (with `noindex` meta)
+            - `docs/versions.json` — `latest` bump + history entry
+            - `docs/sitemap.xml` — versioned URLs added
+
+            Safe to merge. No code change, only doc data.
+          labels: |
+            release
+            auto-snapshot
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          delete-branch: true


### PR DESCRIPTION
## Problem
v0.5.0 release run에서 \`Snapshot Versioned Docs\` job이 실패. 원인:
- main 브랜치 protection: \"Changes must be made through a pull request\"
- 이전까지 \`git push origin main\`이 통하던 시기에 만든 job이라 protection 강화 후 깨졌음
- 핵심 배포(tag · crates.io · binaries)는 영향 없었지만 versioned docs URL (\`/git-parsec/v/0.5.0/\`)이 자동 생성 안됨

## Fix
- \`.github/workflows/release.yml\`: \`git push origin main\` → \`peter-evans/create-pull-request\`로 자동 PR 생성
- \`.github/workflows/ci.yml\` Branch Policy: \`develop\` 외에 \`docs/snapshot-v*\` 브랜치도 main 머지 허용 (자동 생성 PR이 통과하도록)

## 사용 시나리오 (다음 릴리스부터)
1. develop → main 머지 → release.yml 트리거
2. tag · cargo publish · GitHub Release 자동
3. \`snapshot-docs\` job이 \`docs/snapshot-v<ver>\` 브랜치 + PR 자동 생성 (label: \`release\`, \`auto-snapshot\`)
4. Eric 1탭 머지

## Test plan
- [x] yaml syntax OK
- [ ] 다음 릴리스 (v0.5.1 또는 v0.6.0)에서 실제 동작 확인 — 자동 PR 생성되어야 함

Related: PR #342 (v0.5.0 수동 스냅샷).

🤖 Generated with [Claude Code](https://claude.com/claude-code)