### PR TITLE
feat(mcp): Phase 2 — tool registry schemas

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -76,13 +76,19 @@ impl McpContext {
 
 /// A registered MCP tool: name, description, and a handler stub.
 ///
-/// In Phase 2 this will become a full `async fn` trait with JSON-Schema
-/// introspection; for now it carries the metadata that `tools/list` needs.
+/// This carries the stable metadata that `tools/list` needs before the
+/// JSON-RPC dispatcher is wired. Handler functions remain in `src/mcp/tools/`.
 pub struct ToolDef {
     /// Machine-readable tool name (snake_case, matches spec).
     pub name: &'static str,
     /// Human-readable description returned in `tools/list` responses.
     pub description: &'static str,
+    /// JSON Schema draft-07 input schema for this tool.
+    pub input_schema: &'static str,
+    /// Whether this tool can mutate repository or remote state.
+    pub mutating: bool,
+    /// Whether this tool requires GitHub API credentials for normal operation.
+    pub requires_github: bool,
 }
 
 /// All tools exposed by the parsec MCP server.
@@ -93,50 +99,100 @@ pub const TOOLS: &[ToolDef] = &[
     ToolDef {
         name: "worktree_list",
         description: "List all active parsec worktrees with ticket, branch, PR, and CI status.",
+        input_schema: r#"{"type":"object","properties":{"repo":{"type":"string"},"include_pr":{"type":"boolean","default":true},"include_ci":{"type":"boolean","default":false}},"required":[]}"#,
+        mutating: false,
+        requires_github: false,
     },
     ToolDef {
         name: "worktree_start",
         description: "Create an isolated git worktree for a ticket.",
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"base":{"type":"string"},"title":{"type":"string"},"on":{"type":"string"},"dry_run":{"type":"boolean","default":false}},"required":["ticket"]}"#,
+        mutating: true,
+        requires_github: false,
     },
     ToolDef {
         name: "worktree_status",
         description:
             "Show detailed status of a worktree: uncommitted changes, ahead/behind, PR, CI.",
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"}},"required":["ticket"]}"#,
+        mutating: false,
+        requires_github: false,
     },
     ToolDef {
         name: "worktree_ship",
         description:
             "Push the worktree branch to origin, create/update a GitHub PR, and optionally clean up.",
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"draft":{"type":"boolean","default":false},"no_cleanup":{"type":"boolean","default":false},"dry_run":{"type":"boolean","default":false}},"required":["ticket"]}"#,
+        mutating: true,
+        requires_github: true,
     },
     ToolDef {
         name: "smartlog",
         description:
             "Render the smartlog DAG annotated with worktree branches, PR state, and CI status.",
+        input_schema: r#"{"type":"object","properties":{"repo":{"type":"string"},"ticket":{"type":"string"},"limit":{"type":"integer","default":50,"minimum":1,"maximum":500},"no_color":{"type":"boolean","default":true}},"required":[]}"#,
+        mutating: false,
+        requires_github: false,
     },
     ToolDef {
         name: "ci_status",
         description: "Fetch GitHub Actions CI check-run status for a worktree branch.",
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"limit":{"type":"integer","default":10}},"required":["ticket"]}"#,
+        mutating: false,
+        requires_github: true,
     },
     ToolDef {
         name: "pr_status",
         description:
             "Return GitHub PR state, review approvals, merge readiness, and review comments.",
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"}},"required":["ticket"]}"#,
+        mutating: false,
+        requires_github: true,
     },
     ToolDef {
         name: "health_check",
         description:
             "Run worktree health diagnostics: lock files, uncommitted changes, stale branches.",
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"include_ci":{"type":"boolean","default":false}},"required":[]}"#,
+        mutating: false,
+        requires_github: false,
     },
     ToolDef {
         name: "reviews",
         description:
             "List PRs where the user is a requested reviewer or their own PRs awaiting review.",
+        input_schema: r#"{"type":"object","properties":{"repo":{"type":"string"},"filter":{"type":"string","enum":["incoming","outgoing","all"],"default":"all"},"limit":{"type":"integer","default":20}},"required":[]}"#,
+        mutating: false,
+        requires_github: true,
     },
     ToolDef {
         name: "sync",
         description: "Rebase or merge-update stale worktrees against the current base branch.",
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"strategy":{"type":"string","enum":["rebase","merge"],"default":"rebase"},"dry_run":{"type":"boolean","default":true},"stale_days":{"type":"integer","default":5}},"required":[]}"#,
+        mutating: true,
+        requires_github: false,
     },
 ];
+
+/// Render tool metadata in the shape required by MCP `tools/list`.
+///
+/// # Errors
+/// Returns an error if a checked-in schema string is invalid JSON.
+pub fn tools_list_payload() -> anyhow::Result<serde_json::Value> {
+    let tools = TOOLS
+        .iter()
+        .map(|tool| {
+            let input_schema: serde_json::Value = serde_json::from_str(tool.input_schema)?;
+            Ok(serde_json::json!({
+                "name": tool.name,
+                "description": tool.description,
+                "inputSchema": input_schema,
+            }))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    Ok(serde_json::json!({ "tools": tools }))
+}
 
 #[cfg(test)]
 mod tests {
@@ -176,6 +232,80 @@ mod tests {
                 tool.name
             );
         }
+    }
+
+    #[test]
+    fn all_tool_schemas_are_valid_json_objects() {
+        for tool in TOOLS {
+            let schema: serde_json::Value = serde_json::from_str(tool.input_schema)
+                .unwrap_or_else(|err| panic!("Tool '{}' has invalid schema: {err}", tool.name));
+            assert_eq!(
+                schema.get("type").and_then(serde_json::Value::as_str),
+                Some("object"),
+                "Tool '{}' schema must be an object",
+                tool.name
+            );
+            assert!(
+                schema.get("properties").is_some(),
+                "Tool '{}' schema must declare properties",
+                tool.name
+            );
+            assert!(
+                schema.get("required").is_some(),
+                "Tool '{}' schema must declare required fields",
+                tool.name
+            );
+        }
+    }
+
+    #[test]
+    fn tools_list_payload_matches_registry() {
+        let payload = tools_list_payload().expect("tools/list payload should render");
+        let tools = payload
+            .get("tools")
+            .and_then(serde_json::Value::as_array)
+            .expect("tools/list payload must contain an array");
+
+        assert_eq!(tools.len(), TOOLS.len());
+        for (payload_tool, registry_tool) in tools.iter().zip(TOOLS) {
+            assert_eq!(payload_tool["name"], registry_tool.name);
+            assert_eq!(payload_tool["description"], registry_tool.description);
+            assert!(
+                payload_tool.get("inputSchema").is_some(),
+                "Tool '{}' must include inputSchema",
+                registry_tool.name
+            );
+        }
+    }
+
+    #[test]
+    fn mutating_tools_expose_dry_run() {
+        for tool in TOOLS.iter().filter(|tool| tool.mutating) {
+            let schema: serde_json::Value = serde_json::from_str(tool.input_schema).unwrap();
+            assert!(
+                schema
+                    .pointer("/properties/dry_run")
+                    .and_then(|value| value.get("type"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some("boolean"),
+                "Mutating tool '{}' must expose dry_run",
+                tool.name
+            );
+        }
+    }
+
+    #[test]
+    fn github_tools_are_marked() {
+        let github_tools: std::collections::HashSet<_> = TOOLS
+            .iter()
+            .filter(|tool| tool.requires_github)
+            .map(|tool| tool.name)
+            .collect();
+
+        assert!(github_tools.contains("worktree_ship"));
+        assert!(github_tools.contains("ci_status"));
+        assert!(github_tools.contains("pr_status"));
+        assert!(github_tools.contains("reviews"));
     }
 
     #[test]


### PR DESCRIPTION
## 무엇
@erishforG MCP `tools/list` 구현을 위한 registry schema metadata를 `src/mcp/` 안에 추가했습니다.

## 왜
Refs #292. 문서의 tool catalogue와 Rust registry 사이에 `inputSchema` source-of-truth가 필요해 다음 Phase의 JSON-RPC `tools/list` 구현이 작고 검증 가능해집니다.

## 변경
- `ToolDef`에 `input_schema`, `mutating`, `requires_github` metadata 추가
- 10개 MCP tool의 JSON Schema draft-07 input schema 등록
- `tools_list_payload()` helper 추가
- schema validity, tools/list payload, mutating dry-run, GitHub tool marker 테스트 추가

## 다음 Phase 힌트
- #293에서 `parsec mcp serve` skeleton이 `tools_list_payload()`를 stdout JSON-RPC response로 반환하도록 연결
- 이후 schema 문자열을 typed request structs 또는 generated schema로 대체

## 리스크
Low. `src/mcp/` skeleton metadata와 tests만 변경했고 CLI/git/worktree 공유 로직은 건드리지 않았습니다.

## 롤백
이 PR 커밋을 revert하면 기존 MCP skeleton 상태로 돌아갑니다.

## Test plan
- `cargo fmt --check`
- `cargo build --quiet`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`