### PR TITLE
feat(self-update): Phase 1 — version check + upgrade notification · Refs #296

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod smartlog;
 mod stack;
 mod test;
 mod tracker_cmds;
+mod update;
 mod workspace;
 
 pub use ci::*;
@@ -34,4 +35,5 @@ pub use smartlog::smartlog;
 pub use stack::*;
 pub use test::test;
 pub use tracker_cmds::*;
+pub use update::self_update;
 pub use workspace::*;

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -1,0 +1,165 @@
+//! `parsec self-update` — check for a newer release and print upgrade instructions.
+//!
+//! # Phase 1 (this module)
+//! Compares the running version against the latest GitHub release and prints
+//! an upgrade command when a newer version is available.  No binary download
+//! or in-place replacement is performed; that is deferred to Phase 2.
+
+use anyhow::Result;
+use serde::Deserialize;
+
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const GITHUB_REPO: &str = "erishforG/git-parsec";
+/// HTTP timeout for the GitHub releases API call (seconds).
+const CHECK_TIMEOUT_SECS: u64 = 8;
+
+#[derive(Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    html_url: String,
+    body: Option<String>,
+}
+
+/// Compare two semver strings of the form `"X.Y.Z"` or `"vX.Y.Z"`.
+///
+/// Each component is compared numerically so `"0.10.0"` sorts after `"0.9.0"`,
+/// unlike a plain lexicographic comparison.
+fn cmp_semver(a: &str, b: &str) -> std::cmp::Ordering {
+    let parse = |s: &str| -> (u64, u64, u64) {
+        let s = s.trim_start_matches('v');
+        let mut it = s.splitn(3, '.').map(|p| p.parse::<u64>().unwrap_or(0));
+        (
+            it.next().unwrap_or(0),
+            it.next().unwrap_or(0),
+            it.next().unwrap_or(0),
+        )
+    };
+    parse(a).cmp(&parse(b))
+}
+
+/// Fetch the latest release metadata from the GitHub releases API.
+async fn fetch_latest_release() -> anyhow::Result<GitHubRelease> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(CHECK_TIMEOUT_SECS))
+        .user_agent(format!("parsec/{CURRENT_VERSION}"))
+        .build()?;
+    let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
+    let release = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<GitHubRelease>()
+        .await?;
+    Ok(release)
+}
+
+/// `parsec self-update` entry point.
+///
+/// When `offline` is `true` (either `--offline` flag or config), the network
+/// call is skipped and only the current version is printed.
+pub async fn self_update(offline: bool) -> Result<()> {
+    let current = CURRENT_VERSION;
+
+    if offline {
+        println!("parsec {current}");
+        println!("note: version check skipped (--offline)");
+        return Ok(());
+    }
+
+    use std::io::Write as _;
+    print!("parsec {current}  →  checking for updates… ");
+    let _ = std::io::stdout().flush();
+
+    match fetch_latest_release().await {
+        Err(e) => {
+            println!("(network unavailable: {e:#})");
+            println!("Current version: parsec {current}");
+            println!("See https://github.com/{GITHUB_REPO}/releases for the latest release.");
+        }
+        Ok(release) => {
+            let latest_tag = &release.tag_name;
+            let latest = latest_tag.trim_start_matches('v');
+            match cmp_semver(latest, current) {
+                std::cmp::Ordering::Greater => {
+                    println!("update available!\n");
+                    println!("  {current}  →  {latest}");
+                    println!("  {}", release.html_url);
+                    // Show a brief excerpt of the release notes (up to 4 lines).
+                    if let Some(notes) = &release.body {
+                        let preview: String = notes.lines().take(4).collect::<Vec<_>>().join("\n");
+                        if !preview.trim().is_empty() {
+                            println!("\n  Release notes (preview):");
+                            for line in preview.lines() {
+                                println!("    {line}");
+                            }
+                        }
+                    }
+                    println!("\nTo upgrade:");
+                    println!(
+                        "  cargo install --git https://github.com/{GITHUB_REPO} \
+                         --bin parsec --force"
+                    );
+                    println!(
+                        "\nnote: automated binary replacement is planned for Phase 2 \
+                         (see issue #296)."
+                    );
+                }
+                std::cmp::Ordering::Equal => {
+                    println!("✓  already up to date ({current})");
+                }
+                std::cmp::Ordering::Less => {
+                    // The user is running a dev build ahead of the published release.
+                    println!(
+                        "✓  {latest} is the latest published release \
+                         (you are ahead — development build)"
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cmp_semver;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn newer_patch() {
+        assert_eq!(cmp_semver("0.5.1", "0.5.0"), Ordering::Greater);
+    }
+
+    #[test]
+    fn newer_minor_double_digit() {
+        // Numeric comparison: "0.10.0" > "0.9.0"; lexicographic would fail.
+        assert_eq!(cmp_semver("0.10.0", "0.9.0"), Ordering::Greater);
+    }
+
+    #[test]
+    fn newer_major() {
+        assert_eq!(cmp_semver("1.0.0", "0.5.0"), Ordering::Greater);
+    }
+
+    #[test]
+    fn equal_plain() {
+        assert_eq!(cmp_semver("0.5.0", "0.5.0"), Ordering::Equal);
+    }
+
+    #[test]
+    fn v_prefix_stripped() {
+        assert_eq!(cmp_semver("v1.2.3", "1.2.3"), Ordering::Equal);
+        assert_eq!(cmp_semver("v2.0.0", "v1.9.9"), Ordering::Greater);
+    }
+
+    #[test]
+    fn older() {
+        assert_eq!(cmp_semver("0.4.0", "0.5.0"), Ordering::Less);
+    }
+
+    #[test]
+    fn multi_digit_major() {
+        assert_eq!(cmp_semver("10.0.0", "9.99.99"), Ordering::Greater);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -647,6 +647,16 @@ pub enum Command {
         #[command(subcommand)]
         kind: CompleteKind,
     },
+
+    /// Check for a newer parsec release and print upgrade instructions.
+    ///
+    /// Queries the GitHub releases API to compare the running version with
+    /// the latest published release.  Prints an upgrade command when a newer
+    /// version is available.
+    ///
+    /// Phase 1 — notification only; automatic binary replacement is Phase 2.
+    /// Use the global `--offline` flag to skip the network call.
+    SelfUpdate {},
 }
 
 /// Candidate sets the dynamic completion subcommand can emit.
@@ -757,6 +767,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Reviews { .. } => "reviews",
         Command::Dashboard { .. } => "dashboard",
         Command::Test { .. } => "test",
+        Command::SelfUpdate { .. } => "self-update",
     };
     let exec_id = crate::execlog::new_execution_id();
     let exec_started_at = chrono::Utc::now();
@@ -1104,6 +1115,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             .await
         }
         Command::Complete { kind } => commands::complete(&repo_path, kind).await,
+        Command::SelfUpdate {} => commands::self_update(offline).await,
     };
 
     // Record execution entry (best-effort, never fail the command)


### PR DESCRIPTION
## 무엇

`parsec self-update` 새 서브커맨드 추가 — GitHub releases API 에서 최신 버전을 조회해 현재 버전과 비교하고, 업데이트가 있으면 `cargo install` 업그레이드 명령을 출력합니다.

Refs #296

## 왜

`parsec` 에는 자체 업데이트 확인 기능이 없어 사용자가 최신 버전 여부를 수동으로 확인해야 했습니다. Phase 1 은 알림까지, Phase 2 에서 바이너리 자동 교체를 구현합니다.

## 변경

| 파일 | 내용 |
|---|---|
| `src/cli/commands/update.rs` (신규) | `self_update()` async fn — releases API fetch, 숫자 semver 비교, 출력 |
| `src/cli/commands/mod.rs` | `update` 모듈 연결 |
| `src/cli/mod.rs` | `SelfUpdate {}` Command 변형 + run dispatch + cmd_name |

### 핵심 구현

- `reqwest` (기존 dep) — 8 초 타임아웃, `parsec/VERSION` User-Agent
- 숫자 semver 비교: `0.10.0 > 0.9.0` 정확히 처리 (문자열 비교 버그 없음)
- 네트워크 실패 시 graceful degrade (현재 버전 + releases URL 출력)
- `--offline` 글로벌 플래그 준수: 네트워크 스킵, 버전만 출력
- Phase 2: 바이너리 in-place 교체 (issue #296)

## 다음 Phase 힌트

Phase 2: `gh release download` 또는 HTTP 로 바이너리 다운로드 + 임시 파일 원자 교체 + checksum 검증

## 리스크

low — 신규 독립 명령, 기존 코드 미변경, 새 외부 dep 없음, 네트워크 실패 graceful

## 롤백

브랜치 삭제로 완전 롤백 가능. 기존 명령 미영향.

## Test plan

- 7 개 단위 테스트 (숫자 semver 비교 경계값 포함)
- `cargo build` ✓ / `cargo fmt --check` ✓ / `cargo clippy -D warnings` ✓ / `cargo test` 185 passed
- `parsec self-update --help` 로 도움말 확인

@erishforG