### PR TITLE
docs(mcp): Phase 19 — audit sink operations

### DIFF
--- a/docs/mcp/auth.md
+++ b/docs/mcp/auth.md
@@ -117,6 +117,7 @@ Initial error codes:
 | Phase 16 | Require explicit `confirm: true` for non-preview mutating calls |
 | Phase 17 | Emit privacy-safe structured audit events to stderr for every tool call |
 | Phase 18 | Add optional privacy-safe correlation IDs for audit tracing |
+| Phase 19 | Define audit sink rotation, retention, and failure behavior |
 
 Audit events contain only the event version, registered tool name, outcome,
 mutation classification, and dry-run state. They never contain arguments,
@@ -127,5 +128,20 @@ For request tracing, an event may include `correlationId` copied from the
 JSON-RPC request ID. Numeric IDs are accepted. String IDs must be 1–64 ASCII
 letters, digits, hyphens, underscores, or dots; other strings and null IDs are
 omitted so caller-controlled text cannot become an audit-log secret.
+
+### Audit sink operations
+
+The server writes one newline-delimited JSON event to stderr and does not own
+the downstream sink. Deployments should rotate the captured stream by size or
+time, restrict it to the service identity, and retain it only as long as their
+incident-response policy requires. Correlation IDs are diagnostic metadata,
+not a reason to extend retention.
+
+Sink collection is best-effort: an unavailable or full collector must not
+change the JSON-RPC result or retry a tool call. Operators should monitor the
+collector independently and fail closed at the process-supervisor boundary if
+their policy requires guaranteed audit delivery. Raw stderr recordings must
+not be promoted into MCP fixtures; fixtures use the redaction contract in
+`tests/mcp/README.md`.
 
 *Maintained by the git-parsec team. Auth changes require review by @erishforG.*


### PR DESCRIPTION
## 무엇

MCP audit sink의 rotation, retention, failure 동작 계약을 문서화합니다.

## 왜

#294의 privacy/audit log AC를 운영 관점에서 진전시키고, sink 장애가 tool call을 중복 실행하거나 JSON-RPC 결과를 바꾸지 않도록 경계를 명확히 합니다. v1.0 마일스톤 작업입니다. Refs #294.

## 변경

- stderr NDJSON sink 소유권과 접근 제한 명시
- 크기/시간 기반 rotation 및 최소 retention 원칙 명시
- best-effort 수집과 독립 모니터링/fail-closed 경계 명시
- raw stderr의 fixture 유입 금지 명시

## 다음 Phase 힌트

구조화된 audit event schema versioning과 호환성 검증 fixture를 추가합니다.

## 리스크

Low. docs/mcp/ 문서만 변경하며 런타임, 기존 CLI, worktree 로직은 변경하지 않습니다.

## 롤백

이 PR을 revert하면 Phase 18 문서 상태로 복원됩니다.

## Test plan

- `cargo build --quiet`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`
- `git diff --check`

@erishforG