### PR TITLE
feat(smartlog): Phase 3 #310 — branch-tip CI overlay for PR-less nodes

### DIFF
--- a/src/cli/commands/smartlog.rs
+++ b/src/cli/commands/smartlog.rs
@@ -49,6 +49,14 @@
 //!   deserialization. `attach_ci_overlay` counts runs whose `status` is
 //!   `"in_progress"` or `"queued"` (i.e., started but not yet concluded).
 //!
+//! Phase 3 — #310 (CI overlay for PR-less branches): `attach_ci_overlay` now
+//!   also covers worktrees that have no open PR.  For each such node it
+//!   resolves the branch-tip SHA with `git rev-parse <branch>` and calls
+//!   `GitHubClient::get_check_runs_by_sha` to fetch check-run aggregate
+//!   directly, without a PR round-trip.  The resulting `SmartlogCiOverlay` is
+//!   attached exactly as for PR-linked nodes.  Network failures degrade
+//!   gracefully (CI badge omitted) without failing the command.
+//!
 //! Phase 5 (Issue #309 — PR merge readiness overlay):
 //! - `SmartlogPrOverlay::merge_ready: Option<bool>` surface the GitHub
 //!   `mergeable` field that `get_pr_status()` already fetches but previously
@@ -262,10 +270,7 @@ async fn attach_pr_overlay(repo: &Path, config: &ParsecConfig, nodes: &mut [Smar
 /// logged to stderr but never fail the parent command.  Nodes without a PR
 /// overlay are skipped silently.
 async fn attach_ci_overlay(repo: &Path, config: &ParsecConfig, nodes: &mut [SmartlogNode]) {
-    // Skip early if no node has a PR — avoids a gratuitous GitHub client init.
-    if nodes.iter().all(|n| n.pr.is_none()) {
-        return;
-    }
+    // Always init the client: Phase 3 (#310) needs it for PR-less nodes too.
     let remote_url = match git::run_output(repo, &["remote", "get-url", "origin"]) {
         Ok(url) => url.trim().to_string(),
         Err(_) => return,
@@ -276,11 +281,21 @@ async fn attach_ci_overlay(repo: &Path, config: &ParsecConfig, nodes: &mut [Smar
     };
 
     for node in nodes.iter_mut() {
-        let pr_num = match &node.pr {
-            Some(pr) => pr.number,
-            None => continue,
+        let ci_status_result = if let Some(pr) = &node.pr {
+            // PR-linked node: fetch check-runs via the existing PR-based lookup
+            // (which resolves the PR head SHA internally).
+            client.get_check_runs(pr.number).await
+        } else {
+            // Phase 3 (#310): PR-less branch — resolve branch-tip SHA with git
+            // and fetch check-runs directly.  Skip if git lookup fails (e.g.
+            // orphan branch or remote not synced).
+            match resolve_branch_tip_sha(repo, &node.branch) {
+                Some(sha) => client.get_check_runs_by_sha(&sha).await,
+                None => continue,
+            }
         };
-        match client.get_check_runs(pr_num).await {
+
+        match ci_status_result {
             Ok(ci_status) => {
                 let overall = map_ci_overall(&ci_status.overall);
                 let total = ci_status.checks.len();
@@ -314,6 +329,19 @@ async fn attach_ci_overlay(repo: &Path, config: &ParsecConfig, nodes: &mut [Smar
             }
         }
     }
+}
+
+/// Resolve a branch to its tip commit SHA using `git rev-parse`.
+///
+/// Returns the full 40-character SHA, or `None` when the branch cannot be
+/// resolved (e.g., unborn, orphan, or not yet pushed to remote).
+fn resolve_branch_tip_sha(repo: &Path, branch: &str) -> Option<String> {
+    let sha = git::run_output(repo, &["rev-parse", branch]).ok()?;
+    let sha = sha.trim().to_string();
+    if sha.is_empty() || sha.len() < 7 {
+        return None;
+    }
+    Some(sha)
 }
 
 /// Map the raw `CiStatus.overall` string from [`GitHubClient::get_check_runs`]
@@ -1307,5 +1335,56 @@ mod tests {
         assert_eq!(map_ci_overall("pending"), "running");
         assert_eq!(map_ci_overall("no checks"), "none");
         assert_eq!(map_ci_overall("unexpected"), "none");
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3 tests: branch-tip CI overlay for PR-less nodes (#310)
+    // -----------------------------------------------------------------------
+
+    /// A node whose CI field is set from a branch-tip lookup (no PR) should
+    /// render the CI badge identically to a PR-linked node.  This validates
+    /// that the `SmartlogCiOverlay` path is shared between both code paths.
+    #[test]
+    fn ci_badge_renders_same_for_pr_less_node() {
+        // Simulate a node that has no PR but got its CI overlay via SHA lookup.
+        let mut node = mk_node("CL-9", Some("I"), "feat/CL-9", vec![]);
+        assert!(node.pr.is_none(), "node must have no PR for this test");
+        node.ci = Some(mk_ci("passed", 4, 0));
+        let out = render_text(&[node], false);
+        assert!(
+            out.contains("[CI: ✓ passed (4/4)]"),
+            "PR-less node should render CI badge: {}",
+            out
+        );
+    }
+
+    /// A node with no PR and CI=none renders the `[CI: none]` badge so the
+    /// user can see that CI is present but no checks were found (e.g., a fresh
+    /// branch not yet linked to a CI pipeline).
+    #[test]
+    fn ci_badge_none_renders_for_pr_less_node() {
+        let mut node = mk_node("CL-10", Some("J"), "feat/CL-10", vec![]);
+        node.ci = Some(mk_ci("none", 0, 0));
+        let out = render_text(&[node], false);
+        assert!(
+            out.contains("[CI: none]"),
+            "PR-less node with no checks should render [CI: none]: {}",
+            out
+        );
+    }
+
+    /// `resolve_branch_tip_sha` must return `None` for obviously invalid inputs
+    /// without panicking (e.g., empty string from a malformed git command).
+    #[test]
+    fn resolve_branch_tip_sha_rejects_empty() {
+        use std::path::Path;
+        // A path that is definitely not a git repo will cause `git rev-parse`
+        // to fail, which should return None rather than panic.
+        let result = resolve_branch_tip_sha(Path::new("/tmp"), "non-existent-branch");
+        assert!(
+            result.is_none(),
+            "non-git-repo path should return None, got: {:?}",
+            result
+        );
     }
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -547,6 +547,56 @@ impl GitHubClient {
         })
     }
 
+    /// Fetch check runs directly for a commit SHA (no PR lookup).
+    ///
+    /// Used by `smartlog` Phase 3 of issue #310 to show CI status for
+    /// worktree branches that have no open PR yet.  The result is identical
+    /// in shape to [`get_check_runs`]; `pr_number` is set to 0 as a sentinel
+    /// (the caller uses the struct fields, not `pr_number`).
+    pub async fn get_check_runs_by_sha(&self, sha: &str) -> Result<CiStatus> {
+        let rp = self.repo_path();
+        let checks_resp: ApiCheckRunsResponse =
+            send_with_retry(self.get(&format!("{}/commits/{}/check-runs", rp, sha)))
+                .await?
+                .json()
+                .await?;
+
+        let checks: Vec<CheckRun> = checks_resp
+            .check_runs
+            .into_iter()
+            .map(|c| CheckRun {
+                name: c.name,
+                status: c.status,
+                conclusion: c.conclusion,
+                started_at: c.started_at,
+                completed_at: c.completed_at,
+                html_url: c.html_url,
+            })
+            .collect();
+
+        let overall = if checks.is_empty() {
+            "no checks".to_string()
+        } else if checks
+            .iter()
+            .any(|c| c.conclusion.as_deref() == Some("failure"))
+        {
+            "failing".to_string()
+        } else if checks.iter().all(|c| {
+            c.conclusion.as_deref() == Some("success") || c.conclusion.as_deref() == Some("skipped")
+        }) {
+            "passing".to_string()
+        } else {
+            "pending".to_string()
+        };
+
+        Ok(CiStatus {
+            pr_number: 0,
+            head_sha: sha.to_string(),
+            overall,
+            checks,
+        })
+    }
+
     /// Find an open PR by branch name.
     /// Returns the PR number if found.
     pub async fn find_pr_by_branch(&self, branch: &str) -> Result<Option<u64>> {


### PR DESCRIPTION
## 무엇

`attach_ci_overlay` 가 PR이 없는 SmartlogNode를 조용히 건너뛰던 문제를 수정합니다. 이 Phase는 issue #310 의 원래 요구사항을 완성합니다:

> 각 worktree branch tip 에 대해 GitHub check runs aggregate

## 왜 (Epic: Refs #310, Milestone: v1.0)

- Phase 1: `SmartlogCiOverlay` struct + `attach_ci_overlay` skeleton (PR #418)
- Phase 2: `running` 필드 + badge fix (PR #419)
- **Phase 3 (이 PR)**: PR 없는 branch에도 CI badge 표시

PR 없이 작업 중인 worktree(초기 branch, 실험적 spike 등)도 CI 상태를 한눈에 볼 수 있어야 합니다.

## 변경

### `src/github/mod.rs`
- `GitHubClient::get_check_runs_by_sha(sha: &str) -> Result<CiStatus>` 추가
  - PR 조회 없이 `/commits/{sha}/check-runs` 직접 호출
  - `pr_number: 0` sentinel (호출자는 집계 필드만 사용)
  - `get_check_runs`와 동일한 집계 로직 공유

### `src/cli/commands/smartlog.rs`
- `attach_ci_overlay`: 노드별 분기
  - PR 있는 노드 → 기존 `get_check_runs(pr.number)` 경로
  - PR 없는 노드 → `git rev-parse <branch>` 로 SHA 해결 후 `get_check_runs_by_sha` 호출
  - git 실패 시 해당 노드 CI 배지 생략 (graceful degradation)
- `resolve_branch_tip_sha(repo, branch) -> Option<String>` 추가
- Phase 3 모듈 doc comment
- 테스트 3개 추가

## 다음 Phase 힌트

Phase 4 후보:
- 짧은 TTL 캐시로 rate-limit 보호 (issue #310 scope에 언급)
- `parsec smartlog --no-overlay` 시 CI도 완전히 skip되는지 통합 테스트

## 리스크

- **low**: 기존 PR-linked 노드 동작 변경 없음. PR-less 노드는 git rev-parse 실패 시 CI 배지 생략 (이전과 동일). 새 GitHub API 호출은 기존 `get_check_runs`와 같은 엔드포인트.

## 롤백

`git revert e0033c3` — 두 파일만 변경, 메인 로직 불변.

## Test plan

- `cargo build --quiet` ✅
- `cargo fmt --check` ✅  
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --quiet`: 325 tests pass ✅
- 신규 테스트: `ci_badge_renders_same_for_pr_less_node`, `ci_badge_none_renders_for_pr_less_node`, `resolve_branch_tip_sha_rejects_empty`

@erishforG