### PR TITLE
feat(mcp): Phase 18 — safe audit correlation IDs

### DIFF
--- a/docs/mcp/auth.md
+++ b/docs/mcp/auth.md
@@ -116,10 +116,16 @@ Initial error codes:
 | Phase 4 | Add fixture scrubbing rules for MCP e2e recordings |
 | Phase 16 | Require explicit `confirm: true` for non-preview mutating calls |
 | Phase 17 | Emit privacy-safe structured audit events to stderr for every tool call |
+| Phase 18 | Add optional privacy-safe correlation IDs for audit tracing |
 
 Audit events contain only the event version, registered tool name, outcome,
 mutation classification, and dry-run state. They never contain arguments,
 repository paths, credentials, or error messages. JSON-RPC responses remain on
 stdout; operators may route stderr to their preferred audit sink.
+
+For request tracing, an event may include `correlationId` copied from the
+JSON-RPC request ID. Numeric IDs are accepted. String IDs must be 1–64 ASCII
+letters, digits, hyphens, underscores, or dots; other strings and null IDs are
+omitted so caller-controlled text cannot become an audit-log secret.
 
 *Maintained by the git-parsec team. Auth changes require review by @erishforG.*

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -184,19 +184,49 @@ impl AuditOutcome {
 ///
 /// Arguments, repository paths, credentials, and error messages are
 /// deliberately excluded so audit output cannot persist caller secrets.
-fn audit_event(tool: &ToolDef, outcome: AuditOutcome, dry_run: bool) -> serde_json::Value {
-    serde_json::json!({
+fn audit_event(
+    tool: &ToolDef,
+    outcome: AuditOutcome,
+    dry_run: bool,
+    request_id: &serde_json::Value,
+) -> serde_json::Value {
+    let mut event = serde_json::json!({
         "event": "mcp.tool_call",
         "version": 1,
         "tool": tool.name,
         "outcome": outcome.as_str(),
         "mutating": tool.mutating,
         "dryRun": dry_run,
-    })
+    });
+    if let Some(correlation_id) = audit_correlation_id(request_id) {
+        event["correlationId"] = correlation_id;
+    }
+    event
 }
 
-fn emit_audit_event(tool: &ToolDef, outcome: AuditOutcome, dry_run: bool) {
-    eprintln!("{}", audit_event(tool, outcome, dry_run));
+fn audit_correlation_id(request_id: &serde_json::Value) -> Option<serde_json::Value> {
+    match request_id {
+        serde_json::Value::Number(_) => Some(request_id.clone()),
+        serde_json::Value::String(value)
+            if !value.is_empty()
+                && value.len() <= 64
+                && value.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || "-_.".contains(character)
+                }) =>
+        {
+            Some(request_id.clone())
+        }
+        _ => None,
+    }
+}
+
+fn emit_audit_event(
+    tool: &ToolDef,
+    outcome: AuditOutcome,
+    dry_run: bool,
+    request_id: &serde_json::Value,
+) {
+    eprintln!("{}", audit_event(tool, outcome, dry_run, request_id));
 }
 
 /// All tools exposed by the parsec MCP server.
@@ -547,17 +577,17 @@ fn handle_tools_call(
     let dry_run = argument_enabled(&arguments, "dry_run") || ctx.dry_run;
 
     if let Some(error) = preflight_tool_call(tool, &arguments, ctx) {
-        emit_audit_event(tool, AuditOutcome::Denied, dry_run);
+        emit_audit_event(tool, AuditOutcome::Denied, dry_run, &id);
         return json_rpc_result(id, mcp_content_envelope(error, true));
     }
 
     match tools::dispatch(name, ctx, arguments) {
         Ok(payload) => {
-            emit_audit_event(tool, AuditOutcome::Allowed, dry_run);
+            emit_audit_event(tool, AuditOutcome::Allowed, dry_run, &id);
             json_rpc_result(id, mcp_content_envelope(payload, false))
         }
         Err(err) => {
-            emit_audit_event(tool, AuditOutcome::ToolError, dry_run);
+            emit_audit_event(tool, AuditOutcome::ToolError, dry_run, &id);
             json_rpc_result(
                 id,
                 mcp_content_envelope(
@@ -773,14 +803,29 @@ mod tests {
     #[test]
     fn audit_event_contract_excludes_sensitive_call_data() {
         let tool = tool_by_name("worktree_ship").expect("registered tool");
-        let event = audit_event(tool, AuditOutcome::Denied, false);
+        let event = audit_event(
+            tool,
+            AuditOutcome::Denied,
+            false,
+            &serde_json::json!("call-42"),
+        );
         let serialized = event.to_string();
 
         assert_eq!(event["tool"], "worktree_ship");
         assert_eq!(event["outcome"], "denied");
+        assert_eq!(event["correlationId"], "call-42");
         for forbidden in ["token", "arguments", "repo_path", "message"] {
             assert!(!serialized.contains(forbidden));
         }
+    }
+
+    #[test]
+    fn audit_correlation_id_rejects_sensitive_or_oversized_strings() {
+        assert!(audit_correlation_id(&serde_json::json!(42)).is_some());
+        assert!(audit_correlation_id(&serde_json::json!("call_42.a")).is_some());
+        assert!(audit_correlation_id(&serde_json::json!("token secret")).is_none());
+        assert!(audit_correlation_id(&serde_json::json!("x".repeat(65))).is_none());
+        assert!(audit_correlation_id(&serde_json::Value::Null).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## 무엇

MCP audit event에 privacy-safe optional correlation ID를 추가합니다.

## 왜

#294의 privacy/audit log AC를 이어서 진전시키고, 민감한 caller text를 기록하지 않으면서 tool call 추적성을 제공합니다. v1.0 마일스톤 작업입니다. Refs #294.

## 변경

- JSON-RPC numeric request ID를 correlationId로 기록
- 문자열 ID는 1–64자의 ASCII 영숫자, 하이픈, 밑줄, 점 형식만 허용
- 민감하거나 과도하게 긴 문자열 및 null ID 생략 테스트
- auth 문서에 Phase 18 correlation 계약 명시

## 다음 Phase 힌트

운영 환경의 audit sink rotation/retention 계약과 sink failure 정책을 설계합니다.

## 리스크

Medium. MCP 전용 audit metadata와 문서만 변경하며 기존 CLI 및 worktree 핵심 로직은 건드리지 않습니다.

## 롤백

이 PR을 revert하면 Phase 17 audit event 필드 집합으로 복원됩니다.

## Test plan

- cargo build --quiet
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --quiet

@erishforG