### PR TITLE
feat(mcp): Phase 1 — stdio serve skeleton

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -71,6 +71,16 @@ pub enum Command {
         hook: Option<String>,
     },
 
+    /// Run parsec as an MCP server for AI clients.
+    ///
+    /// `parsec mcp serve` speaks newline-delimited JSON-RPC 2.0 over stdio.
+    /// The current phase supports initialize/tools-list transport smoke tests;
+    /// real tool execution is wired in a later MCP phase.
+    Mcp {
+        #[command(subcommand)]
+        action: McpAction,
+    },
+
     /// List all active worktrees
     ///
     /// Shows a table of all parsec-managed worktrees with ticket, branch,
@@ -676,6 +686,12 @@ pub enum CompleteKind {
 }
 
 #[derive(Subcommand)]
+pub enum McpAction {
+    /// Serve MCP JSON-RPC over stdio.
+    Serve,
+}
+
+#[derive(Subcommand)]
 pub enum ConfigAction {
     /// Interactive configuration setup
     ///
@@ -741,6 +757,7 @@ pub async fn run(cli: Cli) -> Result<()> {
     // Observability: extract command name and set up execution tracking
     let cmd_name = match &cli.command {
         Command::Start { .. } => "start",
+        Command::Mcp { .. } => "mcp",
         Command::List { .. } => "list",
         Command::Status { .. } => "status",
         Command::Ticket { .. } => "ticket",
@@ -809,6 +826,9 @@ pub async fn run(cli: Cli) -> Result<()> {
             )
             .await
         }
+        Command::Mcp { action } => match action {
+            McpAction::Serve => crate::mcp::serve_stdio(cli.dry_run),
+        },
         Command::List { no_pr, full } => commands::list(&repo_path, no_pr, full, output_mode).await,
         Command::Status { ticket } => {
             commands::status(&repo_path, ticket.as_deref(), output_mode).await

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -26,8 +26,8 @@
 //!
 //! ## Phases
 //!
-//! - **Phase 1** (this): module skeleton + tool registry shape.
-//! - **Phase 2** (#293): stdio JSON-RPC echo server (`parsec mcp serve`).
+//! - **Phase 1**: module skeleton + tool registry shape.
+//! - **Phase 2** (this, #293): stdio JSON-RPC skeleton (`parsec mcp serve`).
 //! - **Phase 3** (#293): wire real implementations to registered tools.
 
 // Phase 1 skeleton: items are defined but the JSON-RPC dispatcher (Phase 2)
@@ -35,6 +35,8 @@
 #![allow(dead_code)]
 
 pub mod tools;
+
+use std::io::{BufRead, Write};
 
 /// Context passed to every MCP tool handler.
 ///
@@ -194,6 +196,113 @@ pub fn tools_list_payload() -> anyhow::Result<serde_json::Value> {
     Ok(serde_json::json!({ "tools": tools }))
 }
 
+/// Serve newline-delimited JSON-RPC 2.0 messages over stdio.
+///
+/// This Phase 2 skeleton establishes the transport boundary used by MCP
+/// clients. It supports `initialize`, `tools/list`, and an explicit `echo`
+/// method for smoke tests; real tool dispatch lands in the next phase.
+pub fn serve_stdio(dry_run: bool) -> anyhow::Result<()> {
+    serve(std::io::stdin().lock(), std::io::stdout().lock(), dry_run)
+}
+
+fn serve<R, W>(reader: R, writer: W, dry_run: bool) -> anyhow::Result<()>
+where
+    R: BufRead,
+    W: Write,
+{
+    let _ctx = McpContext::from_cwd(dry_run)?;
+    let mut writer = writer;
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let response = match serde_json::from_str::<serde_json::Value>(&line) {
+            Ok(request) => dispatch_json_rpc(request),
+            Err(err) => json_rpc_error(serde_json::Value::Null, -32700, "Parse error", err),
+        };
+
+        serde_json::to_writer(&mut writer, &response)?;
+        writeln!(writer)?;
+        writer.flush()?;
+    }
+
+    Ok(())
+}
+
+fn dispatch_json_rpc(request: serde_json::Value) -> serde_json::Value {
+    let id = request
+        .get("id")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let method = request
+        .get("method")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+
+    match method {
+        "initialize" => json_rpc_result(
+            id,
+            serde_json::json!({
+                "protocolVersion": "2025-03-26",
+                "serverInfo": {
+                    "name": "git-parsec",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+                "capabilities": {
+                    "tools": {},
+                },
+            }),
+        ),
+        "tools/list" => match tools_list_payload() {
+            Ok(payload) => json_rpc_result(id, payload),
+            Err(err) => json_rpc_error(id, -32603, "Internal error", err),
+        },
+        "echo" => json_rpc_result(
+            id,
+            request
+                .get("params")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+        ),
+        "tools/call" => json_rpc_error(
+            id,
+            -32601,
+            "Method not implemented",
+            "tools/call dispatch is planned for the next MCP phase",
+        ),
+        "" => json_rpc_error(id, -32600, "Invalid Request", "missing method"),
+        _ => json_rpc_error(id, -32601, "Method not found", method),
+    }
+}
+
+fn json_rpc_result(id: serde_json::Value, result: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    })
+}
+
+fn json_rpc_error(
+    id: serde_json::Value,
+    code: i64,
+    message: &'static str,
+    data: impl std::fmt::Display,
+) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message,
+            "data": data.to_string(),
+        },
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -322,5 +431,67 @@ mod tests {
             .with_github_token("ghp_test");
         assert!(ctx.dry_run);
         assert_eq!(ctx.github_token.as_deref(), Some("ghp_test"));
+    }
+
+    #[test]
+    fn initialize_returns_server_capabilities() {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        });
+
+        let response = dispatch_json_rpc(request);
+
+        assert_eq!(response["jsonrpc"], "2.0");
+        assert_eq!(response["id"], 1);
+        assert_eq!(response["result"]["serverInfo"]["name"], "git-parsec");
+        assert!(response["result"]["capabilities"]["tools"].is_object());
+    }
+
+    #[test]
+    fn tools_list_method_uses_registry_payload() {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "tools",
+            "method": "tools/list"
+        });
+
+        let response = dispatch_json_rpc(request);
+        let tools = response["result"]["tools"]
+            .as_array()
+            .expect("tools/list should return an array");
+
+        assert_eq!(tools.len(), TOOLS.len());
+        assert_eq!(tools[0]["name"], TOOLS[0].name);
+    }
+
+    #[test]
+    fn echo_round_trips_params_for_stdio_smoke_tests() {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "echo",
+            "params": {"ok": true}
+        });
+
+        let response = dispatch_json_rpc(request);
+
+        assert_eq!(response["result"], serde_json::json!({"ok": true}));
+    }
+
+    #[test]
+    fn unknown_method_returns_json_rpc_error() {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "parsec/nope"
+        });
+
+        let response = dispatch_json_rpc(request);
+
+        assert_eq!(response["error"]["code"], -32601);
+        assert_eq!(response["error"]["message"], "Method not found");
     }
 }


### PR DESCRIPTION
## 무엇
- Add `parsec mcp serve` as the first stdio JSON-RPC transport skeleton for MCP clients.
- Support `initialize`, `tools/list`, and a deterministic `echo` smoke-test method.

## 왜
Refs #293. This advances the v1.0 MCP transport epic on `release/1.0` after the tool spec and registry foundation from #292. @erishforG

## 변경
- Adds the `mcp serve` subcommand without changing existing command signatures.
- Adds newline-delimited JSON-RPC handling in `src/mcp/`.
- Returns the existing MCP registry through `tools/list`.
- Adds unit coverage for initialize, tools/list, echo, and unknown-method errors.

## 다음 Phase 힌트
- Wire `tools/call` to the registered handlers.
- Add client registration docs for Claude Desktop/Cursor once the call path is available.

## 리스크
Low. This is a new subcommand and an MCP-contained transport skeleton; existing commands are unchanged.

## 롤백
Revert this PR to remove the `mcp serve` CLI surface and stdio dispatcher.

## Test plan
- `cargo build --quiet`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`
- `printf ... | cargo run --quiet -- mcp serve` smoke test