### PR TITLE
test(mcp): Phase 4 — guard fixture redaction

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -772,10 +772,8 @@ mod tests {
 
     #[test]
     fn stdio_recording_fixtures_match_dispatcher() {
-        let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/mcp/fixtures/stdio_smoke.jsonl");
-        let fixture = std::fs::read_to_string(&fixture_path)
-            .unwrap_or_else(|err| panic!("failed to read {}: {err}", fixture_path.display()));
+        let fixture_path = stdio_smoke_fixture_path();
+        let fixture = read_fixture(&fixture_path);
 
         for (line_no, line) in fixture.lines().enumerate() {
             let trimmed = line.trim();
@@ -817,6 +815,47 @@ mod tests {
                 assert_fixture_assertion(name, &response, assertion);
             }
         }
+    }
+
+    #[test]
+    fn stdio_recording_fixtures_are_redacted() {
+        let fixture_path = stdio_smoke_fixture_path();
+        let fixture = read_fixture(&fixture_path);
+        let denied = [
+            "ghp_",
+            "github_pat_",
+            "Bearer ",
+            "Authorization",
+            "/Users/",
+            "/home/",
+            "/var/folders/",
+        ];
+
+        for (line_no, line) in fixture.lines().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+
+            for pattern in denied {
+                assert!(
+                    !trimmed.contains(pattern),
+                    "fixture line {} contains unredacted pattern '{}'",
+                    line_no + 1,
+                    pattern
+                );
+            }
+        }
+    }
+
+    fn stdio_smoke_fixture_path() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/mcp/fixtures/stdio_smoke.jsonl")
+    }
+
+    fn read_fixture(path: &std::path::Path) -> String {
+        std::fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()))
     }
 
     fn assert_fixture_assertion(

--- a/tests/mcp/README.md
+++ b/tests/mcp/README.md
@@ -47,10 +47,10 @@ secret-bearing values with deterministic placeholders.
 | Wall-clock timestamps | `<timestamp>` |
 | Network request IDs | `<request-id>` |
 
-Reviewers should reject fixtures that contain token-shaped strings such as
-`ghp_`, `github_pat_`, `Bearer `, or `Authorization`. Fixture responses should
-also avoid raw stdout/stderr dumps from MCP clients; assert only the stable JSON
-fields needed by the smoke contract.
+The test suite rejects fixtures that contain token-shaped strings such as
+`ghp_`, `github_pat_`, `Bearer `, `Authorization`, or common absolute local
+path prefixes. Fixture responses should also avoid raw stdout/stderr dumps from
+MCP clients; assert only the stable JSON fields needed by the smoke contract.
 
 ## Recording Checklist
 
@@ -58,5 +58,5 @@ fields needed by the smoke contract.
 2. Redact secrets, local paths, timestamps, and network-generated IDs.
 3. Prefer `contains_text`, `kind`, `min_len`, and `contains_tool` over copying
    full response payloads.
-4. Run `cargo test --quiet mcp::tests::stdio_recording_fixtures_match_dispatcher`
+4. Run `cargo test --quiet mcp::tests::stdio_recording_fixtures`
    before opening a PR.


### PR DESCRIPTION
## 무엇
MCP stdio recording fixtures에 대한 자동 redaction guard를 추가했습니다.

## 왜
Refs #295. 최근 fixture redaction contract가 문서화되었고, 이번 Phase는 그 계약을 테스트로 고정해 토큰과 로컬 경로가 fixture에 커밋되는 위험을 줄입니다.

## 변경
- stdio fixture 테스트가 공통 fixture reader helper를 사용하도록 정리
- fixture 라인에서 GitHub token, bearer/auth header, common local path prefix를 거부하는 테스트 추가
- tests/mcp README의 checklist를 새 테스트 패턴과 맞춤

## 다음 Phase 힌트
Claude Desktop/Cursor 실제 recording fixture를 추가할 때 redaction guard 범위를 확장하거나 fixture별 metadata validation을 추가할 수 있습니다.

## 리스크
Low. MCP 테스트와 문서만 변경하며 런타임 동작은 바꾸지 않습니다.

## 롤백
해당 커밋을 revert하면 기존 fixture matcher만 남습니다.

## Test plan
- cargo fmt --check
- cargo test --quiet mcp::tests::stdio_recording_fixtures
- cargo build --quiet
- cargo clippy --all-targets -- -D warnings
- cargo test --quiet

@erishforG