### PR TITLE
feat(mcp): Phase 20 — versioned audit schema fixture

### DIFF
--- a/docs/mcp/auth.md
+++ b/docs/mcp/auth.md
@@ -118,6 +118,7 @@ Initial error codes:
 | Phase 17 | Emit privacy-safe structured audit events to stderr for every tool call |
 | Phase 18 | Add optional privacy-safe correlation IDs for audit tracing |
 | Phase 19 | Define audit sink rotation, retention, and failure behavior |
+| Phase 20 | Pin the v1 audit-event schema with a compatibility fixture |
 
 Audit events contain only the event version, registered tool name, outcome,
 mutation classification, and dry-run state. They never contain arguments,
@@ -128,6 +129,11 @@ For request tracing, an event may include `correlationId` copied from the
 JSON-RPC request ID. Numeric IDs are accepted. String IDs must be 1–64 ASCII
 letters, digits, hyphens, underscores, or dots; other strings and null IDs are
 omitted so caller-controlled text cannot become an audit-log secret.
+
+The audit-event `version` identifies its schema. Additive fields may retain the
+same version; removing, renaming, or changing the meaning or type of a field
+requires a new version and a new compatibility fixture. The v1 fixture lives at
+`tests/mcp/fixtures/audit_event_v1.json` and is checked by the MCP unit tests.
 
 ### Audit sink operations
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -170,6 +170,9 @@ enum AuditOutcome {
     ToolError,
 }
 
+/// Schema version emitted with every structured audit event.
+const AUDIT_EVENT_VERSION: u64 = 1;
+
 impl AuditOutcome {
     const fn as_str(self) -> &'static str {
         match self {
@@ -192,7 +195,7 @@ fn audit_event(
 ) -> serde_json::Value {
     let mut event = serde_json::json!({
         "event": "mcp.tool_call",
-        "version": 1,
+        "version": AUDIT_EVENT_VERSION,
         "tool": tool.name,
         "outcome": outcome.as_str(),
         "mutating": tool.mutating,
@@ -817,6 +820,23 @@ mod tests {
         for forbidden in ["token", "arguments", "repo_path", "message"] {
             assert!(!serialized.contains(forbidden));
         }
+    }
+
+    #[test]
+    fn audit_event_matches_versioned_compatibility_fixture() {
+        let tool = tool_by_name("worktree_ship").expect("registered tool");
+        let actual = audit_event(
+            tool,
+            AuditOutcome::Denied,
+            false,
+            &serde_json::json!("call-42"),
+        );
+        let expected: serde_json::Value =
+            serde_json::from_str(include_str!("../../tests/mcp/fixtures/audit_event_v1.json"))
+                .expect("valid audit compatibility fixture");
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual["version"], AUDIT_EVENT_VERSION);
     }
 
     #[test]

--- a/tests/mcp/README.md
+++ b/tests/mcp/README.md
@@ -46,6 +46,10 @@ timestamps, or network-derived fields.
 For wired tool calls, assert stable envelope fields and schema keys instead of
 repository-specific counts, paths, branch names, or timestamps.
 
+Audit compatibility fixtures use `audit_event_v<version>.json`. They are exact
+schema snapshots rather than stdio recordings: breaking field changes require
+a new versioned file, while additive changes update the current fixture.
+
 ## Redaction Contract
 
 Recording fixtures are committed test inputs, so they must be safe to publish

--- a/tests/mcp/fixtures/audit_event_v1.json
+++ b/tests/mcp/fixtures/audit_event_v1.json
@@ -1,0 +1,9 @@
+{
+  "event": "mcp.tool_call",
+  "version": 1,
+  "tool": "worktree_ship",
+  "outcome": "denied",
+  "mutating": true,
+  "dryRun": false,
+  "correlationId": "call-42"
+}


### PR DESCRIPTION
## 무엇\n\nMCP audit event v1 schema를 상수와 exact compatibility fixture로 고정합니다.\n\n## 왜\n\n#294의 privacy-safe audit 계약이 후속 변경에서 조용히 깨지지 않도록 schema version과 직렬화 결과를 테스트로 연결합니다. v1.0 마일스톤 작업입니다. Refs #294.\n\n## 변경\n\n- audit schema version 상수화\n- v1 exact JSON compatibility fixture 추가\n- fixture 일치 unit test 추가\n- version bump 규칙 문서화\n\n## 다음 Phase 힌트\n\naudit sink output을 캡처하는 writer abstraction을 도입해 stderr emission을 직접 테스트합니다.\n\n## 리스크\n\nMedium. src/mcp/ audit event 생성부와 테스트만 변경하며 wire format은 기존과 동일합니다.\n\n## 롤백\n\n이 PR을 revert하면 Phase 19 상태로 복원됩니다.\n\n## Test plan\n\n- cargo build --quiet\n- cargo fmt --check\n- cargo clippy --all-targets -- -D warnings\n- cargo test --quiet\n- git diff --check\n\n@erishforG