### PR TITLE
feat(mcp): Phase 21 — testable audit writer

### DIFF
--- a/docs/mcp/auth.md
+++ b/docs/mcp/auth.md
@@ -119,6 +119,7 @@ Initial error codes:
 | Phase 18 | Add optional privacy-safe correlation IDs for audit tracing |
 | Phase 19 | Define audit sink rotation, retention, and failure behavior |
 | Phase 20 | Pin the v1 audit-event schema with a compatibility fixture |
+| Phase 21 | Route audit emission through a testable newline-delimited writer |
 
 Audit events contain only the event version, registered tool name, outcome,
 mutation classification, and dry-run state. They never contain arguments,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -229,7 +229,20 @@ fn emit_audit_event(
     dry_run: bool,
     request_id: &serde_json::Value,
 ) {
-    eprintln!("{}", audit_event(tool, outcome, dry_run, request_id));
+    let stderr = std::io::stderr();
+    let mut sink = stderr.lock();
+    // Audit failures must not change the JSON-RPC response or expose call data.
+    let _ = write_audit_event(&mut sink, tool, outcome, dry_run, request_id);
+}
+
+fn write_audit_event(
+    sink: &mut impl std::io::Write,
+    tool: &ToolDef,
+    outcome: AuditOutcome,
+    dry_run: bool,
+    request_id: &serde_json::Value,
+) -> std::io::Result<()> {
+    writeln!(sink, "{}", audit_event(tool, outcome, dry_run, request_id))
 }
 
 /// All tools exposed by the parsec MCP server.
@@ -837,6 +850,30 @@ mod tests {
 
         assert_eq!(actual, expected);
         assert_eq!(actual["version"], AUDIT_EVENT_VERSION);
+    }
+
+    #[test]
+    fn audit_writer_emits_one_newline_delimited_event() {
+        let tool = tool_by_name("worktree_ship").expect("registered tool");
+        let mut sink = Vec::new();
+
+        write_audit_event(
+            &mut sink,
+            tool,
+            AuditOutcome::Allowed,
+            true,
+            &serde_json::json!(42),
+        )
+        .expect("in-memory audit write");
+
+        let output = String::from_utf8(sink).expect("UTF-8 audit event");
+        assert_eq!(output.lines().count(), 1);
+        assert!(output.ends_with('\n'));
+        let event: serde_json::Value =
+            serde_json::from_str(output.trim_end()).expect("valid JSON audit event");
+        assert_eq!(event["outcome"], "allowed");
+        assert_eq!(event["dryRun"], true);
+        assert_eq!(event["correlationId"], 42);
     }
 
     #[test]


### PR DESCRIPTION
## 무엇

MCP audit emission을 `Write` 기반 helper로 분리하고 newline-delimited output을 직접 검증합니다.

## 왜

Phase 20에서 고정한 schema가 실제 sink emission에서도 한 줄 JSON으로 유지되는지 회귀 테스트가 필요합니다. v1.0 마일스톤 작업입니다. Refs #294.

## 변경

- stderr emission을 testable writer helper로 분리
- 한 줄 JSON 및 trailing newline 테스트 추가
- sink write failure가 JSON-RPC 응답을 바꾸지 않는 계약 유지
- auth phase 표 갱신

## 다음 Phase 힌트

실패하는 writer fixture로 best-effort sink failure 동작을 명시적으로 테스트합니다.

## 리스크

Medium. `src/mcp/` audit sink 내부와 문서만 변경하며 wire schema와 CLI surface는 동일합니다.

## 롤백

이 PR을 revert하면 직접 stderr emission으로 복원됩니다.

## Test plan

- cargo build --quiet
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --quiet
- git diff --check

@erishforG