### PR TITLE
feat(mcp): Phase 17 — privacy-safe audit events

### DIFF
--- a/docs/mcp/auth.md
+++ b/docs/mcp/auth.md
@@ -115,5 +115,11 @@ Initial error codes:
 | Phase 3 | Validate required auth before GitHub-backed tool dispatch (implemented for `AUTH_REQUIRED`) |
 | Phase 4 | Add fixture scrubbing rules for MCP e2e recordings |
 | Phase 16 | Require explicit `confirm: true` for non-preview mutating calls |
+| Phase 17 | Emit privacy-safe structured audit events to stderr for every tool call |
+
+Audit events contain only the event version, registered tool name, outcome,
+mutation classification, and dry-run state. They never contain arguments,
+repository paths, credentials, or error messages. JSON-RPC responses remain on
+stdout; operators may route stderr to their preferred audit sink.
 
 *Maintained by the git-parsec team. Auth changes require review by @erishforG.*

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -162,6 +162,43 @@ pub struct ToolDef {
     pub github_scopes: &'static [GithubScope],
 }
 
+/// Privacy-safe outcome recorded for an MCP tool call.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum AuditOutcome {
+    Allowed,
+    Denied,
+    ToolError,
+}
+
+impl AuditOutcome {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Allowed => "allowed",
+            Self::Denied => "denied",
+            Self::ToolError => "tool_error",
+        }
+    }
+}
+
+/// Build one structured event for the stderr audit sink.
+///
+/// Arguments, repository paths, credentials, and error messages are
+/// deliberately excluded so audit output cannot persist caller secrets.
+fn audit_event(tool: &ToolDef, outcome: AuditOutcome, dry_run: bool) -> serde_json::Value {
+    serde_json::json!({
+        "event": "mcp.tool_call",
+        "version": 1,
+        "tool": tool.name,
+        "outcome": outcome.as_str(),
+        "mutating": tool.mutating,
+        "dryRun": dry_run,
+    })
+}
+
+fn emit_audit_event(tool: &ToolDef, outcome: AuditOutcome, dry_run: bool) {
+    eprintln!("{}", audit_event(tool, outcome, dry_run));
+}
+
 /// All tools exposed by the parsec MCP server.
 ///
 /// This slice is the single source of truth for `tools/list` responses.
@@ -507,25 +544,34 @@ fn handle_tools_call(
         .cloned()
         .unwrap_or_else(|| serde_json::json!({}));
 
+    let dry_run = argument_enabled(&arguments, "dry_run") || ctx.dry_run;
+
     if let Some(error) = preflight_tool_call(tool, &arguments, ctx) {
+        emit_audit_event(tool, AuditOutcome::Denied, dry_run);
         return json_rpc_result(id, mcp_content_envelope(error, true));
     }
 
     match tools::dispatch(name, ctx, arguments) {
-        Ok(payload) => json_rpc_result(id, mcp_content_envelope(payload, false)),
-        Err(err) => json_rpc_result(
-            id,
-            mcp_content_envelope(
-                serde_json::json!({
-                    "error": {
-                        "code": "tool_error",
-                        "message": err.to_string(),
-                        "tool": name,
-                    }
-                }),
-                true,
-            ),
-        ),
+        Ok(payload) => {
+            emit_audit_event(tool, AuditOutcome::Allowed, dry_run);
+            json_rpc_result(id, mcp_content_envelope(payload, false))
+        }
+        Err(err) => {
+            emit_audit_event(tool, AuditOutcome::ToolError, dry_run);
+            json_rpc_result(
+                id,
+                mcp_content_envelope(
+                    serde_json::json!({
+                        "error": {
+                            "code": "tool_error",
+                            "message": err.to_string(),
+                            "tool": name,
+                        }
+                    }),
+                    true,
+                ),
+            )
+        }
     }
 }
 
@@ -722,6 +768,19 @@ mod tests {
     #[test]
     fn tools_list_is_non_empty() {
         assert!(!TOOLS.is_empty(), "TOOLS registry must not be empty");
+    }
+
+    #[test]
+    fn audit_event_contract_excludes_sensitive_call_data() {
+        let tool = tool_by_name("worktree_ship").expect("registered tool");
+        let event = audit_event(tool, AuditOutcome::Denied, false);
+        let serialized = event.to_string();
+
+        assert_eq!(event["tool"], "worktree_ship");
+        assert_eq!(event["outcome"], "denied");
+        for forbidden in ["token", "arguments", "repo_path", "message"] {
+            assert!(!serialized.contains(forbidden));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 무엇

MCP tool call마다 privacy-safe structured audit event를 stderr에 기록합니다.

## 왜

#294의 privacy/audit log AC를 진전시키면서 JSON-RPC stdout과 credential boundary를 보존합니다. v1.0 마일스톤 작업입니다. Refs #294.

## 변경

- allowed/denied/tool_error 결과의 versioned audit event 추가
- tool name, mutation classification, dry-run state만 기록
- arguments, repo path, credential, error message 비기록 계약 테스트
- auth 문서에 Phase 17 sink 계약 명시

## 다음 Phase 힌트

선택적 correlation ID와 운영 환경의 sink rotation/retention 계약을 설계합니다.

## 리스크

Medium. MCP 전용 dispatch observability와 문서만 변경하며 기존 CLI·worktree 핵심 로직은 건드리지 않습니다.

## 롤백

이 PR을 revert하면 audit stderr 출력 이전 동작으로 복원됩니다.

## Test plan

- `cargo build --quiet`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`

@erishforG