### PR TITLE
test(mcp): Phase 22 — audit sink failure isolation

### DIFF
--- a/docs/mcp/auth.md
+++ b/docs/mcp/auth.md
@@ -120,6 +120,7 @@ Initial error codes:
 | Phase 19 | Define audit sink rotation, retention, and failure behavior |
 | Phase 20 | Pin the v1 audit-event schema with a compatibility fixture |
 | Phase 21 | Route audit emission through a testable newline-delimited writer |
+| Phase 22 | Verify audit sink failures remain best-effort and do not interrupt tool calls |
 
 Audit events contain only the event version, registered tool name, outcome,
 mutation classification, and dry-run state. They never contain arguments,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -231,8 +231,18 @@ fn emit_audit_event(
 ) {
     let stderr = std::io::stderr();
     let mut sink = stderr.lock();
+    emit_audit_event_to(&mut sink, tool, outcome, dry_run, request_id);
+}
+
+fn emit_audit_event_to(
+    sink: &mut impl std::io::Write,
+    tool: &ToolDef,
+    outcome: AuditOutcome,
+    dry_run: bool,
+    request_id: &serde_json::Value,
+) {
     // Audit failures must not change the JSON-RPC response or expose call data.
-    let _ = write_audit_event(&mut sink, tool, outcome, dry_run, request_id);
+    let _ = write_audit_event(sink, tool, outcome, dry_run, request_id);
 }
 
 fn write_audit_event(
@@ -811,6 +821,18 @@ fn mcp_content_envelope(payload: serde_json::Value, is_error: bool) -> serde_jso
 mod tests {
     use super::*;
 
+    struct FailingAuditSink;
+
+    impl std::io::Write for FailingAuditSink {
+        fn write(&mut self, _buffer: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("audit sink unavailable"))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn tools_list_is_non_empty() {
         assert!(!TOOLS.is_empty(), "TOOLS registry must not be empty");
@@ -874,6 +896,20 @@ mod tests {
         assert_eq!(event["outcome"], "allowed");
         assert_eq!(event["dryRun"], true);
         assert_eq!(event["correlationId"], 42);
+    }
+
+    #[test]
+    fn audit_sink_failure_is_best_effort() {
+        let tool = tool_by_name("worktree_ship").expect("registered tool");
+        let mut sink = FailingAuditSink;
+
+        emit_audit_event_to(
+            &mut sink,
+            tool,
+            AuditOutcome::Allowed,
+            false,
+            &serde_json::json!(42),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 무엇

MCP 감사 sink 쓰기 실패가 도구 호출을 중단하지 않는 best-effort 계약을 회귀 테스트로 고정합니다.

## 왜

Refs #294 · v1.0

감사 수집기 장애는 JSON-RPC 결과나 도구 실행을 바꾸면 안 된다는 Phase 19 운영 계약을 실행 가능한 테스트로 보강합니다. @erishforG

## 변경

- 감사 출력을 주입 가능한 내부 helper로 분리
- 실패하는 writer fixture로 오류 격리 회귀 테스트 추가
- auth 문서 Phase 22 기록

## 다음 Phase 힌트

감사 event의 호출 결과별 통합 coverage 또는 운영 sink 관측성 경계를 별도 소규모 Phase로 검토합니다.

## 리스크

낮음. MCP 전용 모듈의 내부 helper와 테스트/문서만 변경하며 CLI 및 wire schema는 불변입니다.

## 롤백

이 PR의 단일 커밋을 revert합니다.

## Test plan

- cargo build --quiet
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --quiet