### PR TITLE
docs: standardize Parsec release text in English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,71 +9,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2026-06-03 — _The visualization release_
 
-v0.5 마일스톤 **16/16 완료**. Polish & Power-User UX: 워크트리/PR/CI를 하나의
-시야에 모아주는 시각화·자동화 명령 6개 신규.
+v0.5 completes the **16/16** milestone for polish and power-user UX, adding
+six visualization and automation commands that bring worktrees, PRs, and CI
+into one view.
 
 ### Added
-- **`parsec smartlog` (alias `sl`)** — 모든 활성 워크트리를 commit DAG로 시각화.
-  ASCII 트리가 base branch별로 워크트리를 묶고 merge-base 이후 커밋을 표시.
-  Phase 2 PR/CI status overlay (`#327`), Phase 3 worktree filter + ANSI 색상 +
-  stack indicator (`#333`). `--json` 출력 지원. (`#245`, `#305`, `#318`, `#319`)
-- **`parsec dashboard` (alias `dash`)** — 실시간 터미널 TUI 대시보드. 워크트리 /
-  CI 상태 / GitHub PR을 3-pane 레이아웃으로 한 화면에. ratatui + crossterm 기반,
-  키바인딩 `q` (종료) / `r` (즉시 새로고침) / `?` (도움말), `--refresh N` 인터벌,
-  `--no-overlay` 오프라인 모드. (`#248`, `#337`)
-- **`parsec test`** — 워크트리 병렬 테스트 러너 + tree-hash 결과 캐싱.
-  `--all`로 모든 활성 워크트리 일괄 실행, `--jobs N` 병렬, `--cache`로 동일 tree
-  재실행 시 즉시 스킵. `[test]` 설정 섹션(`command`, `jobs`, `cache`). 인간/JSON
-  출력. (`#247`, `#336`)
-- **`parsec health`** — 모든 활성 워크트리 헬스 체크. Phase 1: lock(`.git/index.lock`)
-  · uncommitted 파일 수 · stale(7일 초과) 검사 (`#324`, `#325`). Phase 2: CI 상태
-  overlay + configurable stale threshold (`#330`). CLI 통합 테스트 5개 (`#326`).
-- **`parsec reviews`** — 워크트리별 받은/요청한 PR 리뷰를 한 표로. Phase 1 (`#301`,
+- **`parsec smartlog` (alias `sl`)** — visualizes every active worktree as a
+  commit DAG. The ASCII tree groups worktrees by base branch and shows commits
+  since the merge base. Phase 2 adds the PR/CI status overlay (`#327`); Phase 3
+  adds worktree filtering, ANSI colors, stack indicators (`#333`), and `--json`
+  output. (`#245`, `#305`, `#318`, `#319`)
+- **`parsec dashboard` (alias `dash`)** — real-time terminal TUI dashboard with
+  worktrees, CI state, and GitHub PRs in a 3-pane layout. Built on ratatui and
+  crossterm, with `q` to quit, `r` to refresh immediately, `?` for help,
+  `--refresh N` for the polling interval, and `--no-overlay` for offline mode.
+  (`#248`, `#337`)
+- **`parsec test`** — parallel worktree test runner with tree-hash result
+  caching. `--all` runs every active worktree, `--jobs N` controls concurrency,
+  and `--cache` skips reruns for the same tree. Adds the `[test]` config section
+  (`command`, `jobs`, `cache`) and both human-readable and JSON output.
+  (`#247`, `#336`)
+- **`parsec health`** — health checks for every active worktree. Phase 1 checks
+  `.git/index.lock`, uncommitted file counts, and stale worktrees older than
+  seven days (`#324`, `#325`). Phase 2 adds CI status overlays and a configurable
+  stale threshold (`#330`). Includes five CLI integration tests (`#326`).
+- **`parsec reviews`** — shows received and requested PR reviews per worktree
+  in one table. Phase 1 (`#301`,
   `#331`) + Phase 2 `--requested` (GitHub Search API) (`#334`).
-- **`parsec conflicts --simulate`** — 기존 filename overlap 휴리스틱을 보완하는
-  line-level 충돌 시뮬레이션. `git merge-tree --write-tree`로 워크트리 vs base +
-  워크트리 페어 cross-simulate 두 패스. 머지 전 실제 충돌 파일을 read-only로 노출.
+- **`parsec conflicts --simulate`** — line-level conflict simulation that
+  complements the existing filename-overlap heuristic. Uses
+  `git merge-tree --write-tree` for two read-only passes: worktree vs base and
+  cross-simulation across worktree pairs. Exposes actual conflict files before
+  merge.
   (`#246`, `#335`)
-- **`parsec commit`** — AI 커밋 메시지 생성 (OpenAI / Anthropic). staged diff 분석
-  후 자동 prefix + Conventional Commits 포맷(`--conventional`). 수동 메시지
-  override(`--message`). (`#274`)
-- **`parsec sync`** — auto-sync `main`/`develop` into stale worktrees (rebase 또는
-  merge 전략, `--all` 일괄, `--dry-run` behind 카운트, conflict hint). (`#290`)
-- **AI-generated PR descriptions** — `parsec ship`이 OpenAI / Anthropic / Ollama
-  공급자로 PR 본문 자동 작성. `[ai]` 설정. (`#242`, `#275`)
-- **`parsec __complete` shell-completion 헬퍼** — 숨김 subcommand가 워크트리 / branch
-  완성 후보를 newline-separated로 출력. zsh / bash / fish 동적 탭 완성 지원
-  (`#291`, `#312`). Phase 2 dynamic 쉘 스크립트 (`#328`).
-- **`parsec agent` mode (PARSEC_AGENT=1)** — non-interactive JSON 출력 모드, AI
-  에이전트 호출용. (`#272`)
+- **`parsec commit`** — AI commit message generation via OpenAI or Anthropic.
+  Analyzes staged diffs, adds automatic prefixes, supports Conventional Commits
+  with `--conventional`, and allows manual overrides with `--message`. (`#274`)
+- **`parsec sync`** — auto-syncs `main`/`develop` into stale worktrees with rebase
+  or merge strategies, `--all` batch mode, `--dry-run` behind counts, and
+  conflict hints. (`#290`)
+- **AI-generated PR descriptions** — `parsec ship` can generate PR bodies with
+  OpenAI, Anthropic, or Ollama providers via `[ai]` settings. (`#242`, `#275`)
+- **`parsec __complete` shell-completion helper** — hidden subcommand that emits
+  worktree and branch completion candidates as newline-separated output. Supports
+  dynamic tab completion for zsh, bash, and fish
+  (`#291`, `#312`). Phase 2 adds dynamic shell scripts (`#328`).
+- **`parsec agent` mode (PARSEC_AGENT=1)** — non-interactive JSON output mode
+  for AI agent invocations. (`#272`)
 
 ### Changed
-- **Error messages standardized to 3-line format** — 모든 사용자 대상 에러가
-  `error: <summary> / caused by: <root cause> / help: <action>` 포맷으로 통일
+- **Error messages standardized to 3-line format** — all user-facing errors now
+  use the `error: <summary> / caused by: <root cause> / help: <action>` format
   (`#303`, `#306`).
 
 ### Fixed
 - `parsec ship` falls back to `gh auth token` when `PARSEC_GITHUB_TOKEN` /
   `GITHUB_TOKEN` / `GH_TOKEN` env vars are absent — parity with `parsec doctor`
-  and the tracker layer. GitHub host에만 한정해 Bitbucket / GitLab remote는 영향
-  없음 (`#281`).
+  and the tracker layer. The fallback is limited to GitHub hosts and does not
+  affect Bitbucket or GitLab remotes (`#281`).
 
 ### CI
-- Windows VS2026 (Visual Studio 2026 runner) pre-validation 잡 — MSVC toolchain
-  회귀 사전 차단 (`#307`, `#311`).
-- `parsec test`의 shell invocation을 cross-platform화 (sh -c / cmd /C),
-  Windows test가 WSL을 호출하지 않도록 수정.
+- Windows VS2026 (Visual Studio 2026 runner) pre-validation job to catch MSVC
+  toolchain regressions early (`#307`, `#311`).
+- Made `parsec test` shell invocation cross-platform (`sh -c` / `cmd /C`) so
+  Windows tests no longer invoke WSL.
 
 ### Docs
-- 모듈별 RustDoc 보강 — `diff` / `history` (`#321`), `stack` / `ci` (`#323`).
-- CHANGELOG `[Unreleased]` 섹션 누락 항목 보완 (smartlog / complete / errors /
-  win-ci) (`#316`, `#317`).
+- Expanded module-level RustDoc for `diff` / `history` (`#321`) and
+  `stack` / `ci` (`#323`).
+- Filled missing CHANGELOG `[Unreleased]` entries for smartlog, completion,
+  errors, and win-ci (`#316`, `#317`).
 
 ### Tests
-- CLI 통합 테스트 대폭 추가 — `compress` / `config schema` / `log --export`
-  (`#314`, `#315`), `smartlog` / `sl` (`#318`, `#319`), `health` (`#324`, `#326`),
-  `parsec test` (5 신규), `parsec dashboard` (4 신규), `conflicts --simulate`
-  (4 신규).
+- Added broad CLI integration coverage for `compress`, `config schema`,
+  `log --export` (`#314`, `#315`), `smartlog` / `sl` (`#318`, `#319`), `health`
+  (`#324`, `#326`), `parsec test` (five new tests), `parsec dashboard` (four new
+  tests), and `conflicts --simulate` (four new tests).
 
 ## [0.4.0] - 2026-05-04
 

--- a/src/cli/commands/doctor.rs
+++ b/src/cli/commands/doctor.rs
@@ -86,9 +86,10 @@ pub async fn doctor(repo: &Path, mode: Mode) -> Result<()> {
     // ------------------------------------------------------------------
     {
         let config_result = crate::config::ParsecConfig::load();
-        // issue #281: gh auth token fallback 은 lib (`crate::env::gh_auth_token`) 에서
-        // 단일 정의 — `ship` / tracker 와 parity. doctor 는 SOURCE 를 사람이 읽기 위한
-        // 진단 메시지로 분기하므로 별도 매핑 유지.
+        // Issue #281: the gh auth token fallback is defined once in lib
+        // (`crate::env::gh_auth_token`) for parity with `ship` and tracker.
+        // doctor keeps its own source mapping because it reports human-readable
+        // diagnostics.
         let from_gh = crate::env::gh_auth_token().is_some();
         let from_env = std::env::var("GITHUB_TOKEN").is_ok();
         let github_token_found = match &config_result {

--- a/src/env.rs
+++ b/src/env.rs
@@ -235,13 +235,14 @@ mod tests {
         }
     }
 
-    /// 우선순위 + 빈값 fallback + 모두 미설정 시나리오를 한 함수에서 sequential 검사.
-    /// `env_lock()` 으로 process-wide 직렬화 (cargo test 병렬 실행 환경에서 sibling
-    /// 테스트가 env 를 클로버하지 않도록). Windows CI 에서 race 발견 (#289).
+    /// Checks token priority, empty-value fallback, and fully unset scenarios
+    /// in sequence. `env_lock()` serializes the process-wide environment so
+    /// sibling cargo tests cannot clobber these values; Windows CI exposed this
+    /// race in #289.
     #[test]
     fn github_token_priority_order_and_fallback() {
         let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
-        // 1. PARSEC_GITHUB_TOKEN 우선
+        // 1. PARSEC_GITHUB_TOKEN wins.
         {
             let g = EnvGuard::new(&[PARSEC_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN]);
             g.set(PARSEC_GITHUB_TOKEN, "p");
@@ -250,7 +251,7 @@ mod tests {
             assert_eq!(github_token().as_deref(), Some("p"));
             drop(g);
         }
-        // 2. PARSEC_GITHUB_TOKEN 미설정 → GITHUB_TOKEN
+        // 2. Unset PARSEC_GITHUB_TOKEN falls back to GITHUB_TOKEN.
         {
             let g = EnvGuard::new(&[PARSEC_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN]);
             g.set(GITHUB_TOKEN, "g");
@@ -258,14 +259,14 @@ mod tests {
             assert_eq!(github_token().as_deref(), Some("g"));
             drop(g);
         }
-        // 3. PARSEC_GITHUB_TOKEN / GITHUB_TOKEN 미설정 → GH_TOKEN
+        // 3. Unset PARSEC_GITHUB_TOKEN and GITHUB_TOKEN fall back to GH_TOKEN.
         {
             let g = EnvGuard::new(&[PARSEC_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN]);
             g.set(GH_TOKEN, "h");
             assert_eq!(github_token().as_deref(), Some("h"));
             drop(g);
         }
-        // 4. 빈 PARSEC_GITHUB_TOKEN 은 무시 → GITHUB_TOKEN
+        // 4. Empty PARSEC_GITHUB_TOKEN is ignored and falls back to GITHUB_TOKEN.
         {
             let g = EnvGuard::new(&[PARSEC_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN]);
             g.set(PARSEC_GITHUB_TOKEN, "");
@@ -273,8 +274,8 @@ mod tests {
             assert_eq!(github_token().as_deref(), Some("g"));
             drop(g);
         }
-        // 5. 모두 미설정 + gh 실패 → None. CI 환경 (gh 로그인 X) 이 일반.
-        //    local dev 에서 gh auth login 돼있으면 Some(token) 도 허용 (smoke).
+        // 5. All env vars unset and gh unavailable returns None, which is
+        //    common in CI without gh login. Local gh auth may return a token.
         {
             let g = EnvGuard::new(&[PARSEC_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN]);
             match github_token() {
@@ -290,8 +291,9 @@ mod tests {
 
     #[test]
     fn gh_auth_token_returns_option_string_or_none() {
-        // 외부 gh binary 에 의존 — CI 환경 (로그인 X) 에서는 None 기대.
-        // local dev 에서 gh auth login 돼있으면 Some(token). 둘 다 허용 (smoke check only).
+        // Depends on the external gh binary: CI without login should return
+        // None, while local dev with gh auth may return a token. This is only a
+        // smoke check, so both outcomes are valid.
         match gh_auth_token() {
             None => {}
             Some(t) => {


### PR DESCRIPTION
## Summary
- translate the v0.5 changelog release notes to English
- translate remaining Korean Rust comments in env and doctor token fallback code
- verify the repository no longer contains Hangul text

## Verification
- rg -n --pcre2 '[\p{Hangul}]' .
- git diff --check
- cargo fmt --check
- cargo test