### PR TITLE
docs(mcp): Phase 3 — align error schema

### DIFF
--- a/docs/mcp/spec.md
+++ b/docs/mcp/spec.md
@@ -1,7 +1,7 @@
 # git-parsec MCP Tool Specification
 
 **Version**: 0.1 (draft)  
-**Date**: 2026-06-07  
+**Date**: 2026-06-24  
 **Milestone**: v1.0  
 **Refs**: #292, #241
 
@@ -568,10 +568,24 @@ All tools return MCP `isError: true` with a structured body on failure:
 }
 ```
 
+Current Phase 3 transport stubs use the same shape with `tool_error` while a
+registered tool is reachable through `tools/call` but not yet implemented:
+
+```json
+{
+  "error": {
+    "code": "tool_error",
+    "message": "worktree_status: implementation is planned for a later MCP phase (#293)",
+    "tool": "worktree_status"
+  }
+}
+```
+
 **Standard error codes**:
 
 | Code | Meaning |
 |---|---|
+| `tool_error` | Registered tool handler failed or is still a structured stub |
 | `WORKTREE_NOT_FOUND` | Ticket has no managed worktree |
 | `GIT_ERROR` | Underlying git2 / git CLI error |
 | `GITHUB_API_ERROR` | GitHub API call failed (rate limit, auth, network) |
@@ -579,6 +593,10 @@ All tools return MCP `isError: true` with a structured body on failure:
 | `DIRTY_WORKTREE` | Operation blocked by uncommitted changes |
 | `CONFLICT` | Merge/rebase conflict detected |
 | `DRY_RUN` | Preview only; no changes made |
+| `AUTH_REQUIRED` | Tool requires a delegated GitHub token and none was provided |
+| `INSUFFICIENT_SCOPE` | Delegated token does not cover the requested GitHub operation |
+| `SANDBOX_VIOLATION` | Requested repository or path escapes the validated parsec boundary |
+| `DRY_RUN_REQUIRED` | Server policy requires preview mode for the requested mutation |
 
 ---
 


### PR DESCRIPTION
## 무엇
MCP tool spec의 Error Schema를 현재 Phase 3 stdio/tool dispatch 계약과 맞췄습니다.

## 왜
Refs #292

`tools/call`은 이미 MCP content envelope 안에 structured error body를 반환하고 있고, auth/sandbox 문서는 별도 error code를 정의합니다. spec 문서의 공통 Error Schema도 이 계약을 한곳에서 볼 수 있어야 합니다.

## 변경
- `docs/mcp/spec.md` 날짜 갱신
- Phase 3 stub dispatch가 쓰는 `tool_error` 예시 추가
- 표준 error code 표에 `tool_error`, auth, scope, sandbox, dry-run policy 코드를 추가

## 다음 Phase 힌트
- 구현 PR이 auth preflight를 머지하면 `AUTH_REQUIRED` fixture를 stdio smoke contract에 추가
- 실제 tool implementation 단계에서 Rust enum/serializer와 spec 표를 맞추는 parity test 고려

## 리스크
Low. 문서 전용 변경이며 CLI, MCP transport, worktree 로직을 변경하지 않습니다.

## 롤백
이 PR revert만으로 문서 변경 전 상태로 돌아갈 수 있습니다.

## Test plan
- `cargo build --quiet`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`

@erishforG
