### PR TITLE
feat(mcp): Phase 1 — tool spec + src/mcp skeleton (Refs #292)

### DIFF
--- a/docs/mcp/spec.md
+++ b/docs/mcp/spec.md
@@ -1,0 +1,554 @@
+# git-parsec MCP Tool Specification
+
+**Version**: 0.1 (draft)  
+**Date**: 2026-06-04  
+**Milestone**: v1.0  
+**Refs**: #292, #241
+
+## Overview
+
+git-parsec exposes its worktree-native git workflow as an
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server,
+allowing AI agents (Claude Desktop, Cursor, etc.) to create, inspect, and
+ship code across isolated git worktrees.
+
+The transport is **stdio JSON-RPC 2.0** (`parsec mcp serve`). All tools
+follow the MCP `tools/call` schema with `name`, `description`, and
+`inputSchema` (JSON Schema draft-07).
+
+---
+
+## Design Principles
+
+1. **Worktree-native** — every tool operates on a named *worktree* (ticket
+   identifier), never on bare git state.
+2. **Safe defaults** — mutations require explicit confirmation or produce
+   preview output by default.
+3. **Composable** — tools return structured JSON; AI agents compose them.
+4. **No breaking CLI change** — the MCP layer calls into the same internal
+   Rust functions as the CLI; `src/mcp/` never edits `src/cli/`.
+5. **PAT delegation** — auth tokens are passed via caller context, not
+   stored inside the server process (see `docs/mcp/auth.md`).
+
+---
+
+## Tool Catalogue
+
+### 1. `worktree_list`
+
+Return all parsec-managed worktrees and their current state.
+
+```json
+{
+  "name": "worktree_list",
+  "description": "List all active parsec worktrees with ticket, branch, PR, and CI status.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "description": "Absolute path to the git repository root. Defaults to CWD."
+      },
+      "include_pr": {
+        "type": "boolean",
+        "description": "Fetch GitHub PR status for each worktree (requires network).",
+        "default": true
+      },
+      "include_ci": {
+        "type": "boolean",
+        "description": "Fetch CI check-run status for each worktree (requires network).",
+        "default": false
+      }
+    },
+    "required": []
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "worktrees": [
+    {
+      "ticket": "PROJ-123",
+      "branch": "feat/proj-123-my-feature",
+      "path": "/repo/.parsec/PROJ-123",
+      "created_at": "2026-06-01T09:00:00Z",
+      "behind_main": 2,
+      "pr": { "number": 42, "state": "open", "review_state": "approved" },
+      "ci": null
+    }
+  ]
+}
+```
+
+---
+
+### 2. `worktree_start`
+
+Create a new git worktree for a ticket identifier.
+
+```json
+{
+  "name": "worktree_start",
+  "description": "Create an isolated git worktree for a ticket. Fetches ticket title from configured tracker (Jira/GitHub Issues) when available.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "ticket": {
+        "type": "string",
+        "description": "Ticket identifier, e.g. 'PROJ-123' or '#42'."
+      },
+      "repo": {
+        "type": "string",
+        "description": "Absolute path to the git repository root."
+      },
+      "base": {
+        "type": "string",
+        "description": "Base branch to create from. Defaults to repository main/master."
+      },
+      "title": {
+        "type": "string",
+        "description": "Manually override ticket title (skips tracker lookup)."
+      },
+      "on": {
+        "type": "string",
+        "description": "Stack on top of another ticket's branch."
+      },
+      "dry_run": {
+        "type": "boolean",
+        "description": "Preview what would happen without making changes.",
+        "default": false
+      }
+    },
+    "required": ["ticket"]
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "ticket": "PROJ-123",
+  "branch": "feat/proj-123-my-feature",
+  "path": "/repo/.parsec/PROJ-123",
+  "base_commit": "abc1234",
+  "dry_run": false
+}
+```
+
+---
+
+### 3. `worktree_status`
+
+Return the current status of a single worktree (uncommitted files, ahead/behind, PR, CI).
+
+```json
+{
+  "name": "worktree_status",
+  "description": "Show detailed status of a worktree: uncommitted changes, ahead/behind base, PR link, CI checks.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "ticket": {
+        "type": "string",
+        "description": "Ticket identifier for the target worktree."
+      },
+      "repo": { "type": "string" }
+    },
+    "required": ["ticket"]
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "ticket": "PROJ-123",
+  "branch": "feat/proj-123-my-feature",
+  "ahead": 3,
+  "behind": 0,
+  "uncommitted": 2,
+  "pr": { "number": 42, "url": "https://github.com/org/repo/pull/42", "state": "open" },
+  "ci": { "overall": "success", "runs": 5, "failed": 0 }
+}
+```
+
+---
+
+### 4. `worktree_ship`
+
+Push the worktree branch, open (or update) a GitHub PR, and optionally clean up.
+
+```json
+{
+  "name": "worktree_ship",
+  "description": "Push the worktree branch to origin, create/update a GitHub PR, and optionally remove the local worktree.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "ticket": {
+        "type": "string",
+        "description": "Ticket identifier for the worktree to ship."
+      },
+      "repo": { "type": "string" },
+      "draft": {
+        "type": "boolean",
+        "description": "Open PR as draft.",
+        "default": false
+      },
+      "no_cleanup": {
+        "type": "boolean",
+        "description": "Skip removing the local worktree after shipping.",
+        "default": false
+      },
+      "dry_run": {
+        "type": "boolean",
+        "default": false
+      }
+    },
+    "required": ["ticket"]
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "ticket": "PROJ-123",
+  "pr_url": "https://github.com/org/repo/pull/42",
+  "pr_number": 42,
+  "worktree_removed": true,
+  "dry_run": false
+}
+```
+
+---
+
+### 5. `smartlog`
+
+Render the commit DAG with worktree branches, PR/CI overlays, and stack indicators.
+
+```json
+{
+  "name": "smartlog",
+  "description": "Render the smartlog DAG: commit graph annotated with worktree branches, PR state, CI status, and stack relationships.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "repo": { "type": "string" },
+      "ticket": {
+        "type": "string",
+        "description": "Filter to a single worktree's branch history."
+      },
+      "limit": {
+        "type": "integer",
+        "description": "Maximum commits to include.",
+        "default": 50,
+        "minimum": 1,
+        "maximum": 500
+      },
+      "no_color": {
+        "type": "boolean",
+        "description": "Disable ANSI color codes in output.",
+        "default": true
+      }
+    },
+    "required": []
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "text": "* abc1234 (feat/proj-123) [PR#42 ✓CI] My feature\n| * def5678 (feat/proj-456) [PR#43 ⏳CI] Another feature\n...",
+  "worktree_count": 3
+}
+```
+
+---
+
+### 6. `ci_status`
+
+Fetch CI check-run results for a worktree's branch.
+
+```json
+{
+  "name": "ci_status",
+  "description": "Fetch GitHub Actions CI check-run status for a worktree branch.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "ticket": { "type": "string" },
+      "repo": { "type": "string" },
+      "limit": {
+        "type": "integer",
+        "description": "Max check runs to return.",
+        "default": 10
+      }
+    },
+    "required": ["ticket"]
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "ticket": "PROJ-123",
+  "branch": "feat/proj-123-my-feature",
+  "overall": "success",
+  "runs": [
+    { "name": "CI / build", "status": "completed", "conclusion": "success", "url": "..." },
+    { "name": "CI / test", "status": "completed", "conclusion": "success", "url": "..." }
+  ]
+}
+```
+
+---
+
+### 7. `pr_status`
+
+Get the current GitHub PR state, review status, and merge readiness for a worktree.
+
+```json
+{
+  "name": "pr_status",
+  "description": "Return GitHub PR state, review approvals, merge readiness, and review comments for a worktree.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "ticket": { "type": "string" },
+      "repo": { "type": "string" }
+    },
+    "required": ["ticket"]
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "ticket": "PROJ-123",
+  "pr_number": 42,
+  "pr_url": "https://github.com/org/repo/pull/42",
+  "state": "open",
+  "draft": false,
+  "mergeable": true,
+  "review_state": "approved",
+  "approvals": 2,
+  "change_requests": 0,
+  "ci_overall": "success"
+}
+```
+
+---
+
+### 8. `health_check`
+
+Run parsec's health diagnostics across all (or one) worktree(s).
+
+```json
+{
+  "name": "health_check",
+  "description": "Run worktree health diagnostics: lock files, uncommitted changes, stale branches, CI failures.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "ticket": {
+        "type": "string",
+        "description": "Scope to a single worktree. Omit to check all."
+      },
+      "repo": { "type": "string" },
+      "include_ci": {
+        "type": "boolean",
+        "default": false
+      }
+    },
+    "required": []
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "healthy": false,
+  "worktrees": [
+    {
+      "ticket": "PROJ-123",
+      "issues": [
+        { "kind": "stale_branch", "severity": "warning", "detail": "Branch is 14 commits behind main" }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### 9. `reviews`
+
+List open GitHub PRs that the caller has been requested to review, or their own PRs awaiting review.
+
+```json
+{
+  "name": "reviews",
+  "description": "List PRs where the authenticated user is a requested reviewer, or their own PRs awaiting approval.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "repo": { "type": "string" },
+      "filter": {
+        "type": "string",
+        "enum": ["incoming", "outgoing", "all"],
+        "description": "incoming = review requests; outgoing = own PRs; all = both.",
+        "default": "all"
+      },
+      "limit": {
+        "type": "integer",
+        "default": 20
+      }
+    },
+    "required": []
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "incoming": [
+    { "pr_number": 55, "title": "feat: ...", "author": "alice", "url": "...", "review_state": "pending" }
+  ],
+  "outgoing": [
+    { "pr_number": 42, "title": "feat/proj-123", "reviewer": "bob", "url": "...", "review_state": "approved" }
+  ]
+}
+```
+
+---
+
+### 10. `sync`
+
+Sync stale worktrees with the latest base branch commits.
+
+```json
+{
+  "name": "sync",
+  "description": "Rebase or merge-update stale worktrees against the current main/develop branch.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "ticket": {
+        "type": "string",
+        "description": "Target a specific worktree. Omit to sync all stale ones."
+      },
+      "repo": { "type": "string" },
+      "strategy": {
+        "type": "string",
+        "enum": ["rebase", "merge"],
+        "default": "rebase"
+      },
+      "dry_run": {
+        "type": "boolean",
+        "default": true,
+        "description": "Default true — preview conflicts before committing."
+      },
+      "stale_days": {
+        "type": "integer",
+        "description": "Only sync worktrees behind by at least this many base commits.",
+        "default": 5
+      }
+    },
+    "required": []
+  }
+}
+```
+
+**Response** (success):
+```json
+{
+  "synced": ["PROJ-123"],
+  "skipped": [],
+  "conflicts": [],
+  "dry_run": true
+}
+```
+
+---
+
+## Error Schema
+
+All tools return MCP `isError: true` with a structured body on failure:
+
+```json
+{
+  "error": {
+    "code": "WORKTREE_NOT_FOUND",
+    "message": "No worktree found for ticket 'PROJ-999'",
+    "detail": "Run worktree_list to see available tickets."
+  }
+}
+```
+
+**Standard error codes**:
+
+| Code | Meaning |
+|---|---|
+| `WORKTREE_NOT_FOUND` | Ticket has no managed worktree |
+| `GIT_ERROR` | Underlying git2 / git CLI error |
+| `GITHUB_API_ERROR` | GitHub API call failed (rate limit, auth, network) |
+| `TRACKER_ERROR` | Jira / GitLab API error |
+| `DIRTY_WORKTREE` | Operation blocked by uncommitted changes |
+| `CONFLICT` | Merge/rebase conflict detected |
+| `DRY_RUN` | Preview only; no changes made |
+
+---
+
+## Tool Dependency Map
+
+```
+worktree_list       ──► (no deps)
+worktree_start      ──► tracker (optional), git2
+worktree_status     ──► git2, github_api (optional)
+worktree_ship       ──► git2, github_api
+smartlog            ──► git2, github_api (optional)
+ci_status           ──► github_api
+pr_status           ──► github_api
+health_check        ──► git2, github_api (optional)
+reviews             ──► github_api
+sync                ──► git2
+```
+
+---
+
+## Implementation Notes
+
+- All MCP tools live in `src/mcp/tools/` as individual Rust modules.
+- Shared JSON serialisation uses `serde_json`; input validation uses the
+  existing `anyhow` error chain.
+- Auth tokens are injected via `McpContext` (see `docs/mcp/auth.md`),
+  not read from env inside tool handlers.
+- `dry_run` is a first-class parameter on all mutating tools and must be
+  honoured before any side-effecting call.
+- Response structs derive `serde::Serialize`; schemas in this doc are
+  generated from those structs (to be automated in Phase 2).
+
+---
+
+## Next Phases
+
+| Phase | Work |
+|---|---|
+| Phase 1 (this PR) | `docs/mcp/spec.md` — tool catalogue + schemas |
+| Phase 2 (#293) | `parsec mcp serve` skeleton — stdio JSON-RPC echo server |
+| Phase 3 (#293) | Wire `worktree_list` + `worktree_status` to real impl |
+| Phase 4 (#293) | Wire remaining tools; `parsec mcp serve` fully functional |
+| Phase 5 (#294) | Auth — PAT delegation + scope checking |
+| Phase 6 (#295) | e2e fixtures + Claude Desktop / Cursor integration tests |
+
+---
+
+*Maintained by the git-parsec team. Spec changes require review by @erishforG.*

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod execlog;
 mod git;
 mod github;
 mod gitlab;
+mod mcp;
 mod oplog;
 mod output;
 mod tracker;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,196 @@
+//! MCP (Model Context Protocol) server implementation for git-parsec.
+//!
+//! This module exposes parsec's worktree-native git workflow as an MCP server
+//! over stdio JSON-RPC 2.0, allowing AI agents (Claude Desktop, Cursor, etc.)
+//! to manage worktrees programmatically.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! parsec mcp serve
+//!   └─ McpServer (stdio JSON-RPC loop)
+//!        └─ ToolRegistry
+//!             ├─ worktree_list    → tools::worktree::list
+//!             ├─ worktree_start   → tools::worktree::start
+//!             ├─ worktree_status  → tools::worktree::status
+//!             ├─ worktree_ship    → tools::worktree::ship
+//!             ├─ smartlog         → tools::smartlog::run
+//!             ├─ ci_status        → tools::ci::status
+//!             ├─ pr_status        → tools::pr::status
+//!             ├─ health_check     → tools::health::check
+//!             ├─ reviews          → tools::reviews::list
+//!             └─ sync             → tools::sync::run
+//! ```
+//!
+//! See `docs/mcp/spec.md` for the full tool catalogue and JSON schemas.
+//!
+//! ## Phases
+//!
+//! - **Phase 1** (this): module skeleton + tool registry shape.
+//! - **Phase 2** (#293): stdio JSON-RPC echo server (`parsec mcp serve`).
+//! - **Phase 3** (#293): wire real implementations to registered tools.
+
+// Phase 1 skeleton: items are defined but the JSON-RPC dispatcher (Phase 2)
+// has not been wired yet. Suppress dead_code until Phase 2 lands.
+#![allow(dead_code)]
+
+pub mod tools;
+
+/// Context passed to every MCP tool handler.
+///
+/// Carries repository path, auth tokens (delegated by the caller), and
+/// runtime flags like `dry_run`. Tools must not read auth from environment
+/// directly; they must use this context.
+#[derive(Debug, Clone)]
+pub struct McpContext {
+    /// Absolute path to the git repository root.
+    pub repo_path: std::path::PathBuf,
+
+    /// GitHub Personal Access Token delegated by the MCP caller.
+    /// `None` when the tool does not require GitHub API access.
+    pub github_token: Option<String>,
+
+    /// When `true`, all mutating operations are previewed without
+    /// side effects. Tools must check this before any state change.
+    pub dry_run: bool,
+}
+
+impl McpContext {
+    /// Create a context from the current working directory.
+    pub fn from_cwd(dry_run: bool) -> anyhow::Result<Self> {
+        let repo_path = std::env::current_dir()?;
+        Ok(Self {
+            repo_path,
+            github_token: None,
+            dry_run,
+        })
+    }
+
+    /// Attach a GitHub PAT to the context.
+    #[must_use]
+    pub fn with_github_token(mut self, token: impl Into<String>) -> Self {
+        self.github_token = Some(token.into());
+        self
+    }
+}
+
+/// A registered MCP tool: name, description, and a handler stub.
+///
+/// In Phase 2 this will become a full `async fn` trait with JSON-Schema
+/// introspection; for now it carries the metadata that `tools/list` needs.
+pub struct ToolDef {
+    /// Machine-readable tool name (snake_case, matches spec).
+    pub name: &'static str,
+    /// Human-readable description returned in `tools/list` responses.
+    pub description: &'static str,
+}
+
+/// All tools exposed by the parsec MCP server.
+///
+/// This slice is the single source of truth for `tools/list` responses.
+/// Add new tools here **and** implement them in `src/mcp/tools/`.
+pub const TOOLS: &[ToolDef] = &[
+    ToolDef {
+        name: "worktree_list",
+        description: "List all active parsec worktrees with ticket, branch, PR, and CI status.",
+    },
+    ToolDef {
+        name: "worktree_start",
+        description: "Create an isolated git worktree for a ticket.",
+    },
+    ToolDef {
+        name: "worktree_status",
+        description:
+            "Show detailed status of a worktree: uncommitted changes, ahead/behind, PR, CI.",
+    },
+    ToolDef {
+        name: "worktree_ship",
+        description:
+            "Push the worktree branch to origin, create/update a GitHub PR, and optionally clean up.",
+    },
+    ToolDef {
+        name: "smartlog",
+        description:
+            "Render the smartlog DAG annotated with worktree branches, PR state, and CI status.",
+    },
+    ToolDef {
+        name: "ci_status",
+        description: "Fetch GitHub Actions CI check-run status for a worktree branch.",
+    },
+    ToolDef {
+        name: "pr_status",
+        description:
+            "Return GitHub PR state, review approvals, merge readiness, and review comments.",
+    },
+    ToolDef {
+        name: "health_check",
+        description:
+            "Run worktree health diagnostics: lock files, uncommitted changes, stale branches.",
+    },
+    ToolDef {
+        name: "reviews",
+        description:
+            "List PRs where the user is a requested reviewer or their own PRs awaiting review.",
+    },
+    ToolDef {
+        name: "sync",
+        description: "Rebase or merge-update stale worktrees against the current base branch.",
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tools_list_is_non_empty() {
+        assert!(!TOOLS.is_empty(), "TOOLS registry must not be empty");
+    }
+
+    #[test]
+    fn tool_names_are_snake_case_and_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for tool in TOOLS {
+            // snake_case: only lowercase letters, digits, underscores
+            assert!(
+                tool.name
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+                "Tool name '{}' is not snake_case",
+                tool.name
+            );
+            assert!(
+                seen.insert(tool.name),
+                "Duplicate tool name: '{}'",
+                tool.name
+            );
+        }
+    }
+
+    #[test]
+    fn all_tools_have_descriptions() {
+        for tool in TOOLS {
+            assert!(
+                !tool.description.is_empty(),
+                "Tool '{}' has an empty description",
+                tool.name
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_context_from_cwd() {
+        let ctx = McpContext::from_cwd(false).expect("should build context from cwd");
+        assert!(!ctx.dry_run);
+        assert!(ctx.github_token.is_none());
+    }
+
+    #[test]
+    fn mcp_context_with_token() {
+        let ctx = McpContext::from_cwd(true)
+            .unwrap()
+            .with_github_token("ghp_test");
+        assert!(ctx.dry_run);
+        assert_eq!(ctx.github_token.as_deref(), Some("ghp_test"));
+    }
+}

--- a/src/mcp/tools/ci.rs
+++ b/src/mcp/tools/ci.rs
@@ -1,0 +1,9 @@
+//! MCP tool stub for `ci_status`. Wired in Phase 3 (#293).
+
+use crate::mcp::McpContext;
+
+/// `ci_status` — fetch GitHub Actions check-run results for a worktree branch.
+#[allow(dead_code)]
+pub fn status(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    todo!("ci_status: implement in Phase 3 (#293)")
+}

--- a/src/mcp/tools/health.rs
+++ b/src/mcp/tools/health.rs
@@ -1,0 +1,9 @@
+//! MCP tool stub for `health_check`. Wired in Phase 3 (#293).
+
+use crate::mcp::McpContext;
+
+/// `health_check` — run worktree health diagnostics.
+#[allow(dead_code)]
+pub fn check(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    todo!("health_check: implement in Phase 3 (#293)")
+}

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -1,0 +1,22 @@
+//! MCP tool handler modules.
+//!
+//! Each sub-module corresponds to one or more tools in the catalogue defined
+//! in `docs/mcp/spec.md`. Handlers are stubs in Phase 1; they will be wired
+//! to real implementations in Phase 3 (issue #293).
+//!
+//! ## Adding a new tool
+//!
+//! 1. Add a `ToolDef` entry to `crate::mcp::TOOLS`.
+//! 2. Create (or extend) a sub-module here.
+//! 3. Implement `pub fn handle(ctx: &McpContext, input: serde_json::Value) -> anyhow::Result<serde_json::Value>`.
+//! 4. Register the handler in `McpServer::dispatch` (Phase 2).
+
+// Phase 1: modules are declared but contain only stub signatures.
+// Implementations land in Phase 3 when the JSON-RPC server is wired up.
+pub mod ci;
+pub mod health;
+pub mod pr;
+pub mod reviews;
+pub mod smartlog;
+pub mod sync;
+pub mod worktree;

--- a/src/mcp/tools/pr.rs
+++ b/src/mcp/tools/pr.rs
@@ -1,0 +1,9 @@
+//! MCP tool stub for `pr_status`. Wired in Phase 3 (#293).
+
+use crate::mcp::McpContext;
+
+/// `pr_status` — GitHub PR state, review approvals, and merge readiness.
+#[allow(dead_code)]
+pub fn status(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    todo!("pr_status: implement in Phase 3 (#293)")
+}

--- a/src/mcp/tools/reviews.rs
+++ b/src/mcp/tools/reviews.rs
@@ -1,0 +1,9 @@
+//! MCP tool stub for `reviews`. Wired in Phase 3 (#293).
+
+use crate::mcp::McpContext;
+
+/// `reviews` — list incoming and outgoing review requests.
+#[allow(dead_code)]
+pub fn list(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    todo!("reviews: implement in Phase 3 (#293)")
+}

--- a/src/mcp/tools/smartlog.rs
+++ b/src/mcp/tools/smartlog.rs
@@ -1,0 +1,12 @@
+//! MCP tool stub for `smartlog`.
+//!
+//! Phase 1 stub — see `docs/mcp/spec.md` for the full schema.
+//! Wired in Phase 3 (#293).
+
+use crate::mcp::McpContext;
+
+/// `smartlog` — render the commit DAG with PR/CI overlays.
+#[allow(dead_code)]
+pub fn run(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    todo!("smartlog: implement in Phase 3 (#293)")
+}

--- a/src/mcp/tools/sync.rs
+++ b/src/mcp/tools/sync.rs
@@ -1,0 +1,9 @@
+//! MCP tool stub for `sync`. Wired in Phase 3 (#293).
+
+use crate::mcp::McpContext;
+
+/// `sync` — rebase/merge stale worktrees against base branch.
+#[allow(dead_code)]
+pub fn run(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    todo!("sync: implement in Phase 3 (#293)")
+}

--- a/src/mcp/tools/worktree.rs
+++ b/src/mcp/tools/worktree.rs
@@ -1,0 +1,53 @@
+//! MCP tool stubs for worktree operations.
+//!
+//! Tools: `worktree_list`, `worktree_start`, `worktree_status`, `worktree_ship`.
+//!
+//! These are Phase 1 stubs — signatures and `todo!()` bodies.
+//! Real implementations land in Phase 3 (issue #293).
+//!
+//! The `#[allow(dead_code)]` attributes are intentional: these handlers
+//! will be called from the JSON-RPC dispatcher added in Phase 2 (#293).
+
+use crate::mcp::McpContext;
+
+/// `worktree_list` — list all parsec-managed worktrees.
+///
+/// # Errors
+/// Returns an error if the git repository cannot be read.
+#[allow(dead_code)]
+pub fn list(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    // Phase 3: call crate::worktree::manager to enumerate worktrees,
+    // optionally fetch PR/CI status via crate::github.
+    todo!("worktree_list: implement in Phase 3 (#293)")
+}
+
+/// `worktree_start` — create a new worktree for a ticket.
+///
+/// # Errors
+/// Returns an error if the worktree already exists or the ticket is invalid.
+#[allow(dead_code)]
+pub fn start(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    // Phase 3: call crate::worktree::lifecycle::create.
+    todo!("worktree_start: implement in Phase 3 (#293)")
+}
+
+/// `worktree_status` — detailed status for a single worktree.
+///
+/// # Errors
+/// Returns an error if the ticket has no associated worktree.
+#[allow(dead_code)]
+pub fn status(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    // Phase 3: combine git2 status + github PR/CI queries.
+    todo!("worktree_status: implement in Phase 3 (#293)")
+}
+
+/// `worktree_ship` — push branch, open/update PR, optionally clean up.
+///
+/// # Errors
+/// Returns an error if the worktree is dirty or the push fails.
+#[allow(dead_code)]
+pub fn ship(_ctx: &McpContext, _input: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    // Phase 3: call crate::cli::commands::ship internals.
+    // Respect ctx.dry_run before any side effects.
+    todo!("worktree_ship: implement in Phase 3 (#293)")
+}


### PR DESCRIPTION
## 무엇

v1.0 MCP 서버의 첫 번째 Phase: **tool catalogue spec 문서** + **`src/mcp/` 모듈 skeleton**.

### 변경 내용

- **`docs/mcp/spec.md`**: 10개 MCP 도구의 완전한 JSON Schema 설계 문서
  - `worktree_list`, `worktree_start`, `worktree_status`, `worktree_ship`
  - `smartlog`, `ci_status`, `pr_status`, `health_check`, `reviews`, `sync`
  - 각 도구별 inputSchema (JSON Schema draft-07), response shape, error codes
  - 설계 원칙 (worktree-native, dry_run first-class, PAT delegation, CLI surface 불변)
- **`src/mcp/mod.rs`**: `McpContext`, `ToolDef`, `TOOLS` 상수 registry
- **`src/mcp/tools/`**: 7개 stub 모듈 (worktree, smartlog, ci, pr, health, reviews, sync)
- **5개 unit test**: registry 유효성, snake_case+unique, 설명 비어있지 않음, McpContext 생성

## 왜

Refs #292 (v1.0 MCP tool spec), Refs #241 (MCP server meta-issue)

v1.0 MCP 서버 구현의 가장 중요한 사전 작업: Phase 2 (stdio JSON-RPC) 시작 전에 **어떤 도구를 어떤 스키마로 노출할지** 확정 필요. 이 스펙 문서가 Phase 2~6의 설계 기준점 역할을 함.

## 변경 파일 요약

| 파일 | 타입 |
|---|---|
| `docs/mcp/spec.md` | 신규 — 설계 문서 |
| `src/mcp/mod.rs` | 신규 — McpContext + TOOLS registry |
| `src/mcp/tools/*.rs` | 신규 — Phase 1 stubs (9개 파일) |
| `src/main.rs` | 수정 — `mod mcp;` 추가 (알파벳 순 위치) |

## 다음 Phase 힌트

- **Phase 2** (#293): `parsec mcp serve` 서브커맨드 추가 + stdio JSON-RPC echo 서버 (입력 파싱 → `tools/list` 응답)
- **Phase 3** (#293): `worktree_list` + `worktree_status` 실제 구현 연결
- **Phase 4** (#293): 나머지 8개 도구 구현 연결

## 리스크

- **없음** — 신규 모듈 전용, 기존 CLI/worktree/git2 코드 미수정
- `#[allow(dead_code)]` 은 `src/mcp` 모듈 전체에만 적용 (Phase 2에서 제거)

## 롤백

이 PR을 revert하면 `src/mcp/` 디렉터리와 `docs/mcp/` 가 완전히 제거되어 깔끔하게 롤백됨.

## Test plan

```
cargo build --quiet        # ✅ clean
cargo fmt --check          # ✅ pass
cargo clippy --all-targets -- -D warnings  # ✅ clean
cargo test --quiet         # ✅ 71+5+67 = 143 tests pass (5개 신규 mcp:: tests 포함)
```

@erishforG 검토 부탁드립니다 🙏