### PR TITLE
test(mcp): Phase 3 — fixture redaction contract

### DIFF
--- a/tests/mcp/README.md
+++ b/tests/mcp/README.md
@@ -30,3 +30,33 @@ Supported assertion keys:
 
 Keep fixtures deterministic. Do not record machine-local paths, auth tokens,
 timestamps, or network-derived fields.
+
+## Redaction Contract
+
+Recording fixtures are committed test inputs, so they must be safe to publish
+and stable across machines. Before adding a new recording, replace volatile or
+secret-bearing values with deterministic placeholders.
+
+| Source value | Fixture placeholder |
+|---|---|
+| GitHub tokens, PATs, bearer tokens | `<redacted-token>` |
+| `Authorization` headers | `<redacted-authorization>` |
+| User home directories or absolute repo paths | `<repo>` |
+| Temporary directories | `<tmp>` |
+| Real user emails | `<user@example.invalid>` |
+| Wall-clock timestamps | `<timestamp>` |
+| Network request IDs | `<request-id>` |
+
+Reviewers should reject fixtures that contain token-shaped strings such as
+`ghp_`, `github_pat_`, `Bearer `, or `Authorization`. Fixture responses should
+also avoid raw stdout/stderr dumps from MCP clients; assert only the stable JSON
+fields needed by the smoke contract.
+
+## Recording Checklist
+
+1. Capture the smallest request/response pair that exercises the behavior.
+2. Redact secrets, local paths, timestamps, and network-generated IDs.
+3. Prefer `contains_text`, `kind`, `min_len`, and `contains_tool` over copying
+   full response payloads.
+4. Run `cargo test --quiet mcp::tests::stdio_recording_fixtures_match_dispatcher`
+   before opening a PR.


### PR DESCRIPTION
## 무엇
MCP recording fixture README에 redaction contract와 recording checklist를 추가했습니다.

## 왜
Refs #295. Claude Desktop / Cursor e2e fixture가 늘어나기 전에 token, local path, timestamp, network-generated ID가 저장되지 않도록 안전한 fixture 기준을 고정합니다. @erishforG

## 변경
- tests/mcp/README.md에 redaction placeholder table 추가
- token-shaped strings 및 authorization header 리뷰 기준 추가
- fixture capture/review checklist 추가

## 다음 Phase 힌트
- 실제 client recording fixture를 추가할 때 이 checklist를 기준으로 scrubbed fixture를 저장
- 필요하면 fixture hygiene 검사 테스트를 별도 Phase로 추가

## 리스크
Low. 문서만 변경하며 CLI, MCP dispatcher, git/worktree 로직은 변경하지 않습니다.

## 롤백
tests/mcp/README.md의 redaction/checklist 섹션만 되돌리면 됩니다.

## Test plan
- cargo build --quiet
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --quiet mcp::tests::stdio_recording_fixtures_match_dispatcher