### PR TITLE
docs(mcp): Phase 9 — agent workflow contract

### DIFF
--- a/docs/mcp/spec.md
+++ b/docs/mcp/spec.md
@@ -162,6 +162,58 @@ Mutating tools are `worktree_start`, `worktree_ship`, and `sync`.
 - If a mutation is blocked by dirty state or conflicts, return a structured
   error and leave recovery to the caller.
 
+### Agent Workflow Contract
+
+Phase 9 fixes the expected ordering for clients that compose multiple tools
+into a larger coding workflow. These rules keep agent behavior predictable
+without adding client-specific state to the server.
+
+#### Startup Discovery
+
+Agents should call `tools/list` once after `initialize` and cache the returned
+tool metadata for the session. Before mutating repository state, agents should
+also call `worktree_list` or `worktree_status` so they can confirm the target
+ticket, branch, and base branch still match their plan.
+
+#### Create, Inspect, Ship
+
+The default happy path for a new ticket is:
+
+1. `worktree_start` with `dry_run: true` to preview the worktree path, branch,
+   and base commit.
+2. `worktree_start` with `dry_run: false` only after the preview matches the
+   intended ticket and base branch.
+3. `worktree_status` before making edits so the agent records the clean
+   starting state.
+4. Local editing and tests outside MCP.
+5. `health_check` with the target `ticket` before any PR operation.
+6. `worktree_ship` with `dry_run: true` to preview push, PR, and cleanup
+   effects.
+7. `worktree_ship` with `dry_run: false` when the preview is acceptable.
+
+Agents should prefer `smartlog`, `pr_status`, and `ci_status` for inspection
+between those steps instead of inferring branch state from free-form command
+output.
+
+#### Recovery Expectations
+
+Tool failures are resumable unless the error body says otherwise. Agents should
+not retry mutating tools blindly; they should inspect the latest state with
+`worktree_status` or `health_check`, update their plan, then issue a new
+`dry_run: true` preview before attempting the mutation again.
+
+If a client disconnects after sending a mutating request, it must treat the
+operation result as unknown. On reconnect, it should inspect state before
+issuing another mutation. Tools should make successful responses specific
+enough for this reconciliation, including ticket, branch, worktree path, PR
+number or URL, and whether cleanup ran.
+
+#### Idempotency Keys
+
+The v1.0 draft does not require a formal idempotency-key field. Future versions
+may add one, but until then clients should rely on `ticket` plus repository
+state inspection instead of replaying mutation calls.
+
 ---
 
 ## Design Principles


### PR DESCRIPTION
## 무엇
MCP spec에 에이전트가 여러 tool call을 조합할 때 따를 workflow contract를 추가합니다.

## 왜
Refs #292. v1.0 MCP tool spec이 개별 tool schema와 auth/error contract는 갖췄지만, create/inspect/ship 흐름에서 dry-run, state inspection, retry ordering을 명시하지 않아 클라이언트별 동작 차이가 생길 수 있습니다. @erishforG

## 변경
- startup discovery에서 initialize 이후 tools/list 캐시와 mutation 전 state inspection 규칙 추가
- worktree_start -> worktree_status -> health_check -> worktree_ship 순서의 happy path 정의
- mutating tool 실패/연결 종료 후 recovery expectation 추가
- v1.0 draft의 idempotency-key 비요구 방침과 ticket 기반 reconciliation 명시

## 다음 Phase 힌트
- tools/list 메타데이터에 workflow hint나 mutating/dry_run capability가 충분히 노출되는지 검토
- fixture에 create/inspect/ship 시퀀스 문서 예시를 추가

## 리스크
Low. docs/mcp/spec.md 문서-only 변경이며 CLI, transport, git/worktree 로직은 수정하지 않았습니다.

## 롤백
해당 문서 섹션을 revert하면 됩니다.

## Test plan
- cargo build --quiet
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --quiet