### PR TITLE
feat(ship): --no-cleanup flag + wire auto_cleanup Phase 3 · Closes #313

### DIFF
--- a/src/cli/commands/ship.rs
+++ b/src/cli/commands/ship.rs
@@ -24,6 +24,7 @@ pub async fn ship(
     reviewers: Vec<String>,
     labels: Vec<String>,
     template: Option<String>,
+    no_cleanup: bool,
     mode: Mode,
 ) -> Result<()> {
     crate::execlog::set_ticket(ticket);
@@ -361,6 +362,22 @@ pub async fn ship(
             ErrorCode::E012,
             "Ship partial: branch pushed but PR/MR creation failed. Worktree preserved."
         );
+    }
+
+    // Phase 3: clean up worktree + local branch (respects config.ship.auto_cleanup).
+    // Skipped when --no-cleanup is passed, e.g. for incremental multi-commit workflows.
+    if !no_cleanup {
+        match manager.ship_cleanup(ticket) {
+            Ok(true) => {
+                if mode == output::Mode::Human {
+                    eprintln!("  Cleaned up worktree for '{}'.", ticket);
+                }
+            }
+            Ok(false) => {} // auto_cleanup=false in config — intentional no-op
+            Err(e) => {
+                eprintln!("warning: failed to clean up worktree after ship: {e}");
+            }
+        }
     }
 
     Ok(())

--- a/src/cli/commands/stack.rs
+++ b/src/cli/commands/stack.rs
@@ -229,6 +229,7 @@ pub async fn stack_submit(repo: &Path, mode: Mode) -> Result<()> {
             Vec::new(), // reviewers
             Vec::new(), // labels
             None,       // template
+            false,      // no_cleanup: use config default during stack ship
             mode,
         )
         .await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -148,6 +148,12 @@ pub enum Command {
         /// Path to PR body template file
         #[arg(long)]
         template: Option<String>,
+
+        /// Skip worktree removal after PR creation.
+        /// Overrides `ship.auto_cleanup = true` in config for this invocation.
+        /// Useful when making incremental commits to the same ticket across multiple ship calls.
+        #[arg(long)]
+        no_cleanup: bool,
     },
 
     /// Remove merged or stale worktrees
@@ -802,14 +808,16 @@ pub async fn run(cli: Cli) -> Result<()> {
             reviewer,
             label,
             template,
+            no_cleanup,
         } => {
             if cli.dry_run {
                 eprintln!(
-                    "[dry-run] Would ship ticket '{}' (draft: {}, no_pr: {}, base: {})",
+                    "[dry-run] Would ship ticket '{}' (draft: {}, no_pr: {}, base: {}, no_cleanup: {})",
                     ticket,
                     draft,
                     no_pr,
-                    base.as_deref().unwrap_or("auto")
+                    base.as_deref().unwrap_or("auto"),
+                    no_cleanup
                 );
                 return Ok(());
             }
@@ -824,6 +832,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 reviewer,
                 label,
                 template,
+                no_cleanup,
                 output_mode,
             )
             .await

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -940,6 +940,117 @@ fn test_ship_dry_run() {
         .stdout(predicate::str::contains("DRY-SHIP"));
 }
 
+#[test]
+fn test_ship_no_cleanup_preserves_worktree() {
+    let (repo, _bare) = setup_repo_with_remote();
+    let repo_path = repo.path().to_str().unwrap();
+
+    parsec()
+        .args(["start", "NC-SHIP", "--repo", repo_path])
+        .assert()
+        .success();
+
+    // Read worktree path from state.
+    let state_path = repo.path().join(".parsec").join("state.json");
+    let state_contents = std::fs::read_to_string(&state_path).unwrap();
+    let state: serde_json::Value = serde_json::from_str(&state_contents).unwrap();
+    let wt_path = state["workspaces"]["NC-SHIP"]["path"]
+        .as_str()
+        .expect("state.json should contain path for NC-SHIP")
+        .to_owned();
+
+    // Commit something so git push has content to send.
+    std::fs::write(format!("{}/nc.txt", wt_path), "no-cleanup test").unwrap();
+    StdCommand::new("git")
+        .args(["add", "nc.txt"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+    StdCommand::new("git")
+        .args(["commit", "-m", "nc commit"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+
+    // ship --no-pr --no-cleanup: push branch, skip PR creation, skip worktree removal.
+    parsec()
+        .args([
+            "ship",
+            "NC-SHIP",
+            "--no-pr",
+            "--no-cleanup",
+            "--repo",
+            repo_path,
+        ])
+        .assert()
+        .success();
+
+    // Worktree must still be listed despite auto_cleanup=true default.
+    parsec()
+        .args(["list", "--repo", repo_path])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("NC-SHIP"));
+
+    // Worktree directory must physically exist.
+    assert!(
+        std::path::Path::new(&wt_path).exists(),
+        "worktree directory should still exist after --no-cleanup ship"
+    );
+}
+
+#[test]
+fn test_ship_auto_cleanup_removes_worktree() {
+    let (repo, _bare) = setup_repo_with_remote();
+    let repo_path = repo.path().to_str().unwrap();
+
+    parsec()
+        .args(["start", "AC-SHIP", "--repo", repo_path])
+        .assert()
+        .success();
+
+    // Read worktree path from state.
+    let state_path = repo.path().join(".parsec").join("state.json");
+    let state_contents = std::fs::read_to_string(&state_path).unwrap();
+    let state: serde_json::Value = serde_json::from_str(&state_contents).unwrap();
+    let wt_path = state["workspaces"]["AC-SHIP"]["path"]
+        .as_str()
+        .expect("state.json should contain path for AC-SHIP")
+        .to_owned();
+
+    // Commit something so git push has content to send.
+    std::fs::write(format!("{}/ac.txt", wt_path), "auto-cleanup test").unwrap();
+    StdCommand::new("git")
+        .args(["add", "ac.txt"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+    StdCommand::new("git")
+        .args(["commit", "-m", "ac commit"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+
+    // ship --no-pr without --no-cleanup: auto_cleanup=true (default) should remove the worktree.
+    parsec()
+        .args(["ship", "AC-SHIP", "--no-pr", "--repo", repo_path])
+        .assert()
+        .success();
+
+    // Worktree must no longer be listed.
+    parsec()
+        .args(["list", "--repo", repo_path])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("AC-SHIP").not());
+
+    // Worktree directory must be physically gone.
+    assert!(
+        !std::path::Path::new(&wt_path).exists(),
+        "worktree directory should be removed after auto_cleanup ship"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // doctor
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 무엇

`parsec ship`에 `--no-cleanup` 플래그를 추가하고, 오랫동안 호출되지 않았던 `ship_cleanup()` Phase 3를 ship 커맨드 핸들러에 연결합니다.

**문제 1 (이슈 #313)**: 점진적 마이그레이션 작업(동일 ticket에 여러 번 commit + ship)을 할 때 `parsec ship`이 worktree를 제거해 불편함.

**문제 2 (코드 갭)**: `WorktreeManager::ship_cleanup()`이 존재하지만 `commands/ship.rs` 핸들러에서 호출되지 않음. 리팩토링 과정에서 Phase 3 연결이 누락됨 (`manager.ship()`은 `#[allow(dead_code)]`로만 남아있었음).

## 왜

`config.ship.auto_cleanup = true` (기본값)이고 CLI help도 "removes the worktree"라고 명시하지만, 실제 ship 커맨드는 worktree를 제거하지 않는 불일치 상태였음. 이 PR이 두 문제를 동시에 해결합니다.

## 변경

| 파일 | 변경 내용 |
|---|---|
| `src/cli/mod.rs` | `Command::Ship`에 `--no-cleanup` 플래그 추가, dispatch + dry-run 메시지 업데이트 |
| `src/cli/commands/ship.rs` | `no_cleanup: bool` 파라미터 추가; Phase 3 블록: `!no_cleanup`이면 `manager.ship_cleanup()` 호출 (config.ship.auto_cleanup 여전히 존중) |
| `src/cli/commands/stack.rs` | 업데이트된 시그니처에 `no_cleanup = false` 전달 (stack ship은 config 기본값 사용) |
| `tests/cli_tests.rs` | 2개 통합 테스트: `test_ship_no_cleanup_preserves_worktree`, `test_ship_auto_cleanup_removes_worktree` |

## 사용법

```bash
# 기존 동작 (변경 없음) — auto_cleanup=true면 worktree 제거
parsec ship CL-2428

# 새 플래그 — worktree 유지 (점진적 커밋 워크플로우)
parsec ship CL-2428 --no-cleanup   # push + PR, worktree 보존
# ... 추가 작업 후 ...
parsec ship CL-2428 --no-cleanup   # 또 push (PR 업데이트)
# ... 완료 후 ...
parsec ship CL-2428                # 마지막 ship, worktree 제거
```

## 다음 Phase 힌트

- `parsec merge --no-cleanup` 도 동일하게 추가 가능 (#313 관련 UX 통일)
- stack ship 에서도 마지막 ticket만 cleanup 하고 나머지는 no-cleanup 하는 전략 가능

## 리스크

기존에 ship이 cleanup을 하지 않던 상태 → 이제 auto_cleanup=true 시 ship이 worktree를 제거함. 이는 원래 의도된 동작이지만, `--no-cleanup` escape hatch로 기존 수동 워크플로우 보호.

## 롤백

`git revert <commit>` 또는 config에서 `ship.auto_cleanup = false` 설정.

## Test plan

- `cargo build` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo test` 173 tests pass ✅
- `test_ship_no_cleanup_preserves_worktree`: --no-cleanup 시 worktree 디렉토리 물리적으로 유지 확인
- `test_ship_auto_cleanup_removes_worktree`: auto_cleanup 시 worktree 제거 확인

Closes #313
@erishforG
