### PR TITLE
feat(mcp): Phase 36 — mcp.toml config-file auth (token + scopes) · Refs #294

### DIFF
--- a/docs/mcp/auth.md
+++ b/docs/mcp/auth.md
@@ -122,6 +122,7 @@ Initial error codes:
 | Phase 21 | Route audit emission through a testable newline-delimited writer |
 | Phase 22 | Verify audit sink failures remain best-effort and do not interrupt tool calls |
 | Phase 35 | Read `PARSEC_GITHUB_TOKEN` env var in `serve_stdio` → `McpContext.github_token` (non-interactive host support) |
+| Phase 36 | `~/.config/parsec/mcp.toml` config-file support — `[auth]` token + optional scopes; env var wins; `PARSEC_MCP_CONFIG` overrides default path |
 
 Audit events contain only the event version, registered tool name, outcome,
 mutation classification, and dry-run state. They never contain arguments,
@@ -152,5 +153,35 @@ collector independently and fail closed at the process-supervisor boundary if
 their policy requires guaranteed audit delivery. Raw stderr recordings must
 not be promoted into MCP fixtures; fixtures use the redaction contract in
 `tests/mcp/README.md`.
+
+## Config-file Auth (Phase 36)
+
+For deployments where setting environment variables is inconvenient, token and
+scope metadata can be declared in a config file. The server reads (in order):
+
+1. `PARSEC_GITHUB_TOKEN` env var — if set and non-empty, used immediately;
+   config file is skipped entirely.
+2. `PARSEC_MCP_CONFIG` env var — if set, overrides the config-file path.
+3. `~/.config/parsec/mcp.toml` — default path on Linux/macOS;
+   `%APPDATA%\parsec\mcp.toml` on Windows.
+
+Config file format:
+
+```toml
+[auth]
+token = "ghp_your_token_here"
+# Optional: declare scopes so per-tool scope checks are enforced.
+# When omitted, all scopes are treated as available (same as env-var delegation).
+scopes = ["pull_request:read", "checks:read"]
+```
+
+Valid scope strings match the values in the Scope Matrix above:
+`"pull_request:read"`, `"checks:read"`, `"pull_request:write"`.
+Unrecognised scope strings are silently ignored so unknown future scopes do
+not break existing installations.
+
+The config file is read once at server startup; dynamic reload is not
+supported. Token values are never written to stdout, JSON-RPC responses,
+or audit events.
 
 *Maintained by the git-parsec team. Auth changes require review by @erishforG.*

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -38,6 +38,8 @@
 //! - All 10 tools wired.
 //! - **Phase 35** (#294): `PARSEC_GITHUB_TOKEN` env var read in `serve_stdio` → `McpContext.github_token`
 //!   (non-interactive host support; distinct from ambient `GITHUB_TOKEN`/`GH_TOKEN`).
+//! - **Phase 36** (#294): `~/.config/parsec/mcp.toml` config-file support — token + optional scopes;
+//!   env var wins over config file; `PARSEC_MCP_CONFIG` overrides default path.
 
 // All 10 tools are wired (Phase 31). The allow(dead_code) below covers
 // internal helpers (e.g. AuditOutcome variants) that are constructed only
@@ -71,6 +73,42 @@ impl GithubScope {
             Self::PullRequestWrite => "pull_request:write",
         }
     }
+
+    /// Parse a scope string produced by [`as_str`](Self::as_str).
+    /// Returns `None` for unrecognised strings so unknown scopes are ignored
+    /// rather than causing a hard failure when loading a config file.
+    fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "pull_request:read" => Some(Self::PullRequestRead),
+            "checks:read" => Some(Self::ChecksRead),
+            "pull_request:write" => Some(Self::PullRequestWrite),
+            _ => None,
+        }
+    }
+}
+
+/// TOML schema for `~/.config/parsec/mcp.toml` (or the path given by
+/// `PARSEC_MCP_CONFIG`). Unknown top-level keys are silently ignored.
+#[derive(Debug, serde::Deserialize, Default)]
+struct McpConfigFile {
+    auth: Option<McpConfigAuth>,
+}
+
+/// `[auth]` section of the MCP config file.
+#[derive(Debug, serde::Deserialize)]
+struct McpConfigAuth {
+    /// GitHub personal-access token to delegate to every tool call.
+    token: Option<String>,
+    /// Declared scope strings (e.g. `["pull_request:read", "checks:read"]`).
+    /// When present, scope checks are applied per-tool; when absent, all scopes
+    /// are assumed available (the same behaviour as env-var delegation).
+    scopes: Option<Vec<String>>,
+}
+
+/// Returns the default MCP config path (`~/.config/parsec/mcp.toml` on
+/// Linux/macOS; `%APPDATA%\parsec\mcp.toml` on Windows).
+fn default_mcp_config_path() -> Option<std::path::PathBuf> {
+    dirs::config_dir().map(|d| d.join("parsec").join("mcp.toml"))
 }
 
 /// Delegated GitHub token that redacts its secret in debug output.
@@ -140,23 +178,32 @@ impl McpContext {
     }
 
     /// Create a context from the current working directory, also reading
-    /// `PARSEC_GITHUB_TOKEN` from the environment if it is set and non-empty.
+    /// `PARSEC_GITHUB_TOKEN` from the environment **or** from the MCP config
+    /// file if it is set and non-empty.
+    ///
+    /// **Priority** (highest wins):
+    /// 1. `PARSEC_GITHUB_TOKEN` environment variable — token only, no declared scopes.
+    /// 2. Config file at `PARSEC_MCP_CONFIG` or `~/.config/parsec/mcp.toml` —
+    ///    token + optional `scopes` list.
     ///
     /// This is the entry point for `parsec mcp serve` on non-interactive hosts
     /// where the MCP client cannot forward a PAT inline (e.g., Claude Desktop,
-    /// Cursor, systemd service). The env var is treated as a pre-delegated
-    /// token with no declared scopes; scope checks still gate individual tools
-    /// at call time, but `AUTH_REQUIRED` is suppressed for token-bearing calls.
+    /// Cursor, systemd service).
     ///
     /// `PARSEC_GITHUB_TOKEN` is intentionally distinct from `GITHUB_TOKEN` /
     /// `GH_TOKEN` so this server is not implicitly activated by ambient CI
     /// tokens on workstations or CI runners.
     pub fn from_env(dry_run: bool) -> anyhow::Result<Self> {
-        Self::from_env_lookup(dry_run, |key| std::env::var(key).ok())
+        Self::from_env_and_config_lookup(
+            dry_run,
+            |key| std::env::var(key).ok(),
+            |path| std::fs::read_to_string(path).ok(),
+        )
     }
 
     /// Like [`from_env`] but accepts an env-lookup closure for unit testing
-    /// without mutating process-global state.
+    /// without mutating process-global state. Does **not** consult the config
+    /// file; use [`from_env_and_config_lookup`] when both paths are needed.
     fn from_env_lookup<F>(dry_run: bool, lookup: F) -> anyhow::Result<Self>
     where
         F: Fn(&str) -> Option<String>,
@@ -167,6 +214,62 @@ impl McpContext {
                 ctx = ctx.with_github_token(token);
             }
         }
+        Ok(ctx)
+    }
+
+    /// Full resolution with both env and config-file injection, using injectable
+    /// closures so tests never touch the real filesystem or process environment.
+    ///
+    /// - `env_lookup`: returns the value of an env var by name.
+    /// - `file_read`: returns the UTF-8 contents of a path, or `None` when the
+    ///   file does not exist or cannot be read.
+    fn from_env_and_config_lookup<E, R>(
+        dry_run: bool,
+        env_lookup: E,
+        file_read: R,
+    ) -> anyhow::Result<Self>
+    where
+        E: Fn(&str) -> Option<String>,
+        R: Fn(&std::path::Path) -> Option<String>,
+    {
+        let mut ctx = Self::from_cwd(dry_run)?;
+
+        // Priority 1: PARSEC_GITHUB_TOKEN env var (highest — no declared scopes).
+        if let Some(token) = env_lookup("PARSEC_GITHUB_TOKEN") {
+            if !token.is_empty() {
+                ctx = ctx.with_github_token(token);
+                return Ok(ctx); // env var wins; skip config file.
+            }
+        }
+
+        // Priority 2: config file (PARSEC_MCP_CONFIG override or default path).
+        let config_path = match env_lookup("PARSEC_MCP_CONFIG") {
+            Some(p) if !p.is_empty() => Some(std::path::PathBuf::from(p)),
+            _ => default_mcp_config_path(),
+        };
+
+        if let Some(path) = config_path {
+            if let Some(contents) = file_read(&path) {
+                if let Ok(config) = toml::from_str::<McpConfigFile>(&contents) {
+                    if let Some(auth) = config.auth {
+                        if let Some(token) = auth.token.filter(|t| !t.is_empty()) {
+                            let scopes: Vec<GithubScope> = auth
+                                .scopes
+                                .unwrap_or_default()
+                                .iter()
+                                .filter_map(|s| GithubScope::from_str_opt(s))
+                                .collect();
+                            if scopes.is_empty() {
+                                ctx = ctx.with_github_token(token);
+                            } else {
+                                ctx = ctx.with_github_auth(token, scopes);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         Ok(ctx)
     }
 
@@ -1230,6 +1333,151 @@ mod tests {
             ctx.github_token.is_none(),
             "empty env var should not populate token"
         );
+    }
+
+    // ------------------------------------------------------------------ //
+    // Phase 36: from_env_and_config_lookup tests
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn mcp_config_file_token_loaded_when_no_env_var() {
+        let toml_contents = "[auth]\ntoken = \"ghp_config_test\"\n";
+        let ctx = McpContext::from_env_and_config_lookup(
+            false,
+            |_| None, // no env vars set
+            |_| Some(toml_contents.to_owned()),
+        )
+        .expect("from_env_and_config_lookup");
+
+        assert!(
+            ctx.github_token.is_some(),
+            "token should be populated from config file"
+        );
+        assert_eq!(
+            ctx.github_token
+                .as_ref()
+                .map(DelegatedGithubToken::expose_secret),
+            Some("ghp_config_test")
+        );
+        // No declared scopes when the config omits the `scopes` key.
+        assert!(
+            ctx.github_scopes.is_none(),
+            "missing scopes key should leave github_scopes as None"
+        );
+    }
+
+    #[test]
+    fn mcp_config_file_token_with_scopes() {
+        let toml_contents =
+            "[auth]\ntoken = \"ghp_scoped\"\nscopes = [\"pull_request:read\", \"checks:read\"]\n";
+        let ctx = McpContext::from_env_and_config_lookup(
+            false,
+            |_| None,
+            |_| Some(toml_contents.to_owned()),
+        )
+        .expect("from_env_and_config_lookup with scopes");
+
+        let scopes = ctx
+            .github_scopes
+            .as_deref()
+            .expect("scopes should be populated");
+        assert!(scopes.contains(&GithubScope::PullRequestRead));
+        assert!(scopes.contains(&GithubScope::ChecksRead));
+        assert!(!scopes.contains(&GithubScope::PullRequestWrite));
+    }
+
+    #[test]
+    fn env_var_wins_over_config_file() {
+        // Env var must take priority; config file provides a different token.
+        let toml_contents = "[auth]\ntoken = \"ghp_from_config\"\n";
+        let ctx = McpContext::from_env_and_config_lookup(
+            false,
+            |key| {
+                if key == "PARSEC_GITHUB_TOKEN" {
+                    Some("ghp_from_env".to_owned())
+                } else {
+                    None
+                }
+            },
+            |_| Some(toml_contents.to_owned()),
+        )
+        .expect("env wins over config");
+
+        assert_eq!(
+            ctx.github_token
+                .as_ref()
+                .map(DelegatedGithubToken::expose_secret),
+            Some("ghp_from_env"),
+            "env var token must win over config-file token"
+        );
+    }
+
+    #[test]
+    fn parsec_mcp_config_overrides_default_path() {
+        // When PARSEC_MCP_CONFIG is set we should pass that exact path to
+        // the file reader; verify via path tracking.
+        use std::cell::Cell;
+        let custom_path = std::path::Path::new("/custom/path/mcp.toml");
+        let path_seen = Cell::new(false);
+
+        let _ctx = McpContext::from_env_and_config_lookup(
+            false,
+            |key| {
+                if key == "PARSEC_MCP_CONFIG" {
+                    Some("/custom/path/mcp.toml".to_owned())
+                } else {
+                    None
+                }
+            },
+            |path| {
+                if path == custom_path {
+                    path_seen.set(true);
+                }
+                None // file does not exist; that is fine
+            },
+        )
+        .expect("config path override");
+
+        assert!(
+            path_seen.get(),
+            "PARSEC_MCP_CONFIG should route file_read to the custom path"
+        );
+    }
+
+    #[test]
+    fn mcp_config_missing_file_leaves_token_none() {
+        // Simulates a fresh machine with no config file present.
+        let ctx = McpContext::from_env_and_config_lookup(
+            false,
+            |_| None,
+            |_| None, // file does not exist
+        )
+        .expect("missing config file is not an error");
+
+        assert!(
+            ctx.github_token.is_none(),
+            "missing config file should leave token as None"
+        );
+    }
+
+    #[test]
+    fn mcp_config_unknown_scopes_are_skipped() {
+        // Unknown scope strings must not panic and must be filtered out.
+        let toml_contents =
+            "[auth]\ntoken = \"ghp_scoped\"\nscopes = [\"unknown:future\", \"pull_request:read\"]\n";
+        let ctx = McpContext::from_env_and_config_lookup(
+            false,
+            |_| None,
+            |_| Some(toml_contents.to_owned()),
+        )
+        .expect("unknown scope is skipped");
+
+        let scopes = ctx
+            .github_scopes
+            .as_deref()
+            .expect("known scope should survive filtering");
+        assert_eq!(scopes.len(), 1);
+        assert!(scopes.contains(&GithubScope::PullRequestRead));
     }
 
     #[test]


### PR DESCRIPTION
## 무엇

`parsec mcp serve`가 `~/.config/parsec/mcp.toml` (또는 `PARSEC_MCP_CONFIG` env var 경로)에서 GitHub 토큰과 선택적 scope 메타데이터를 읽도록 함. 비대화형 호스트(Claude Desktop, Cursor, systemd 서비스)에서 환경변수 주입 없이도 GitHub-backed 도구가 동작 가능해짐.

## 왜

Refs #294 · Milestone: v1.0

Phase 35(PR #406)에서 예고한 Phase 36: *"config-file 경로 지원 (~/.config/parsec/mcp.toml 또는 PARSEC_MCP_CONFIG) — 토큰 + 스코프를 파일로 선언."*

이로써 issue #294 AC 항목 `PAT 위임 (env or config)`의 `config` 쪽이 완성됨.

## 변경

| 파일 | 내용 |
|---|---|
| `src/mcp/mod.rs` | `McpConfigFile` / `McpConfigAuth` TOML 구조체 · `GithubScope::from_str_opt()` (미인식 scope 무시) · `default_mcp_config_path()` (dirs::config_dir 기반) · `from_env_and_config_lookup<E,R>()` (클로저 주입 테스트 안전) · `from_env()` → 새 함수 사용 · 유닛 테스트 6개 |
| `docs/mcp/auth.md` | Phase 36 impl 표 항목 + Config-file Auth 섹션 (TOML 예시 + scope 문자열 목록) |

**우선순위 (highest → lowest)**:
1. `PARSEC_GITHUB_TOKEN` 환경변수 — 설정하면 즉시 사용, config 파일 건너뜀
2. `PARSEC_MCP_CONFIG` 환경변수로 경로 지정 또는 기본 `~/.config/parsec/mcp.toml`

**설계 포인트**: `from_env_and_config_lookup` 는 env-lookup 클로저와 file-read 클로저를 주입받아 병렬 테스트에서 프로세스 전역 상태를 건드리지 않음. 기존 `from_env_lookup` (env 전용, 기존 테스트 계속 사용) 시그니처는 변경 없음.

## 다음 Phase 힌트

Phase 37 (#294): scope 강제(enforcement) 통합 테스트 — config에서 scopes 선언 시 실제 도구 호출에서 scope gate 동작 검증(e2e).

## 리스크

low — `src/mcp/` 신규 구조체 + 메서드, `docs/` 업데이트만. 기존 CLI surface 불변. 신규 외부 의존성 없음 (기존 `toml`, `dirs` 크레이트 사용).

## 롤백

`from_env()`를 `from_env_lookup` 직접 호출로 되돌리기 + 신규 구조체/함수 제거.

## Test plan

```
cargo build --quiet       ✅
cargo fmt --check         ✅
cargo clippy -D warnings  ✅
cargo test --quiet        ✅ 293 tests all passed (201 unit + 6 new config tests + 81 + 6 e2e)
```

@erishforG