### PR TITLE
test(mcp): Phase 5 — harden fixture contract

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -907,6 +907,7 @@ mod tests {
             .join("tests/mcp/fixtures/stdio_smoke.jsonl");
         let fixture = std::fs::read_to_string(&fixture_path)
             .unwrap_or_else(|err| panic!("failed to read {}: {err}", fixture_path.display()));
+        let mut fixture_names = std::collections::HashSet::new();
 
         for (line_no, line) in fixture.lines().enumerate() {
             let trimmed = line.trim();
@@ -920,6 +921,7 @@ mod tests {
                 .get("name")
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("<unnamed>");
+            validate_stdio_fixture_record(name, &record, line_no + 1, &mut fixture_names);
             let request = record
                 .get("request")
                 .cloned()
@@ -987,6 +989,46 @@ mod tests {
         }
     }
 
+    fn validate_stdio_fixture_record(
+        name: &str,
+        record: &serde_json::Value,
+        line_no: usize,
+        fixture_names: &mut std::collections::HashSet<String>,
+    ) {
+        assert_ne!(
+            name, "<unnamed>",
+            "fixture line {line_no} must declare a string name"
+        );
+        assert!(
+            fixture_names.insert(name.to_owned()),
+            "fixture name '{name}' is duplicated"
+        );
+        assert!(
+            record.get("request").is_some(),
+            "fixture '{name}' must declare a request"
+        );
+
+        let expects_no_response = record
+            .get("no_response")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        let assertions = record
+            .get("assertions")
+            .and_then(serde_json::Value::as_array);
+
+        if expects_no_response {
+            assert!(
+                assertions.is_none(),
+                "fixture '{name}' cannot combine no_response with assertions"
+            );
+        } else {
+            assert!(
+                assertions.is_some_and(|items| !items.is_empty()),
+                "fixture '{name}' must declare at least one assertion"
+            );
+        }
+    }
+
     fn assert_fixture_assertion(
         name: &str,
         response: &serde_json::Value,
@@ -999,6 +1041,15 @@ mod tests {
         let actual = response
             .pointer(pointer)
             .unwrap_or_else(|| panic!("fixture '{name}' pointer '{pointer}' did not match"));
+        let has_matcher = assertion.get("equals").is_some()
+            || assertion.get("min_len").is_some()
+            || assertion.get("kind").is_some()
+            || assertion.get("contains_text").is_some()
+            || assertion.get("contains_tool").is_some();
+        assert!(
+            has_matcher,
+            "fixture '{name}' assertion for {pointer} must declare a matcher"
+        );
 
         if let Some(expected) = assertion.get("equals") {
             assert_eq!(

--- a/tests/mcp/README.md
+++ b/tests/mcp/README.md
@@ -19,6 +19,10 @@ Each non-empty, non-comment line has this shape:
 - `no_response`: set to `true` for JSON-RPC notifications that must not emit
   a response.
 
+Fixture names must be unique within a recording file. Response fixtures must
+declare at least one assertion, while notification fixtures use `no_response`
+without assertions.
+
 Supported assertion keys:
 
 - `pointer`: required JSON Pointer into the response.


### PR DESCRIPTION
## 무엇
@erishforG MCP stdio recording fixture 계약을 더 엄격하게 검증하는 Phase 5 테스트 보강입니다.

## 왜
Refs #295. v1.0 MCP e2e/recording fixture가 늘어날수록 중복 fixture 이름, assertion 누락, notification/response 계약 혼용을 초기에 잡아야 합니다.

## 변경
- `stdio_recording_fixtures_match_dispatcher`에서 fixture name 유일성, request 존재, response assertion 존재, `no_response`/`assertions` 상호 배타성을 검증합니다.
- 각 assertion이 JSON pointer 외에 최소 하나의 matcher를 선언하도록 검증합니다.
- `tests/mcp/README.md`에 fixture naming/response 계약을 문서화했습니다.

## 다음 Phase 힌트
- 실제 Claude Desktop/Cursor recording 파일이 추가되면 fixture 파일별 runner와 client profile metadata를 분리할 수 있습니다.

## 리스크
Low. 테스트 하네스와 MCP fixture 문서만 변경하며 런타임 MCP 동작은 바꾸지 않습니다.

## 롤백
이 PR revert로 fixture 계약 검증만 이전 상태로 돌아갑니다.

## Test plan
- `cargo fmt --check`
- `cargo build --quiet`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`
