### PR TITLE
test(mcp): Phase 4 — fixture redaction guard

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -819,6 +819,43 @@ mod tests {
         }
     }
 
+    #[test]
+    fn stdio_recording_fixtures_are_redacted() {
+        let fixture_dir =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/mcp/fixtures");
+        let forbidden_fragments = [
+            "ghp_",
+            "github_pat_",
+            "Bearer ",
+            "Authorization",
+            "/Users/",
+            "/home/",
+            "C:\\Users\\",
+        ];
+
+        for entry in std::fs::read_dir(&fixture_dir)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", fixture_dir.display()))
+        {
+            let path = entry
+                .expect("fixture directory entry should be readable")
+                .path();
+            if path.extension().and_then(std::ffi::OsStr::to_str) != Some("jsonl") {
+                continue;
+            }
+
+            let fixture = std::fs::read_to_string(&path)
+                .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+            for fragment in forbidden_fragments {
+                assert!(
+                    !fixture.contains(fragment),
+                    "fixture {} contains unredacted sensitive fragment '{}'",
+                    path.display(),
+                    fragment
+                );
+            }
+        }
+    }
+
     fn assert_fixture_assertion(
         name: &str,
         response: &serde_json::Value,

--- a/tests/mcp/README.md
+++ b/tests/mcp/README.md
@@ -60,3 +60,5 @@ fields needed by the smoke contract.
    full response payloads.
 4. Run `cargo test --quiet mcp::tests::stdio_recording_fixtures_match_dispatcher`
    before opening a PR.
+5. Run `cargo test --quiet mcp::tests::stdio_recording_fixtures_are_redacted`
+   after adding or updating any committed recording.


### PR DESCRIPTION
## 무엇
MCP recording fixtures now have an automated redaction guard that scans committed JSONL recordings for token-shaped strings, authorization headers, and common absolute home-directory paths.

## 왜
Refs #295. The fixture redaction contract was documented, but future Claude Desktop / Cursor recordings also need a test gate so sensitive or machine-local values cannot land by accident.

## 변경
- Added `stdio_recording_fixtures_are_redacted` for all `tests/mcp/fixtures/*.jsonl` files.
- Documented the focused redaction test in the MCP fixture checklist.

## 다음 Phase 힌트
Add client-specific fixture files once Claude Desktop / Cursor recordings are available, keeping them under the same redaction guard.

## 리스크
Low: test-only guard plus README update, isolated to MCP paths.

## 롤백
Revert this commit to remove the redaction check and README checklist item.

## Test plan
- `cargo test --quiet stdio_recording_fixtures`
- `cargo build --quiet`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`

@erishforG
