### PR TITLE
feat(ship): Phase 1 template variable substitution · Refs #304

### DIFF
--- a/src/cli/commands/ship.rs
+++ b/src/cli/commands/ship.rs
@@ -172,6 +172,7 @@ pub async fn ship(
 
         let pr_body = build_pr_body(
             &result.ticket,
+            &result.branch,
             effective_title,
             ticket_url.as_deref(),
             stack_info.as_ref(),
@@ -421,8 +422,33 @@ fn gather_stack_info(manager: &WorktreeManager, ticket: &str) -> Option<StackPrI
     })
 }
 
+/// Substitute `{{variable}}` placeholders in a PR template string.
+///
+/// Supported variables:
+/// - `{{ticket}}` → the ticket / workspace ID (e.g. `CL-1234`)
+/// - `{{branch}}` → the git branch name pushed for this ticket
+/// - `{{title}}` → PR title; empty string when not available
+/// - `{{ticket_url}}` → tracker URL; empty string when not available
+///
+/// Unknown `{{…}}` tokens are left as-is so templates using other tooling
+/// variables are not silently mangled.
+fn substitute_template_vars(
+    template: &str,
+    ticket: &str,
+    branch: &str,
+    title: Option<&str>,
+    ticket_url: Option<&str>,
+) -> String {
+    template
+        .replace("{{ticket}}", ticket)
+        .replace("{{branch}}", branch)
+        .replace("{{title}}", title.unwrap_or(""))
+        .replace("{{ticket_url}}", ticket_url.unwrap_or(""))
+}
+
 fn build_pr_body(
     ticket: &str,
+    branch: &str,
     title: Option<&str>,
     ticket_url: Option<&str>,
     stack_info: Option<&StackPrInfo>,
@@ -461,10 +487,11 @@ fn build_pr_body(
         body.push('\n');
     }
 
-    // Include PR template content (#233)
+    // Include PR template content (#233 #304) with variable substitution.
     if let Some(tmpl) = template_content {
+        let rendered = substitute_template_vars(tmpl, ticket, branch, title, ticket_url);
         body.push_str("---\n\n");
-        body.push_str(tmpl);
+        body.push_str(&rendered);
         body.push('\n');
     }
 
@@ -503,4 +530,61 @@ fn resolve_template(repo_root: &Path, explicit_path: Option<&str>) -> Option<Str
     }
 
     None
+}
+
+#[cfg(test)]
+mod template_var_tests {
+    use super::*;
+
+    #[test]
+    fn test_substitute_all_vars() {
+        let tmpl = "Ticket: {{ticket}}\nBranch: {{branch}}\nTitle: {{title}}\nURL: {{ticket_url}}";
+        let result = substitute_template_vars(
+            tmpl,
+            "CL-42",
+            "feature/CL-42",
+            Some("My PR"),
+            Some("https://example.com/CL-42"),
+        );
+        assert_eq!(
+            result,
+            "Ticket: CL-42\nBranch: feature/CL-42\nTitle: My PR\nURL: https://example.com/CL-42"
+        );
+    }
+
+    #[test]
+    fn test_substitute_missing_optional_vars_become_empty() {
+        let tmpl = "Ticket: {{ticket}}\nTitle: {{title}}\nURL: {{ticket_url}}";
+        let result = substitute_template_vars(tmpl, "CL-99", "feature/CL-99", None, None);
+        assert_eq!(result, "Ticket: CL-99\nTitle: \nURL: ");
+    }
+
+    #[test]
+    fn test_substitute_unknown_placeholder_left_intact() {
+        let tmpl = "{{ticket}} — {{unknown_var}} — {{branch}}";
+        let result = substitute_template_vars(tmpl, "T-1", "feat/T-1", None, None);
+        assert_eq!(result, "T-1 — {{unknown_var}} — feat/T-1");
+    }
+
+    #[test]
+    fn test_substitute_multiple_occurrences() {
+        let tmpl = "{{ticket}} ({{ticket}}) on {{branch}}";
+        let result = substitute_template_vars(tmpl, "AB-7", "feat/AB-7", None, None);
+        assert_eq!(result, "AB-7 (AB-7) on feat/AB-7");
+    }
+
+    #[test]
+    fn test_build_pr_body_renders_template_vars() {
+        let tmpl = "Refs {{ticket}} on `{{branch}}`";
+        let body = build_pr_body(
+            "T-5",
+            "feat/T-5",
+            Some("Nice title"),
+            None,
+            None,
+            Some(tmpl),
+        );
+        assert!(body.contains("Refs T-5 on `feat/T-5`"), "body: {body}");
+        assert!(body.contains("## Nice title"), "body: {body}");
+    }
 }


### PR DESCRIPTION
## 무엇

`parsec ship`의 PR template에 `{{ticket}}`, `{{branch}}`, `{{title}}`, `{{ticket_url}}` 변수 치환 기능을 추가합니다 (#304 Phase 1).

기존에는 `.github/PULL_REQUEST_TEMPLATE.md` 를 탐지해 읽어오는 것까지는 구현되어 있었지만, 파일 내용이 변수 치환 없이 verbatim으로 삽입됐습니다. 이 PR로 template 내 `{{…}}` placeholder가 ship 컨텍스트 값으로 치환됩니다.

## 왜

이슈 #304의 AC 중 "template 변수 (commits, branch) 자동 치환"이 미구현 상태였음. 사용자가 `.github/PULL_REQUEST_TEMPLATE.md`에 `{{ticket}}`이나 `{{branch}}`를 써도 그대로 출력되어 실용성이 낮았음.

Refs #304

## 변경

| 파일 | 변경 내용 |
|---|---|
| `src/cli/commands/ship.rs` | `substitute_template_vars()` 신규 함수 + `build_pr_body()`에 `branch` 파라미터 추가 + template 치환 로직 + 5 unit tests |

### 지원 변수

| 변수 | 치환 값 |
|---|---|
| `{{ticket}}` | ticket/workspace ID (예: `CL-1234`) |
| `{{branch}}` | push된 git branch 이름 |
| `{{title}}` | PR 제목 (없으면 빈 문자열) |
| `{{ticket_url}}` | tracker URL (없으면 빈 문자열) |

미지원 `{{…}}` 토큰은 그대로 유지 (다른 tooling 변수 보호).

### 예시 template

```markdown
## {{title}}

Ticket: [{{ticket}}]({{ticket_url}})
Branch: `{{branch}}`
```

ship 실행 후:

```markdown
## feat: my change

Ticket: [CL-42](https://linear.app/CL-42)
Branch: `feature/CL-42`
```

## 다음 Phase 힌트

- Phase 2: `{{commits}}` 변수 — git log 요약 자동 삽입
- Phase 3: `--template` 명시 옵션 +  config에 default template 경로 설정
- Phase 4: AI PR description (#275)과 template 호환 확인

## 리스크

low — 새 private helper 함수 추가 + `build_pr_body()` 내부 시그니처 변경만. 외부 CLI 인터페이스 불변. template 미사용 시 동작 동일.

## 롤백

`git revert` 또는 `--template` 없이 사용하면 기존과 동일 동작.

## Test plan

- `cargo build` ✅
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` 178 tests pass ✅ (90 + 5 unit + 83 integration)
- 5 신규 unit tests: all-vars, optional-vars-empty, unknown-var-intact, multi-occurrence, build_pr_body end-to-end

@erishforG