### PR TITLE
feat(mcp): Phase 16 — explicit mutation confirmation

### DIFF
--- a/docs/mcp/auth.md
+++ b/docs/mcp/auth.md
@@ -104,6 +104,7 @@ Initial error codes:
 | `INSUFFICIENT_SCOPE` | Token was delegated but does not cover the requested operation |
 | `SANDBOX_VIOLATION` | Requested path is outside the resolved repository boundary |
 | `DRY_RUN_REQUIRED` | Server policy requires preview mode for a mutating call |
+| `CONFIRMATION_REQUIRED` | Mutating call omitted `confirm: true` after preview |
 
 ## Implementation Phases
 
@@ -113,5 +114,6 @@ Initial error codes:
 | Phase 2 | Add redacted credential helpers and scope metadata in `src/mcp/` |
 | Phase 3 | Validate required auth before GitHub-backed tool dispatch (implemented for `AUTH_REQUIRED`) |
 | Phase 4 | Add fixture scrubbing rules for MCP e2e recordings |
+| Phase 16 | Require explicit `confirm: true` for non-preview mutating calls |
 
 *Maintained by the git-parsec team. Auth changes require review by @erishforG.*

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -178,7 +178,7 @@ pub const TOOLS: &[ToolDef] = &[
     ToolDef {
         name: "worktree_start",
         description: "Create an isolated git worktree for a ticket.",
-        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"base":{"type":"string"},"title":{"type":"string"},"on":{"type":"string"},"dry_run":{"type":"boolean","default":false}},"required":["ticket"]}"#,
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"base":{"type":"string"},"title":{"type":"string"},"on":{"type":"string"},"dry_run":{"type":"boolean","default":false},"confirm":{"type":"boolean","default":false}},"required":["ticket"]}"#,
         mutating: true,
         requires_github: false,
         github_scopes: &[],
@@ -196,7 +196,7 @@ pub const TOOLS: &[ToolDef] = &[
         name: "worktree_ship",
         description:
             "Push the worktree branch to origin, create/update a GitHub PR, and optionally clean up.",
-        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"draft":{"type":"boolean","default":false},"no_cleanup":{"type":"boolean","default":false},"dry_run":{"type":"boolean","default":false}},"required":["ticket"]}"#,
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"draft":{"type":"boolean","default":false},"no_cleanup":{"type":"boolean","default":false},"dry_run":{"type":"boolean","default":false},"confirm":{"type":"boolean","default":false}},"required":["ticket"]}"#,
         mutating: true,
         requires_github: true,
         github_scopes: &[GithubScope::PullRequestWrite],
@@ -248,7 +248,7 @@ pub const TOOLS: &[ToolDef] = &[
     ToolDef {
         name: "sync",
         description: "Rebase or merge-update stale worktrees against the current base branch.",
-        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"strategy":{"type":"string","enum":["rebase","merge"],"default":"rebase"},"dry_run":{"type":"boolean","default":true},"stale_days":{"type":"integer","default":5}},"required":[]}"#,
+        input_schema: r#"{"type":"object","properties":{"ticket":{"type":"string"},"repo":{"type":"string"},"strategy":{"type":"string","enum":["rebase","merge"],"default":"rebase"},"dry_run":{"type":"boolean","default":true},"confirm":{"type":"boolean","default":false},"stale_days":{"type":"integer","default":5}},"required":[]}"#,
         mutating: true,
         requires_github: false,
         github_scopes: &[],
@@ -546,6 +546,16 @@ fn preflight_tool_call(
         ));
     }
 
+    let dry_run = argument_enabled(arguments, "dry_run") || ctx.dry_run;
+    if tool.mutating && !dry_run && !argument_enabled(arguments, "confirm") {
+        return Some(tool_error_payload(
+            "CONFIRMATION_REQUIRED",
+            format!("Tool '{}' requires explicit confirmation.", tool.name),
+            "Preview with dry_run=true, then retry with confirm=true.".to_owned(),
+            tool.name,
+        ));
+    }
+
     if tool.requires_github && ctx.github_token.is_none() {
         return Some(tool_error_payload(
             "AUTH_REQUIRED",
@@ -803,6 +813,43 @@ mod tests {
                 tool.name
             );
         }
+    }
+
+    #[test]
+    fn mutating_tools_expose_confirmation() {
+        for tool in TOOLS.iter().filter(|tool| tool.mutating) {
+            let schema: serde_json::Value =
+                serde_json::from_str(tool.input_schema).expect("valid tool schema");
+            assert_eq!(
+                schema.pointer("/properties/confirm/type"),
+                Some(&serde_json::json!("boolean")),
+                "Mutating tool '{}' must expose confirm",
+                tool.name
+            );
+        }
+    }
+
+    #[test]
+    fn mutation_requires_confirmation_after_preview() {
+        let ctx = McpContext::from_cwd(false).expect("context");
+        let tool = tool_by_name("worktree_start").expect("registered tool");
+
+        let error = preflight_tool_call(tool, &serde_json::json!({"ticket": "ABC-123"}), &ctx)
+            .expect("unconfirmed mutation should fail");
+        assert_eq!(error["error"]["code"], "CONFIRMATION_REQUIRED");
+
+        assert!(preflight_tool_call(
+            tool,
+            &serde_json::json!({"ticket": "ABC-123", "dry_run": true}),
+            &ctx
+        )
+        .is_none());
+        assert!(preflight_tool_call(
+            tool,
+            &serde_json::json!({"ticket": "ABC-123", "confirm": true}),
+            &ctx
+        )
+        .is_none());
     }
 
     #[test]


### PR DESCRIPTION
## 무엇

MCP mutating tools에 명시적 `confirm: true` preflight를 추가했습니다.

## 왜

#294의 destructive operation 확인 계약을 구현해 에이전트가 preview 없이 mutation을 실행하는 것을 차단합니다. v1.0 마일스톤 작업입니다. Refs #294.

## 변경

- 모든 mutating tool schema에 `confirm` boolean 추가
- non-preview mutation에 `CONFIRMATION_REQUIRED` 반환
- dry-run 및 명시 확인 허용 경로 테스트
- auth/sandbox 문서의 에러·Phase 계약 갱신

## 다음 Phase 힌트

민감값을 제외한 구조화 audit event sink를 설계하고 fixture로 검증합니다.

## 리스크

Medium. MCP 전용 preflight와 schema만 변경하며 기존 CLI·worktree 핵심 로직은 건드리지 않습니다.

## 롤백

이 PR을 revert하면 기존 dispatch 동작으로 복원됩니다.

## Test plan

- `cargo build --quiet`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`

@erishforG