### PR TITLE
feat(smartlog): Phase 5 — PR merge readiness overlay · Refs #309

### DIFF
--- a/src/cli/commands/smartlog.rs
+++ b/src/cli/commands/smartlog.rs
@@ -34,6 +34,17 @@
 //!   grandparent → parent → child ordering is preserved.
 //! - Cycle-safe: a `placed` set ensures no group is emitted twice even if
 //!   worktree branches form unusual reference loops.
+//!
+//! Phase 5 (Issue #309 — PR merge readiness overlay):
+//! - `SmartlogPrOverlay::merge_ready: Option<bool>` surface the GitHub
+//!   `mergeable` field that `get_pr_status()` already fetches but previously
+//!   discarded before reaching the smartlog layer.
+//! - `format_pr_badge()` appends `⬆ ready` (green) or `⚡ conflicts` (red)
+//!   when the field is populated; open PRs with unknown mergeable state or
+//!   non-open PRs omit the segment so output stays compact.
+//! - Backward-compatible: `merge_ready` is `#[serde(skip_serializing_if =
+//!   "Option::is_none")]` so existing JSON consumers and golden fixtures keep
+//!   working.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::IsTerminal as _;
@@ -87,6 +98,14 @@ pub struct SmartlogPrOverlay {
     /// `approved` / `changes_requested` / `pending` / `no reviews`.
     pub review_status: String,
     pub url: String,
+    /// GitHub merge readiness — `Some(true)` when the PR can be merged
+    /// (no conflicts, all checks green per GitHub's internal verdict),
+    /// `Some(false)` when there are conflicts or blocking checks.
+    /// `None` when GitHub has not yet computed the state (e.g., immediately
+    /// after a push) or the PR is already merged/closed.
+    /// Skip-serialised when absent so existing JSON consumers see no change.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge_ready: Option<bool>,
 }
 
 /// Single commit in a worktree's diff against its base.
@@ -198,12 +217,20 @@ async fn fetch_overlay(client: &GitHubClient, branch: &str) -> Result<Option<Sma
         None => return Ok(None),
     };
     let status = client.get_pr_status(pr_num).await?;
+    // Populate merge_ready only for open PRs; merged/closed PRs don't have a
+    // meaningful "can be merged" state from GitHub's perspective.
+    let merge_ready = if status.state == "open" {
+        status.mergeable
+    } else {
+        None
+    };
     Ok(Some(SmartlogPrOverlay {
         number: status.number,
         state: status.state,
         ci_status: status.ci_status,
         review_status: status.review_status,
         url: status.url,
+        merge_ready,
     }))
 }
 
@@ -276,6 +303,18 @@ fn format_pr_badge(pr: &SmartlogPrOverlay, color: bool) -> String {
         // Strip the closing bracket, append review, re-close.
         out.pop();
         out.push_str(&format!(" {}]", r));
+    }
+    // Phase 5: merge readiness segment — only for open PRs.
+    if pr.state == "open" {
+        if let Some(ready) = pr.merge_ready {
+            let segment = if ready {
+                ansi_wrap(32, "⬆ ready", color) // green
+            } else {
+                ansi_wrap(31, "⚡ conflicts", color) // red
+            };
+            out.pop(); // remove ']'
+            out.push_str(&format!(" {}]", segment));
+        }
     }
     out
 }
@@ -613,6 +652,23 @@ mod tests {
             ci_status: ci.to_string(),
             review_status: review.to_string(),
             url: "https://github.com/erishforG/git-parsec/pull/42".to_string(),
+            merge_ready: None,
+        }
+    }
+
+    fn mk_overlay_with_readiness(
+        state: &str,
+        ci: &str,
+        review: &str,
+        merge_ready: Option<bool>,
+    ) -> SmartlogPrOverlay {
+        SmartlogPrOverlay {
+            number: 99,
+            state: state.to_string(),
+            ci_status: ci.to_string(),
+            review_status: review.to_string(),
+            url: "https://github.com/erishforG/git-parsec/pull/99".to_string(),
+            merge_ready,
         }
     }
 
@@ -859,5 +915,103 @@ mod tests {
         assert!(s.contains("main (base)") || s.contains("develop (base)"));
         assert!(s.contains("CL-A") && s.contains("CL-B"));
         assert!(s.contains("0 stacked"), "no stacks expected");
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 5 tests: merge readiness overlay (#309)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn merge_ready_true_appends_ready_segment() {
+        let overlay = mk_overlay_with_readiness("open", "success", "approved", Some(true));
+        let badge = format_pr_badge(&overlay, false);
+        assert!(
+            badge.contains("⬆ ready"),
+            "expected '⬆ ready' in badge but got: {}",
+            badge
+        );
+        assert!(
+            badge.ends_with("⬆ ready]"),
+            "ready segment should be last: {}",
+            badge
+        );
+    }
+
+    #[test]
+    fn merge_ready_false_appends_conflicts_segment() {
+        let overlay = mk_overlay_with_readiness("open", "success", "approved", Some(false));
+        let badge = format_pr_badge(&overlay, false);
+        assert!(
+            badge.contains("⚡ conflicts"),
+            "expected '⚡ conflicts' in badge but got: {}",
+            badge
+        );
+    }
+
+    #[test]
+    fn merge_ready_none_omits_readiness_segment() {
+        let overlay = mk_overlay_with_readiness("open", "success", "no reviews", None);
+        let badge = format_pr_badge(&overlay, false);
+        assert!(
+            !badge.contains("ready") && !badge.contains("conflicts"),
+            "unknown readiness should omit segment: {}",
+            badge
+        );
+    }
+
+    #[test]
+    fn merge_ready_skipped_for_merged_pr() {
+        // A merged PR with merge_ready=Some(true) should NOT show the segment
+        // because the PR is no longer open.
+        let overlay = mk_overlay_with_readiness("merged", "success", "approved", Some(true));
+        let badge = format_pr_badge(&overlay, false);
+        assert!(
+            !badge.contains("⬆ ready"),
+            "merged PR should not show ready segment: {}",
+            badge
+        );
+    }
+
+    #[test]
+    fn merge_ready_skipped_for_draft_pr() {
+        // Draft PRs are open but merge_ready is typically None from GitHub;
+        // even if Some(true) somehow arrives, verify the format is correct.
+        let overlay = mk_overlay_with_readiness("draft", "pending", "no reviews", Some(false));
+        let badge = format_pr_badge(&overlay, false);
+        // draft is rendered as state="draft"; open check uses pr.state == "open"
+        // so draft should NOT emit the readiness segment.
+        assert!(
+            !badge.contains("⚡ conflicts"),
+            "draft PR should not show conflicts segment: {}",
+            badge
+        );
+    }
+
+    #[test]
+    fn merge_ready_serde_roundtrip_omits_none() {
+        // When merge_ready is None, the serialised JSON must not contain
+        // the field (backward-compat for existing JSON consumers).
+        let overlay = mk_overlay("open", "pending", "no reviews");
+        assert!(overlay.merge_ready.is_none());
+        let json = serde_json::to_string(&overlay).expect("serialize");
+        assert!(
+            !json.contains("merge_ready"),
+            "merge_ready=None should be omitted from JSON, got: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn merge_ready_serde_roundtrip_present() {
+        // When merge_ready is Some, it must survive a JSON round-trip.
+        let overlay = mk_overlay_with_readiness("open", "success", "approved", Some(true));
+        let json = serde_json::to_string(&overlay).expect("serialize");
+        assert!(
+            json.contains("\"merge_ready\":true"),
+            "missing field: {}",
+            json
+        );
+        let back: SmartlogPrOverlay = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.merge_ready, Some(true));
     }
 }


### PR DESCRIPTION
## 무엇

`SmartlogPrOverlay`에 `merge_ready: Option<bool>` 필드를 추가해 GitHub의 병합 가능 여부를 smartlog 한 줄 뱃지에 표시한다.

| 변경 | 설명 |
|---|---|
| `merge_ready` 필드 추가 | `SmartlogPrOverlay`에 `Option<bool>`; `skip_serializing_if=None`으로 기존 JSON 호환 유지 |
| `fetch_overlay()` 수정 | `PrStatus::mergeable` (이미 API에서 가져오던 값)을 open PR에만 채워 전달 |
| `format_pr_badge()` 수정 | open PR에서 readiness 알 때만 뒤에 `⬆ ready` (green) / `⚡ conflicts` (red) 세그먼트 추가 |
| 7개 Phase 5 테스트 | ready/conflict 뱃지, None 생략, merged/draft 미표시, serde round-trip |
| `mk_overlay_with_readiness()` 헬퍼 | 기존 `mk_overlay()` 확장 (merge_ready=None 기본값 유지) |

뱃지 출력 예시:
```
[PR #42 ● open ✓ CI ✓ approved ⬆ ready]      # 머지 가능
[PR #42 ● open ✓ CI ✓ approved ⚡ conflicts]  # 충돌 있음
[PR #42 ● open ✓ CI ✓ approved]               # GitHub 아직 계산 중 (None)
```

## 왜 (이슈 참조)

Refs #309 — smartlog PR overlay merge readiness Phase 5.

`PrStatus.mergeable`은 이미 `get_pr_status()`가 GitHub API에서 가져오고 있었지만 `SmartlogPrOverlay`에 전달되지 않았음. worktree별 한 줄 뱃지를 보면서 충돌 여부를 즉시 파악하는 것이 #309의 핵심 value.

## 변경

- `src/cli/commands/smartlog.rs` 1파일, +154줄
  - `SmartlogPrOverlay::merge_ready` 필드
  - `fetch_overlay()`: open PR일 때만 `status.mergeable` 복사
  - `format_pr_badge()`: Phase 5 세그먼트 추가 (open 상태일 때만)
  - `mk_overlay_with_readiness()` 헬퍼
  - Phase 5 테스트 7개

## 다음 Phase 힌트

- #309 완전 구현을 위해 `review_decision` (REVIEW_REQUIRED vs APPROVED) 세분화 가능
- #310 (CI overlay per-check): `get_check_runs()`를 `SmartlogNode.ci` 에 채우는 Phase 1

## 리스크

low — 순수 additive 변경. `merge_ready=None`이 기본값이라 기존 동작 영향 0. GitHub API 호출 추가 없음 (이미 가져오는 값 활용). 뱃지 포맷 변경은 open PR에만, 뒤에 세그먼트 추가 방식.

## 롤백

`git revert 4db2d93` — 즉시 이전 상태 복원.

## Test plan

- `cargo test -- smartlog`: 36 tests pass (기존 29 + Phase 5 신규 7)
- `cargo build --quiet` + `cargo clippy -D warnings` + `cargo fmt --check`: all clean
- 기존 CLI integration tests (smartlog_json_empty_is_array 등): 5개 전부 통과

@erishforG