### PR TITLE
feat(mcp): Phase 15 — repository sandbox preflight

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -534,6 +534,18 @@ fn preflight_tool_call(
     arguments: &serde_json::Value,
     ctx: &McpContext,
 ) -> Option<serde_json::Value> {
+    if !repo_argument_is_within_boundary(arguments, &ctx.repo_path) {
+        return Some(tool_error_payload(
+            "SANDBOX_VIOLATION",
+            format!(
+                "Tool '{}' requested a repository outside the MCP session boundary.",
+                tool.name
+            ),
+            "Use the repository bound to this MCP server session.".to_owned(),
+            tool.name,
+        ));
+    }
+
     if tool.requires_github && ctx.github_token.is_none() {
         return Some(tool_error_payload(
             "AUTH_REQUIRED",
@@ -583,6 +595,27 @@ fn preflight_tool_call(
     }
 
     None
+}
+
+fn repo_argument_is_within_boundary(
+    arguments: &serde_json::Value,
+    boundary: &std::path::Path,
+) -> bool {
+    let Some(requested) = arguments.get("repo").and_then(serde_json::Value::as_str) else {
+        return true;
+    };
+
+    let requested = std::path::Path::new(requested);
+    let requested = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        boundary.join(requested)
+    };
+
+    match (boundary.canonicalize(), requested.canonicalize()) {
+        (Ok(boundary), Ok(requested)) => requested.starts_with(boundary),
+        _ => false,
+    }
 }
 
 fn requested_github_scopes(tool: &ToolDef, arguments: &serde_json::Value) -> Vec<GithubScope> {
@@ -1163,6 +1196,49 @@ mod tests {
                 .is_some_and(|text| !text.contains("INSUFFICIENT_SCOPE")),
             "write scope should satisfy pull request read preflight"
         );
+    }
+
+    #[test]
+    fn repository_argument_cannot_escape_session_boundary() {
+        let boundary = tempfile::tempdir().expect("temporary repository boundary");
+        let outside = tempfile::tempdir().expect("outside directory");
+        let ctx = McpContext {
+            repo_path: boundary.path().to_path_buf(),
+            github_token: None,
+            github_scopes: None,
+            dry_run: false,
+        };
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "sandbox",
+            "method": "tools/call",
+            "params": {
+                "name": "worktree_list",
+                "arguments": {"repo": outside.path()}
+            }
+        });
+
+        let response = dispatch_json_rpc_with_context(request, &ctx)
+            .expect("tools/call should produce a response");
+        let text = response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("MCP error envelope should contain text");
+
+        assert_eq!(response["result"]["isError"], true);
+        assert!(text.contains("SANDBOX_VIOLATION"));
+        assert!(!text.contains(&outside.path().display().to_string()));
+    }
+
+    #[test]
+    fn repository_argument_allows_descendant_of_session_boundary() {
+        let boundary = tempfile::tempdir().expect("temporary repository boundary");
+        let child = boundary.path().join("worktree");
+        std::fs::create_dir(&child).expect("child directory");
+
+        assert!(repo_argument_is_within_boundary(
+            &serde_json::json!({"repo": child}),
+            boundary.path(),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## 무엇\nMCP tools/call의 repo 인자를 dispatch 전에 canonicalize하고, 서버 세션 저장소 경계 밖 요청을 SANDBOX_VIOLATION으로 차단합니다.\n\n## 왜\n#294의 sandbox 계약 중 repository escape 방지를 실제 preflight에 적용합니다. v1.0 마일스톤의 MCP 전용 Phase이며 공유 CLI/worktree 코드는 변경하지 않습니다.\n\nRefs #294\n\n## 변경\n- 세션 repository boundary 검사 추가\n- 상대/절대 경로 canonicalization 및 descendant 허용\n- 외부 경로 거부 시 로컬 경로를 노출하지 않는 구조화 오류 반환\n- 경계 외부 거부/내부 descendant 허용 회귀 테스트 추가\n\n## 다음 Phase 힌트\nparsec-managed worktree 여부 검증 또는 mutating tool의 dry-run 정책 preflight를 별도 Phase로 추가할 수 있습니다.\n\n## 리스크\n낮음~중간. 변경은 src/mcp/ dispatch preflight에만 한정되며 존재하지 않는 명시적 repo 경로는 안전하게 거부됩니다.\n\n## 롤백\n이 PR의 단일 커밋을 revert하면 기존 dispatch 동작으로 복원됩니다.\n\n## Test plan\n- cargo build --quiet\n- cargo fmt --check\n- cargo clippy --all-targets -- -D warnings\n- cargo test --quiet\n\n@erishforG 검토 부탁드립니다.