### PR TITLE
feat(ship): Phase 2 — PR template commit list substitution

### DIFF
--- a/src/cli/commands/ship.rs
+++ b/src/cli/commands/ship.rs
@@ -169,12 +169,29 @@ pub async fn ship(
             manager.repo_root(),
             template.as_deref().or(config.ship.template.as_deref()),
         );
+        let template_commits = if template_content
+            .as_deref()
+            .is_some_and(|tmpl| tmpl.contains("{{commits}}"))
+        {
+            manager
+                .get(ticket)
+                .and_then(|workspace| {
+                    collect_template_commits(&workspace.path, &result.base_branch, &result.branch)
+                })
+                .unwrap_or_else(|error| {
+                    eprintln!("warning: failed to collect commits for PR template: {error}");
+                    String::new()
+                })
+        } else {
+            String::new()
+        };
 
         let pr_body = build_pr_body(
             &result.ticket,
             &result.branch,
             effective_title,
             ticket_url.as_deref(),
+            &template_commits,
             stack_info.as_ref(),
             template_content.as_deref(),
         );
@@ -429,6 +446,7 @@ fn gather_stack_info(manager: &WorktreeManager, ticket: &str) -> Option<StackPrI
 /// - `{{branch}}` → the git branch name pushed for this ticket
 /// - `{{title}}` → PR title; empty string when not available
 /// - `{{ticket_url}}` → tracker URL; empty string when not available
+/// - `{{commits}}` → Markdown list of commit subjects in `base..branch`
 ///
 /// Unknown `{{…}}` tokens are left as-is so templates using other tooling
 /// variables are not silently mangled.
@@ -438,12 +456,29 @@ fn substitute_template_vars(
     branch: &str,
     title: Option<&str>,
     ticket_url: Option<&str>,
+    commits: &str,
 ) -> String {
     template
         .replace("{{ticket}}", ticket)
         .replace("{{branch}}", branch)
         .replace("{{title}}", title.unwrap_or(""))
         .replace("{{ticket_url}}", ticket_url.unwrap_or(""))
+        .replace("{{commits}}", commits)
+}
+
+fn collect_template_commits(worktree: &Path, base: &str, branch: &str) -> Result<String> {
+    let range = format!("{base}..{branch}");
+    let subjects = git::run_output(worktree, &["log", &range, "--pretty=format:%s"])?;
+    Ok(format_template_commits(&subjects))
+}
+
+fn format_template_commits(subjects: &str) -> String {
+    subjects
+        .lines()
+        .filter(|subject| !subject.trim().is_empty())
+        .map(|subject| format!("- {subject}"))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn build_pr_body(
@@ -451,6 +486,7 @@ fn build_pr_body(
     branch: &str,
     title: Option<&str>,
     ticket_url: Option<&str>,
+    commits: &str,
     stack_info: Option<&StackPrInfo>,
     template_content: Option<&str>,
 ) -> String {
@@ -489,7 +525,7 @@ fn build_pr_body(
 
     // Include PR template content (#233 #304) with variable substitution.
     if let Some(tmpl) = template_content {
-        let rendered = substitute_template_vars(tmpl, ticket, branch, title, ticket_url);
+        let rendered = substitute_template_vars(tmpl, ticket, branch, title, ticket_url, commits);
         body.push_str("---\n\n");
         body.push_str(&rendered);
         body.push('\n');
@@ -538,38 +574,39 @@ mod template_var_tests {
 
     #[test]
     fn test_substitute_all_vars() {
-        let tmpl = "Ticket: {{ticket}}\nBranch: {{branch}}\nTitle: {{title}}\nURL: {{ticket_url}}";
+        let tmpl = "Ticket: {{ticket}}\nBranch: {{branch}}\nTitle: {{title}}\nURL: {{ticket_url}}\nCommits:\n{{commits}}";
         let result = substitute_template_vars(
             tmpl,
             "CL-42",
             "feature/CL-42",
             Some("My PR"),
             Some("https://example.com/CL-42"),
+            "- first commit\n- second commit",
         );
         assert_eq!(
             result,
-            "Ticket: CL-42\nBranch: feature/CL-42\nTitle: My PR\nURL: https://example.com/CL-42"
+            "Ticket: CL-42\nBranch: feature/CL-42\nTitle: My PR\nURL: https://example.com/CL-42\nCommits:\n- first commit\n- second commit"
         );
     }
 
     #[test]
     fn test_substitute_missing_optional_vars_become_empty() {
         let tmpl = "Ticket: {{ticket}}\nTitle: {{title}}\nURL: {{ticket_url}}";
-        let result = substitute_template_vars(tmpl, "CL-99", "feature/CL-99", None, None);
+        let result = substitute_template_vars(tmpl, "CL-99", "feature/CL-99", None, None, "");
         assert_eq!(result, "Ticket: CL-99\nTitle: \nURL: ");
     }
 
     #[test]
     fn test_substitute_unknown_placeholder_left_intact() {
         let tmpl = "{{ticket}} — {{unknown_var}} — {{branch}}";
-        let result = substitute_template_vars(tmpl, "T-1", "feat/T-1", None, None);
+        let result = substitute_template_vars(tmpl, "T-1", "feat/T-1", None, None, "");
         assert_eq!(result, "T-1 — {{unknown_var}} — feat/T-1");
     }
 
     #[test]
     fn test_substitute_multiple_occurrences() {
         let tmpl = "{{ticket}} ({{ticket}}) on {{branch}}";
-        let result = substitute_template_vars(tmpl, "AB-7", "feat/AB-7", None, None);
+        let result = substitute_template_vars(tmpl, "AB-7", "feat/AB-7", None, None, "");
         assert_eq!(result, "AB-7 (AB-7) on feat/AB-7");
     }
 
@@ -581,10 +618,24 @@ mod template_var_tests {
             "feat/T-5",
             Some("Nice title"),
             None,
+            "",
             None,
             Some(tmpl),
         );
         assert!(body.contains("Refs T-5 on `feat/T-5`"), "body: {body}");
         assert!(body.contains("## Nice title"), "body: {body}");
+    }
+
+    #[test]
+    fn test_format_template_commits_as_markdown_list() {
+        assert_eq!(
+            format_template_commits("first commit\nsecond commit\n"),
+            "- first commit\n- second commit"
+        );
+    }
+
+    #[test]
+    fn test_format_template_commits_empty_range() {
+        assert_eq!(format_template_commits(""), "");
     }
 }


### PR DESCRIPTION
## 무엇

PR template의 `{{commits}}` 변수를 대상 base와 작업 branch 사이의 커밋 제목 Markdown 목록으로 치환합니다.

## 왜

#304의 template 변수 AC에서 branch 치환은 Phase 1에 완료됐지만 commits 치환이 남아 있었습니다. Refs #304

## 변경

- template에 `{{commits}}`가 있을 때만 읽기 전용 `git log base..branch` 수행
- 커밋 제목을 `- subject` Markdown 목록으로 렌더링
- 수집 실패 시 warning 후 빈 값으로 graceful degrade
- 다중 커밋과 빈 범위 단위 테스트 추가

## 다음 Phase 힌트

Phase 3: AI PR description (#275) 활성 시 template section과 생성 본문 결합 규칙 검증.

## 리스크

med — ship PR 본문 생성 경로 변경. push/cleanup 및 핵심 git 상태 변경 로직은 건드리지 않으며 새 의존성 없음.

## 롤백

이 PR을 revert하면 Phase 1의 기존 template 변수 동작으로 복귀합니다.

## Test plan

- cargo build --quiet
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --quiet (99 unit + 5 command + 83 integration)

@erishforG